### PR TITLE
Add Safire.token_response_valid? for SMART 2.2.0 token response compliance

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -222,6 +222,35 @@ When endpoints are provided, Safire uses them directly instead of fetching from 
 
 ---
 
+## Token Response Validation
+
+After a successful token exchange, use `Safire.token_response_valid?` to verify the server's
+response meets SMART App Launch 2.2.0 requirements. This is a caller-invoked helper — token
+exchange methods return the raw response without checking compliance.
+
+Logs a warning per violation and returns `false`. Never raises.
+
+```ruby
+token_data = client.request_access_token(code: code, code_verifier: verifier)
+
+unless Safire.token_response_valid?(token_data)
+  # Safire has already logged each violation, e.g.:
+  # WARN: SMART token response non-compliance: required field 'scope' is missing
+  # WARN: SMART token response non-compliance: token_type is "bearer"; expected 'Bearer'
+  raise "Server token response does not meet SMART App Launch 2.2.0 requirements"
+end
+```
+
+**Checks performed (SMART App Launch 2.2.0 §Token Response):**
+
+| Field | Requirement |
+|-------|-------------|
+| `access_token` | SHALL be present |
+| `token_type` | SHALL be present and exactly `"Bearer"` (case-sensitive) |
+| `scope` | SHALL be present |
+
+---
+
 ## Logging Configuration
 
 Configure Safire's logger for debugging:

--- a/lib/safire.rb
+++ b/lib/safire.rb
@@ -40,6 +40,68 @@ module Safire
     def http_client
       @http_client ||= Safire::HTTPClient.new
     end
+
+    # Validates a token response for SMART App Launch 2.2.0 compliance.
+    #
+    # This is a caller-invoked helper — Safire's token exchange methods do not call this
+    # automatically. Use it after {Safire::Client#request_access_token} or
+    # {Safire::Client#refresh_token} when you need to verify server compliance.
+    #
+    # Checks all required token response fields per SMART App Launch 2.2.0 §Token Response:
+    # - +access_token+ must be present (SHALL)
+    # - +token_type+ must be present and exactly +"Bearer"+ (SHALL, case-sensitive)
+    # - +scope+ must be present (SHALL)
+    #
+    # Logs a warning via {Safire.logger} for each violation found and returns false.
+    # Never raises an exception.
+    #
+    # @param response [Hash] the token response returned by the server
+    # @return [Boolean] true if the response is compliant, false otherwise
+    #
+    # @example
+    #   token_data = client.request_access_token(code: code, code_verifier: verifier)
+    #   unless Safire.token_response_valid?(token_data)
+    #     # Safire has already logged the violation details
+    #     raise "Server token response does not meet SMART App Launch 2.2.0 requirements"
+    #   end
+    def token_response_valid?(response)
+      unless response.is_a?(Hash)
+        Safire.logger.warn('SMART token response non-compliance: response is not a JSON object')
+        return false
+      end
+
+      valid = true
+
+      %w[access_token scope].each do |field|
+        next if response[field].present?
+
+        Safire.logger.warn(
+          "SMART token response non-compliance: required field '#{field}' is missing"
+        )
+        valid = false
+      end
+
+      token_type_valid?(response) && valid
+    end
+
+    private
+
+    def token_type_valid?(response)
+      if response['token_type'].blank?
+        Safire.logger.warn(
+          "SMART token response non-compliance: required field 'token_type' is missing"
+        )
+        return false
+      end
+
+      return true if response['token_type'] == 'Bearer'
+
+      Safire.logger.warn(
+        "SMART token response non-compliance: token_type is #{response['token_type'].inspect}; " \
+        "expected 'Bearer' (SMART App Launch 2.2.0 requires token_type \"Bearer\")"
+      )
+      false
+    end
   end
 
   class Configuration

