### PR TITLE
Add POST-based authorization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Safire is a lean Ruby library that implements **SMART on FHIR** and **UDAP** cli
 - SMART on FHIR Public Client (PKCE)
 - SMART on FHIR Confidential Symmetric Client (client_secret + Basic Auth)
 - SMART on FHIR Confidential Asymmetric Client (private_key_jwt with RS384/ES384)
+- POST-Based Authorization (`authorize-post` capability, SMART 2.2.0)
 
 **Planned:**
 
@@ -72,7 +73,9 @@ puts "Capabilities: #{metadata.capabilities.join(', ')}"
 # Safire automatically retrieves endpoints from SMART metadata
 
 # Step 1 – /launch route (authorization request)
-auth_data = client.authorize_url
+# Use method: :post if the server advertises the 'authorize-post' capability
+auth_data = client.authorize_url            # GET redirect (default)
+# auth_data = client.authorize_url(method: :post)  # POST form submission
 
 session[:state] = auth_data[:state]
 session[:code_verifier] = auth_data[:code_verifier]

--- a/docs/smart-on-fhir/confidential-asymmetric.md
+++ b/docs/smart-on-fhir/confidential-asymmetric.md
@@ -193,6 +193,11 @@ def launch
 end
 ```
 
+{: .note }
+> **POST-Based Authorization**
+>
+> If the server advertises the `authorize-post` capability, you can pass `method: :post` to `authorize_url` to submit the authorization request as a form POST instead of a GET redirect. See [POST-Based Authorization]({% link smart-on-fhir/post-based-authorization.md %}) for details.
+
 ---
 
 ## Step 3: Token Exchange

--- a/docs/smart-on-fhir/confidential-symmetric.md
+++ b/docs/smart-on-fhir/confidential-symmetric.md
@@ -159,6 +159,11 @@ The URL is identical to public clients:
 >
 > Confidential clients typically request `offline_access` scope to obtain refresh tokens for long-lived sessions.
 
+{: .note }
+> **POST-Based Authorization**
+>
+> If the server advertises the `authorize-post` capability, you can pass `method: :post` to `authorize_url` to submit the authorization request as a form POST instead of a GET redirect. See [POST-Based Authorization]({% link smart-on-fhir/post-based-authorization.md %}) for details.
+
 ---
 
 ## Step 3: Token Exchange

--- a/docs/smart-on-fhir/index.md
+++ b/docs/smart-on-fhir/index.md
@@ -18,6 +18,7 @@ This section provides step-by-step guides for implementing SMART on FHIR authori
 | [Public Client]({% link smart-on-fhir/public-client.md %}) | Authorization flow for browser-based and mobile applications |
 | [Confidential Symmetric Client]({% link smart-on-fhir/confidential-symmetric.md %}) | Authorization flow for server-side applications with client secrets |
 | [Confidential Asymmetric Client]({% link smart-on-fhir/confidential-asymmetric.md %}) | Authorization flow using private_key_jwt (RSA/EC key pair) |
+| [POST-Based Authorization]({% link smart-on-fhir/post-based-authorization.md %}) | Sending the authorization request as a form POST (`authorize-post` capability) |
 
 ## Choosing a Client Type
 

--- a/docs/smart-on-fhir/post-based-authorization.md
+++ b/docs/smart-on-fhir/post-based-authorization.md
@@ -1,0 +1,190 @@
+---
+layout: default
+title: POST-Based Authorization
+parent: SMART on FHIR
+nav_order: 5
+has_toc: true
+---
+
+# POST-Based Authorization
+
+{: .no_toc }
+
+<div class="code-example" markdown="1">
+SMART App Launch 2.2.0 introduces the `authorize-post` capability, allowing servers to accept the authorization request as an HTTP form POST instead of a GET redirect. This page explains when and how to use it with Safire.
+</div>
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Overview
+
+By default, SMART authorization uses a GET redirect — the user's browser is sent to the authorization server with all parameters in the query string. Servers that advertise the `authorize-post` capability also accept the authorization request as an HTTP POST with parameters in the request body.
+
+POST-based authorization can be useful when:
+- Authorization parameters are too large for a URL (e.g. rich `state` or `launch` values)
+- The client prefers to avoid sensitive parameters appearing in browser history or server logs
+
+---
+
+## Detecting Server Support
+
+Check whether the authorization server advertises the `authorize-post` capability before using POST mode:
+
+```ruby
+client = Safire::Client.new(config, auth_type: :public)
+metadata = client.smart_metadata
+
+if metadata.supports_post_based_authorization?
+  puts "Server supports POST-based authorization"
+end
+```
+
+---
+
+## Generating a POST Authorization Request
+
+Pass `method: :post` (or `method: 'post'`) to `authorize_url`:
+
+```ruby
+auth_data = client.authorize_url(method: :post)
+
+auth_data[:auth_url]      # The bare authorization endpoint URL
+auth_data[:params]        # Hash of parameters to POST as the request body
+auth_data[:state]         # Store in session for CSRF verification
+auth_data[:code_verifier] # Store in session for token exchange
+```
+
+The `:get` method returns `auth_url` as a fully-formed URL with query parameters. The `:post` method returns the endpoint separately from the parameters so your application can submit a form POST.
+
+---
+
+## Rails Example
+
+```ruby
+# app/controllers/smart_auth_controller.rb
+def launch
+  # Check server support (optional but recommended)
+  metadata = @client.smart_metadata
+  use_post = metadata.supports_post_based_authorization?
+
+  auth_data = @client.authorize_url(method: use_post ? :post : :get)
+
+  session[:oauth_state] = auth_data[:state]
+  session[:code_verifier] = auth_data[:code_verifier]
+
+  if use_post
+    # Render a form that auto-submits to the authorization endpoint
+    @auth_url = auth_data[:auth_url]
+    @auth_params = auth_data[:params]
+    render :authorize_post
+  else
+    redirect_to auth_data[:auth_url], allow_other_host: true
+  end
+end
+```
+
+```erb
+<%# app/views/smart_auth/authorize_post.html.erb %>
+<form id="auth-form" method="POST" action="<%= @auth_url %>">
+  <% @auth_params.each do |key, value| %>
+    <input type="hidden" name="<%= key %>" value="<%= value %>">
+  <% end %>
+</form>
+
+<script>
+  // Auto-submit after the page loads
+  document.getElementById('auth-form').submit();
+</script>
+```
+
+### Response Hash Comparison
+
+| Key           | GET (`method: :get`)                          | POST (`method: :post`)         |
+|---------------|-----------------------------------------------|--------------------------------|
+| `:auth_url`   | Full URL with query string parameters         | Bare authorization endpoint URL |
+| `:state`      | State value (also embedded in query string)   | State value                    |
+| `:code_verifier` | PKCE code verifier                         | PKCE code verifier             |
+| `:params`     | Not present                                   | Hash of all authorization parameters |
+
+The callback handling (token exchange) is identical for both methods — the authorization server always redirects back to your `redirect_uri` with an authorization code.
+
+---
+
+## Sinatra Example
+
+```ruby
+get '/launch' do
+  auth_data = @client.authorize_url(method: :post)
+
+  session[:state] = auth_data[:state]
+  session[:code_verifier] = auth_data[:code_verifier]
+
+  @auth_url = auth_data[:auth_url]
+  @auth_params = auth_data[:params]
+  erb :authorize_post
+end
+```
+
+```erb
+<%# views/authorize_post.erb %>
+<form id="auth-form" method="POST" action="<%= @auth_url %>">
+  <% @auth_params.each do |key, value| %>
+    <input type="hidden" name="<%= key %>" value="<%= value %>">
+  <% end %>
+</form>
+<script>document.getElementById('auth-form').submit();</script>
+```
+
+---
+
+## String and Symbol Forms
+
+Both string and symbol values are accepted:
+
+```ruby
+client.authorize_url(method: :post)   # symbol
+client.authorize_url(method: 'post')  # string — also accepted
+client.authorize_url(method: :get)    # default
+client.authorize_url(method: 'get')   # also accepted
+```
+
+Passing any other value raises a `Safire::Errors::ConfigurationError`:
+
+```ruby
+client.authorize_url(method: :put)
+# => Safire::Errors::ConfigurationError:
+#      Invalid authorization method: :put. Supported methods are :get and :post
+```
+
+---
+
+## Authorization Parameters
+
+The parameters included in `:params` (POST) are identical to those embedded in the query string for GET:
+
+| Parameter | Description |
+|---|---|
+| `response_type` | `"code"` — OAuth 2.0 authorization code flow |
+| `client_id` | Your registered client identifier |
+| `redirect_uri` | Callback URL for your application |
+| `scope` | Requested permissions (space-separated) |
+| `state` | CSRF protection token (32 hex chars, randomly generated) |
+| `aud` | FHIR server being accessed |
+| `code_challenge_method` | `"S256"` — PKCE using SHA-256 |
+| `code_challenge` | SHA-256 hash of the code verifier |
+| `launch` | EHR launch token (if provided via `launch:` argument) |
+
+---
+
+## Next Steps
+
+- [Public Client Workflow]({% link smart-on-fhir/public-client.md %})
+- [Confidential Symmetric Client Workflow]({% link smart-on-fhir/confidential-symmetric.md %})
+- [Confidential Asymmetric Client Workflow]({% link smart-on-fhir/confidential-asymmetric.md %})
+- [SMART Discovery Details]({% link smart-on-fhir/discovery.md %})

--- a/docs/smart-on-fhir/public-client.md
+++ b/docs/smart-on-fhir/public-client.md
@@ -135,6 +135,11 @@ auth_data
 >
 > Each call to `authorize_url()` generates a new `state` and `code_verifier`. These values are unique per authorization attempt.
 
+{: .note }
+> **POST-Based Authorization**
+>
+> If the server advertises the `authorize-post` capability, you can pass `method: :post` to `authorize_url` to submit the authorization request as a form POST instead of a GET redirect. See [POST-Based Authorization]({% link smart-on-fhir/post-based-authorization.md %}) for details.
+
 ### Authorization URL Parameters
 
 The generated URL includes:

--- a/lib/safire/client.rb
+++ b/lib/safire/client.rb
@@ -116,8 +116,8 @@ module Safire
       @smart_metadata ||= smart_client.well_known_config
     end
 
-    def authorize_url(launch: nil, custom_scopes: nil)
-      smart_client.authorization_url(launch:, custom_scopes:)
+    def authorize_url(launch: nil, custom_scopes: nil, method: :get)
+      smart_client.authorization_url(launch:, custom_scopes:, method:)
     end
 
     def request_access_token(code:, code_verifier:, client_secret: config.client_secret,

--- a/lib/safire/protocols/smart.rb
+++ b/lib/safire/protocols/smart.rb
@@ -124,28 +124,34 @@ module Safire
         raise Errors::DiscoveryError.new(msg, details: details)
       end
 
-      # Builds the authorization URL to request an authorization code.
+      # Builds the authorization request data for the authorization code flow.
       #
       # See {Safire::Protocols::Smart} for configuration details and supported auth types.
       #
       # @param launch [String, nil] optional launch parameter
       # @param custom_scopes [Array<String>, nil] optional custom scopes to override the configured ones
+      # @param method [Symbol, String] authorization request method; +:get+ (default) or +:post+.
+      #   Both symbol and string forms are accepted (e.g. +method: :post+ or +method: 'post'+).
+      #   * +:get+  — builds a redirect URL with all parameters in the query string (standard flow)
+      #   * +:post+ — returns the endpoint and parameters separately for POST-based authorization
+      #     (SMART App Launch 2.2.0 +authorize-post+ capability)
       # @return [Hash] containing:
-      #   * :auth_url [String] the authorization URL to redirect the user to
-      #   * :state [String] the state parameter for CSRF protection
-      #   * :code_verifier [String] the PKCE code verifier for the token exchange
-      # @raise [Errors::ConfigurationError] if no scopes are configured or provided
-      def authorization_url(launch: nil, custom_scopes: nil)
+      #   * :auth_url [String] authorization URL (GET) or bare endpoint URL (POST)
+      #   * :state [String] state parameter for CSRF protection; store and verify on callback
+      #   * :code_verifier [String] PKCE code verifier for the token exchange
+      #   * :params [Hash] (POST only) authorization parameters to submit as the request body
+      # @raise [Errors::ConfigurationError] if no scopes are configured or if method is invalid
+      def authorization_url(launch: nil, custom_scopes: nil, method: :get)
+        method = method.to_sym
         validate_presence_of_scopes(custom_scopes)
+        validate_authorization_method(method)
 
-        Safire.logger.info("Generating authorization URL for SMART #{auth_type}...")
+        Safire.logger.info("Generating authorization URL for SMART #{auth_type} (method: #{method})...")
 
         code_verifier = PKCE.generate_code_verifier
+        params = authorization_params(launch:, custom_scopes:, code_verifier:)
 
-        uri = Addressable::URI.parse(authorization_endpoint)
-        uri.query_values = authorization_params(launch:, custom_scopes:, code_verifier:)
-
-        { auth_url: uri.to_s, state: uri.query_values['state'], code_verifier: }
+        build_authorization_response(method, params, code_verifier)
       end
 
       # Exchanges the authorization code for an access token.
@@ -221,6 +227,23 @@ module Safire
 
         raise Errors::ConfigurationError,
               "SMART Client configuration missing attributes: #{missing.to_sentence}"
+      end
+
+      def validate_authorization_method(method)
+        return if %i[get post].include?(method)
+
+        raise Errors::ConfigurationError,
+              "Invalid authorization method: #{method.inspect}. Supported methods are :get and :post"
+      end
+
+      def build_authorization_response(method, params, code_verifier)
+        if method == :post
+          { auth_url: authorization_endpoint, params:, state: params[:state], code_verifier: }
+        else
+          uri = Addressable::URI.parse(authorization_endpoint)
+          uri.query_values = params
+          { auth_url: uri.to_s, state: uri.query_values['state'], code_verifier: }
+        end
       end
 
       def validate_presence_of_scopes(custom_scopes = nil)

--- a/spec/safire/protocols/smart_spec.rb
+++ b/spec/safire/protocols/smart_spec.rb
@@ -328,6 +328,58 @@ RSpec.describe Safire::Protocols::Smart do
       data2 = described_class.new(cfg2).authorization_url
       expect(data2[:auth_url]).to include(CGI.escape(cfg2[:redirect_uri]))
     end
+
+    context 'when method: :post' do
+      let(:post_auth_data) { described_class.new(config).authorization_url(method: :post) }
+
+      it 'returns auth_url, params, state, and code_verifier' do
+        expect(post_auth_data.keys).to contain_exactly(:auth_url, :params, :state, :code_verifier)
+      end
+
+      it 'auth_url is the bare authorization endpoint with no query string' do
+        expect(post_auth_data[:auth_url]).to eq(config[:authorization_endpoint])
+        expect(post_auth_data[:auth_url]).not_to include('?')
+      end
+
+      it 'params contains all required oauth and pkce fields' do
+        p = post_auth_data[:params]
+        expect(p).to include(
+          response_type: 'code',
+          client_id: config[:client_id],
+          redirect_uri: config[:redirect_uri],
+          aud: config[:base_url],
+          code_challenge_method: 'S256'
+        )
+        expect(p[:code_challenge]).to match(/\A[A-Za-z0-9_-]{43}\z/)
+        expect(p[:code_challenge]).to eq(Safire::PKCE.generate_code_challenge(post_auth_data[:code_verifier]))
+      end
+
+      it 'state in response matches state in params' do
+        expect(post_auth_data[:state]).to eq(post_auth_data[:params][:state])
+        expect(post_auth_data[:state]).to match(/\A[a-f0-9]{32}\z/)
+      end
+    end
+
+    context 'when method is provided as a string' do
+      it 'accepts "post" and returns params hash' do
+        data = described_class.new(config).authorization_url(method: 'post')
+        expect(data[:auth_url]).to eq(config[:authorization_endpoint])
+        expect(data[:params]).to be_a(Hash)
+      end
+
+      it 'accepts "get" and returns redirect URL' do
+        data = described_class.new(config).authorization_url(method: 'get')
+        expect(data[:auth_url]).to include('?')
+        expect(data.key?(:params)).to be(false)
+      end
+    end
+
+    context 'when method is invalid' do
+      it 'raises ConfigurationError' do
+        expect { described_class.new(config).authorization_url(method: :patch) }
+          .to raise_error(Safire::Errors::ConfigurationError, /Invalid authorization method/)
+      end
+    end
   end
 
   # ---------- Token Exchange ----------


### PR DESCRIPTION
## Summary

- Adds `method: :get/:post` parameter to `authorization_url` / `authorize_url` (both string and symbol accepted)
- `:post` returns `{ auth_url:, params:, state:, code_verifier: }` — bare endpoint + separate params hash for form POST submission
- `:get` (default) is unchanged — returns a fully-formed redirect URL
- Implements the SMART App Launch 2.2.0 `authorize-post` capability
- New `docs/smart-on-fhir/post-based-authorization.md` with Rails and Sinatra examples
- Brief `authorize-post` notes added to all three client workflow docs and README

## Test plan

- [x] `method: :post` returns bare `auth_url` and separate `params` hash
- [x] `method: :get` (default) returns unchanged fully-formed URL
- [x] String forms (`'post'`, `'get'`) are accepted and coerced
- [x] Invalid method raises `Safire::Errors::ConfigurationError`
- [x] All 198 RSpec examples pass, 0 Rubocop offenses
- [x] Jekyll docs build clean