### PR TITLE
Enforce HTTPS on ClientConfig URI attributes (SMART 2.2.0)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,6 +43,54 @@ Safire accepts configuration either as a Hash or a `Safire::ClientConfig` object
 
 ---
 
+## URI Validation and HTTPS Enforcement
+
+`ClientConfig` validates all URI parameters at initialization time and raises a `Safire::Errors::ConfigurationError` for any violation.
+
+### Rules
+
+- All URI attributes must be well-formed (scheme + host required)
+- All URIs must use `https` — enforced per SMART App Launch 2.2.0, which requires TLS for all exchanges involving sensitive data
+- **Exception:** `http` is permitted when the host is `localhost` or `127.0.0.1`, to support local development without a TLS termination proxy
+
+### Validated Attributes
+
+| Attribute | Required? |
+|-----------|-----------|
+| `base_url` | Always |
+| `redirect_uri` | Always |
+| `issuer` | When provided (defaults to `base_url`) |
+| `authorization_endpoint` | When provided |
+| `token_endpoint` | When provided |
+| `jwks_uri` | When provided |
+
+### Examples
+
+```ruby
+# Valid — HTTPS on production host
+Safire::ClientConfig.new(
+  base_url: 'https://fhir.example.com',
+  client_id: 'my_client',
+  redirect_uri: 'https://myapp.example.com/callback'
+)
+
+# Valid — HTTP allowed for localhost
+Safire::ClientConfig.new(
+  base_url: 'http://localhost:3000/fhir',
+  client_id: 'my_client',
+  redirect_uri: 'http://localhost:3000/callback'
+)
+
+# Raises ConfigurationError — HTTP on non-localhost host
+Safire::ClientConfig.new(
+  base_url: 'http://fhir.example.com',  # => ConfigurationError
+  client_id: 'my_client',
+  redirect_uri: 'https://myapp.example.com/callback'
+)
+```
+
+---
+
 ## Creating a Client
 
 ### Using a Hash (Recommended)

--- a/lib/safire/client_config.rb
+++ b/lib/safire/client_config.rb
@@ -78,25 +78,68 @@ module Safire
 
     private
 
+    URI_ATTRS = %i[base_url redirect_uri issuer authorization_endpoint token_endpoint jwks_uri].freeze
+    OPTIONAL_URI_ATTRS = %i[authorization_endpoint token_endpoint jwks_uri].freeze
+    private_constant :URI_ATTRS, :OPTIONAL_URI_ATTRS
+
+    # Validates all URI attributes for structure and HTTPS requirement.
+    #
+    # Per SMART App Launch 2.2.0 (§App Protection, §Confidential Asymmetric),
+    # all exchanges involving sensitive data SHALL use TLS. All endpoint URIs
+    # must therefore use the `https` scheme.
+    #
+    # Exception: `http` is permitted when the host is `localhost` or `127.0.0.1`
+    # to support local development without a TLS termination proxy.
+    #
+    # @raise [Errors::ConfigurationError] if any URI is malformed or uses HTTP on a non-localhost host
     def validate_uris!
-      uri_attrs = %i[base_url redirect_uri issuer authorization_endpoint token_endpoint jwks_uri]
-      optional_uri_attrs = %i[authorization_endpoint token_endpoint jwks_uri]
+      invalid_uris, non_https_uris = collect_uri_violations
+      messages = build_uri_error_messages(invalid_uris, non_https_uris)
+      raise Errors::ConfigurationError, messages.join('. ') if messages.any?
+    end
 
-      invalid_uris = uri_attrs.select do |attr|
+    def collect_uri_violations
+      invalid_uris = []
+      non_https_uris = []
+
+      URI_ATTRS.each do |attr|
         value = send(attr)
-        next false if value.nil? && optional_uri_attrs.include?(attr)
+        next if value.nil? && OPTIONAL_URI_ATTRS.include?(attr)
 
-        begin
-          uri = Addressable::URI.parse(value)
-          !(uri.scheme && uri.host)
-        rescue Addressable::URI::InvalidURIError
-          true
+        case classify_uri(value)
+        when :invalid   then invalid_uris << attr
+        when :non_https then non_https_uris << attr
         end
       end
-      return if invalid_uris.empty?
 
