### PR TITLE
Move pry and pry-byebug to development dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gemspec
 group :development, :test do
   gem 'bundler-audit', '~> 0.9'
   gem 'debug'
+  gem 'pry'
+  gem 'pry-byebug'
   gem 'rspec', '~> 3.12'
   gem 'rubocop', '~> 1.57'
   gem 'rubocop-rspec', '~> 3.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,6 @@ PATH
       faraday (~> 2.14)
       faraday-follow_redirects (~> 0.4)
       jwt (~> 2.8)
-      pry
-      pry-byebug
 
 GEM
   remote: https://rubygems.org/
@@ -163,6 +161,8 @@ PLATFORMS
 DEPENDENCIES
   bundler-audit (~> 0.9)
   debug
+  pry
+  pry-byebug
   rspec (~> 3.12)
   rubocop (~> 1.57)
   rubocop-rspec (~> 3.0)

--- a/safire.gemspec
+++ b/safire.gemspec
@@ -34,6 +34,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '~> 2.14'
   spec.add_dependency 'faraday-follow_redirects', '~> 0.4'
   spec.add_dependency 'jwt', '~> 2.8'
-  spec.add_dependency 'pry'
-  spec.add_dependency 'pry-byebug'
 end


### PR DESCRIPTION
## Summary

- Removes `pry` and `pry-byebug` from runtime `add_dependency` in `safire.gemspec`
- Adds both gems to the `:development, :test` group in `Gemfile`

## Motivation

Debugging tools must never be runtime dependencies. Every consumer who adds `gem 'safire'` to their application was silently receiving `pry` and `pry-byebug` as transitive installs — adding unnecessary weight and a potential attack surface to production environments.

## Test plan

- [x] `bundle exec rspec` — 198 examples, 0 failures
- [x] `bundle exec rubocop` — 34 files, no offenses
- [x] `require 'pry'` in `spec/spec_helper.rb` continues to work (pry remains available in dev/test)