--- a/spec/safire_spec.rb
+++ b/spec/safire_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+RSpec.describe Safire do
+  describe '.token_response_valid?' do
+    before { allow(described_class.logger).to receive(:warn) }
+
+    let(:valid_response) do
+      { 'access_token' => 'abc123', 'token_type' => 'Bearer', 'scope' => 'openid profile' }
+    end
+
+    context 'when all required fields are present and token_type is "Bearer"' do
+      it 'returns true and does not warn' do
+        result = described_class.token_response_valid?(valid_response)
+        expect(result).to be(true)
+        expect(described_class.logger).not_to have_received(:warn)
+      end
+    end
+
+    context 'when access_token is missing' do
+      it 'returns false and logs a warning' do
+        result = described_class.token_response_valid?(valid_response.except('access_token'))
+        expect(result).to be(false)
+        expect(described_class.logger).to have_received(:warn).with(/'access_token' is missing/)
+      end
+    end
+
+    context 'when scope is missing' do
+      it 'returns false and logs a warning' do
+        result = described_class.token_response_valid?(valid_response.except('scope'))
+        expect(result).to be(false)
+        expect(described_class.logger).to have_received(:warn).with(/'scope' is missing/)
+      end
+    end
+
+    context 'when token_type is missing' do
+      it 'returns false and logs a warning' do
+        result = described_class.token_response_valid?(valid_response.except('token_type'))
+        expect(result).to be(false)
+        expect(described_class.logger).to have_received(:warn).with(/'token_type' is missing/)
+      end
+    end
+
+    context 'when token_type is lowercase "bearer"' do
+      it 'returns false and logs a warning' do
+        result = described_class.token_response_valid?(valid_response.merge('token_type' => 'bearer'))
+        expect(result).to be(false)
+        expect(described_class.logger).to have_received(:warn).with(/token_type.*bearer.*Bearer/)
+      end
+    end
+
+    context 'when token_type is "BEARER"' do
+      it 'returns false and logs a warning' do
+        result = described_class.token_response_valid?(valid_response.merge('token_type' => 'BEARER'))
+        expect(result).to be(false)
+        expect(described_class.logger).to have_received(:warn).with(/token_type/)
+      end
+    end
+
+    context 'when multiple required fields are missing' do
+      it 'returns false and logs a warning for each missing field' do
+        result = described_class.token_response_valid?({})
+        expect(result).to be(false)
+        expect(described_class.logger).to have_received(:warn).with(/'access_token' is missing/)
+        expect(described_class.logger).to have_received(:warn).with(/'scope' is missing/)
+        expect(described_class.logger).to have_received(:warn).with(/'token_type' is missing/)
+      end
+    end
+
+    context 'when response is not a Hash' do
+      it 'returns false and logs a warning' do
+        result = described_class.token_response_valid?('not a hash')
+        expect(result).to be(false)
+        expect(described_class.logger).to have_received(:warn).with(/not a JSON object/)
+      end
+    end
+
+    context 'when response is nil' do
+      it 'returns false and logs a warning' do
+        result = described_class.token_response_valid?(nil)
+        expect(result).to be(false)
+        expect(described_class.logger).to have_received(:warn).with(/not a JSON object/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Safire.token_response_valid?(response)` — a caller-invoked helper that validates all required token response fields per SMART App Launch 2.2.0 §Token Response
- Validates `access_token` (SHALL be present), `token_type` (SHALL be `"Bearer"`, case-sensitive), and `scope` (SHALL be present)
- Logs a warning per violation via `Safire.logger.warn`; returns `false` on any violation; never raises — consistent with the warn-and-return pattern established by `SmartMetadata#valid?`
- 9 new tests in `spec/safire_spec.rb`; full suite 191 examples, 0 failures, 0 Rubocop offenses
- Updated `docs/configuration.md` with Token Response Validation section

## Test plan

- [x] `bundle exec rspec spec/safire_spec.rb` — all 9 examples pass
- [x] `bundle exec rspec` — 191 examples, 0 failures
- [x] `bundle exec rubocop lib/safire.rb spec/safire_spec.rb` — 0 offenses
- [x] Jekyll build (`cd docs && bundle exec jekyll build`) — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)