-      raise Errors::ConfigurationError,
-            "Client configuration has invalid URIs for attributes: #{invalid_uris.to_sentence}"
+      [invalid_uris, non_https_uris]
+    end
+
+    def classify_uri(value)
+      uri = Addressable::URI.parse(value)
+      return :invalid unless uri.scheme && uri.host
+
+      :non_https if uri.scheme != 'https' && !localhost_host?(uri.host)
+    rescue Addressable::URI::InvalidURIError
+      :invalid
+    end
+
+    def build_uri_error_messages(invalid_uris, non_https_uris)
+      messages = []
+      if invalid_uris.any?
+        messages << "Client configuration has invalid URIs for attributes: #{invalid_uris.to_sentence}"
+      end
+      if non_https_uris.any?
+        messages << "Client configuration requires HTTPS for: #{non_https_uris.to_sentence} " \
+                    '(SMART App Launch 2.2.0 requires TLS; HTTP is only allowed for localhost)'
+      end
+      messages
+    end
+
+    # Returns true when the host is a local loopback address.
+    # HTTP is permitted for localhost to support development environments.
+    def localhost_host?(host)
+      %w[localhost 127.0.0.1].include?(host)
     end
 
     def validate!

--- a/spec/safire/client_config_spec.rb
+++ b/spec/safire/client_config_spec.rb
@@ -1,0 +1,168 @@
+require 'spec_helper'
+
+RSpec.describe Safire::ClientConfig do
+  let(:valid_attrs) do
+    {
+      base_url: 'https://fhir.example.com',
+      client_id: 'my_client',
+      redirect_uri: 'https://myapp.example.com/callback'
+    }
+  end
+
+  # ---------- Required attribute validation ----------
+
+  describe 'required attribute validation' do
+    it 'initializes successfully with all required attributes' do
+      expect { described_class.new(valid_attrs) }.not_to raise_error
+    end
+
+    %i[base_url client_id redirect_uri].each do |attr|
+      it "raises ConfigurationError when #{attr} is missing" do
+        expect { described_class.new(valid_attrs.except(attr)) }
+          .to raise_error(Safire::Errors::ConfigurationError, /#{attr}/)
+      end
+    end
+  end
+
+  # ---------- URI format validation ----------
+
+  describe 'URI format validation' do
+    it 'raises ConfigurationError when base_url is not a valid URI' do
+      expect { described_class.new(valid_attrs.merge(base_url: 'not a url')) }
+        .to raise_error(Safire::Errors::ConfigurationError, /invalid URIs/)
+    end
+
+    it 'raises ConfigurationError when redirect_uri has no host' do
+      expect { described_class.new(valid_attrs.merge(redirect_uri: 'justpath')) }
+        .to raise_error(Safire::Errors::ConfigurationError, /invalid URIs/)
+    end
+  end
+
+  # ---------- HTTPS enforcement ----------
+
+  describe 'HTTPS enforcement' do
+    context 'when base_url uses HTTP on a non-localhost host' do
+      it 'raises ConfigurationError' do
+        expect { described_class.new(valid_attrs.merge(base_url: 'http://fhir.example.com')) }
+          .to raise_error(Safire::Errors::ConfigurationError,
+                          /requires HTTPS.*base_url.*SMART App Launch 2\.2\.0 requires TLS/)
+      end
+    end
+
+    context 'when redirect_uri uses HTTP on a non-localhost host' do
+      it 'raises ConfigurationError' do
+        expect { described_class.new(valid_attrs.merge(redirect_uri: 'http://myapp.example.com/callback')) }
+          .to raise_error(Safire::Errors::ConfigurationError, /requires HTTPS.*redirect_uri/)
+      end
+    end
+
+    context 'when optional token_endpoint uses HTTP on a non-localhost host' do
+      it 'raises ConfigurationError' do
+        expect do
+          described_class.new(valid_attrs.merge(token_endpoint: 'http://fhir.example.com/token'))
+        end.to raise_error(Safire::Errors::ConfigurationError, /requires HTTPS.*token_endpoint/)
+      end
+    end
+
+    context 'when optional authorization_endpoint uses HTTP on a non-localhost host' do
+      it 'raises ConfigurationError' do
+        expect do
+          described_class.new(valid_attrs.merge(authorization_endpoint: 'http://fhir.example.com/auth'))
+        end.to raise_error(Safire::Errors::ConfigurationError, /requires HTTPS.*authorization_endpoint/)
+      end
+    end
+
+    context 'when optional jwks_uri uses HTTP on a non-localhost host' do
+      it 'raises ConfigurationError' do
+        expect do
+          described_class.new(valid_attrs.merge(jwks_uri: 'http://myapp.example.com/jwks.json'))
+        end.to raise_error(Safire::Errors::ConfigurationError, /requires HTTPS.*jwks_uri/)
+      end
+    end
+
+    context 'when multiple URIs use HTTP on non-localhost hosts' do
+      it 'reports all non-HTTPS attributes in a single error' do
+        expect do
+          described_class.new(
+            valid_attrs.merge(
+              base_url: 'http://fhir.example.com',
+              redirect_uri: 'http://myapp.example.com/callback'
+            )
+          )
+        end.to raise_error(Safire::Errors::ConfigurationError, /base_url.*redirect_uri|redirect_uri.*base_url/)
+      end
+    end
+
+    context 'with localhost exception' do
+      it 'allows HTTP for localhost base_url' do
+        expect do
+          described_class.new(valid_attrs.merge(base_url: 'http://localhost:3000/fhir'))
+        end.not_to raise_error
+      end
+
+      it 'allows HTTP for 127.0.0.1 base_url' do
+        expect do
+          described_class.new(valid_attrs.merge(base_url: 'http://127.0.0.1:8080/fhir'))
+        end.not_to raise_error
+      end
+
+      it 'allows HTTP for localhost redirect_uri' do
+        expect do
+          described_class.new(valid_attrs.merge(redirect_uri: 'http://localhost:3000/callback'))
+        end.not_to raise_error
+      end
+
+      it 'allows HTTP for localhost token_endpoint' do
+        expect do
+          described_class.new(valid_attrs.merge(token_endpoint: 'http://localhost:9000/token'))
+        end.not_to raise_error
+      end
+
+      it 'allows HTTP for 127.0.0.1 redirect_uri' do
+        expect do
+          described_class.new(valid_attrs.merge(redirect_uri: 'http://127.0.0.1:4000/callback'))
+        end.not_to raise_error
+      end
+    end
+
+    context 'with HTTPS URIs' do
+      it 'accepts all HTTPS endpoints' do
+        expect do
+          described_class.new(
+            valid_attrs.merge(
+              token_endpoint: 'https://fhir.example.com/token',
+              authorization_endpoint: 'https://fhir.example.com/auth',
+              jwks_uri: 'https://myapp.example.com/.well-known/jwks.json'
+            )
+          )
+        end.not_to raise_error
+      end
+    end
+  end
+
+  # ---------- Issuer defaults to base_url ----------
+
+  describe 'issuer defaulting' do
+    it 'defaults issuer to base_url when not provided' do
+      config = described_class.new(valid_attrs)
+      expect(config.issuer).to eq(valid_attrs[:base_url])
+    end
+
+    it 'uses provided issuer when given' do
+      config = described_class.new(valid_attrs.merge(issuer: 'https://issuer.example.com'))
+      expect(config.issuer).to eq('https://issuer.example.com')
+    end
+  end
+
+  # ---------- to_hash ----------
+
+  describe '#to_hash' do
+    it 'returns a hash with symbolized keys' do
+      config = described_class.new(valid_attrs)
+      hash = config.to_hash
+      expect(hash).to be_a(Hash)
+      expect(hash[:base_url]).to eq(valid_attrs[:base_url])
+      expect(hash[:client_id]).to eq(valid_attrs[:client_id])
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Enforces HTTPS on all URI attributes in `ClientConfig` (`base_url`, `redirect_uri`, `issuer`, `authorization_endpoint`, `token_endpoint`, `jwks_uri`) per SMART App Launch 2.2.0 §App Protection
- HTTP is permitted only for `localhost` / `127.0.0.1` to support local development without a TLS proxy
- Violations raise `Safire::Errors::ConfigurationError` with a single message listing all offending attributes
- Optional URI attrs skip validation when `nil`
- Refactored `validate_uris!` into extracted helpers (`collect_uri_violations`, `classify_uri`, `build_uri_error_messages`, `localhost_host?`) to satisfy Rubocop metrics
- 21 new tests in `spec/safire/client_config_spec.rb`; full suite 182 examples, 0 failures, 0 Rubocop offenses
- Updated `docs/configuration.md` with URI Validation and HTTPS Enforcement section

## Test plan

- [x] `bundle exec rspec spec/safire/client_config_spec.rb` — all 21 examples pass
- [x] `bundle exec rspec` — 182 examples, 0 failures
- [x] `bundle exec rubocop lib/safire/client_config.rb spec/safire/client_config_spec.rb` — 0 offenses
- [x] Jekyll build (`cd docs && bundle exec jekyll build`) — no errors