### PR TITLE
Filter sensitive data from HTTP logs; make logging configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -253,13 +253,28 @@ end
 
 ## Logging Configuration
 
-Configure Safire's logger for debugging:
+Configure Safire's logger and HTTP request logging via `Safire.configure`:
 
 ```ruby
 # config/initializers/safire.rb
 Safire.configure do |config|
-  config.logger = Rails.logger
+  config.logger    = Rails.logger
   config.log_level = Logger::DEBUG  # In development
+  config.log_http  = true           # Default — log HTTP requests with sensitive data filtered
+end
+```
+
+### `log_http` — HTTP Request Logging
+
+| Value | Behaviour |
+|-------|-----------|
+| `true` (default) | HTTP requests and responses are logged. The `Authorization` header is replaced with `[FILTERED]`. Request and response bodies are **never** logged to prevent credential or token leakage. |
+| `false` | No HTTP request or response logging. |
+
+```ruby
+# Disable HTTP logging in production if not needed
+Safire.configure do |config|
+  config.log_http = false
 end
 ```
 
@@ -267,9 +282,9 @@ end
 
 | Level | Description |
 |-------|-------------|
-| `Logger::DEBUG` | Detailed request/response logging |
-| `Logger::INFO` | Standard operation logging |
-| `Logger::WARN` | Warnings only |
+| `Logger::DEBUG` | Verbose Safire operation logging |
+| `Logger::INFO` | Standard operation logging (default) |
+| `Logger::WARN` | Compliance warnings and non-critical issues only |
 | `Logger::ERROR` | Errors only |
 
 ---

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -525,14 +525,26 @@ Log output includes:
 
 ### Inspect HTTP Requests
 
-Safire logs HTTP requests automatically:
+HTTP request logging is enabled by default (`log_http: true`). Sensitive data is always protected:
+
+- The `Authorization` header is replaced with `[FILTERED]`
+- Request and response bodies are **never** logged (they contain tokens and secrets)
 
 ```
 INFO -- : request: POST https://fhir.example.com/token
 INFO -- : request: User-Agent: "Safire v0.0.1"
          Accept: "application/json"
          Content-Type: "application/x-www-form-urlencoded"
+         Authorization: [FILTERED]
 INFO -- : response: Status 200
+```
+
+To disable HTTP logging entirely:
+
+```ruby
+Safire.configure do |config|
+  config.log_http = false
+end
 ```
 
 ### Test with Reference Server

--- a/lib/safire.rb
+++ b/lib/safire.rb
@@ -105,10 +105,11 @@ module Safire
   end
 
   class Configuration
-    attr_accessor :logger, :log_level, :user_agent
+    attr_accessor :logger, :log_level, :user_agent, :log_http
 
     def initialize
       @user_agent = "Safire v#{Safire::VERSION}"
+      @log_http   = true
     end
   end
 

--- a/lib/safire/http_client.rb
+++ b/lib/safire/http_client.rb
@@ -40,8 +40,16 @@ module Safire
         builder.response :follow_redirects
         builder.response :json
         builder.response :raise_error
-        builder.response :logger
+        configure_logger(builder)
         builder.adapter @adapter
+      end
+    end
+
+    def configure_logger(builder)
+      return if Safire.configuration&.log_http == false
+
+      builder.response :logger, Safire.logger, { headers: { request: true, response: true }, bodies: false } do |logger|
+        logger.filter(/(Authorization: )(.+)/, '\1[FILTERED]')
       end
     end
 

--- a/spec/safire/http_client_spec.rb
+++ b/spec/safire/http_client_spec.rb
@@ -48,6 +48,60 @@ RSpec.describe Safire::HTTPClient do
     end
   end
 
+  describe 'HTTP request logging' do
+    let(:log_output) { StringIO.new }
+    let(:test_logger) { Logger.new(log_output) }
+
+    context 'when log_http is true (default)' do
+      before do
+        allow(Safire).to receive_messages(
+          configuration: instance_double(Safire::Configuration, log_http: true),
+          logger: test_logger
+        )
+      end
+
+      let(:logging_client) { described_class.new(base_url:) }
+
+      it 'logs HTTP requests' do
+        stub_request(:get, base_url).to_return(status: 200, body: {}.to_json)
+        logging_client.get
+        expect(log_output.string).not_to be_empty
+      end
+
+      it 'filters the Authorization header value' do
+        stub_request(:post, "#{base_url}/token").to_return(status: 200, body: {}.to_json)
+        logging_client.post('/token', headers: { 'Authorization' => 'Basic c2VjcmV0' })
+        expect(log_output.string).to include('[FILTERED]')
+        expect(log_output.string).not_to include('c2VjcmV0')
+      end
+
+      it 'does not log request or response bodies' do
+        stub_request(:post, "#{base_url}/token")
+          .to_return(status: 200, body: { access_token: 'secret_token' }.to_json)
+        logging_client.post('/token', body: { client_secret: 'my_secret' })
+        expect(log_output.string).not_to include('my_secret')
+        expect(log_output.string).not_to include('secret_token')
+      end
+    end
+
+    context 'when log_http is false' do
+      before do
+        allow(Safire).to receive_messages(
+          configuration: instance_double(Safire::Configuration, log_http: false),
+          logger: test_logger
+        )
+      end
+
+      let(:quiet_client) { described_class.new(base_url:) }
+
+      it 'does not log HTTP requests' do
+        stub_request(:get, base_url).to_return(status: 200, body: {}.to_json)
+        quiet_client.get
+        expect(log_output.string).to be_empty
+      end
+    end
+  end
+
   describe 'integration scenarios' do
     it 'handles full CRUD cycle' do
       body = { id: 1, name: 'Item 1' }.to_json


### PR DESCRIPTION
## Summary

- Adds `log_http` attribute to `Safire::Configuration` (default: `true`)
- Replaces unconditional Faraday `:logger` middleware with a `configure_logger` helper that reads `Safire.configuration.log_http` at connection build time
- When HTTP logging is enabled, the `Authorization` header is replaced with `[FILTERED]` and request/response bodies are **never** logged — preventing credential and token leakage
- Set `log_http: false` in `Safire.configure` to disable HTTP logging entirely
- Updates `docs/configuration.md` with `log_http` reference table and corrected log level descriptions
- Updates `docs/troubleshooting.md` "Inspect HTTP Requests" section to reflect filtering behaviour

## Security

Previously, the Faraday `:logger` middleware logged request headers (including `Authorization: Basic <base64(client_id:secret)>`) and response bodies (containing `access_token`, `refresh_token`) with no filtering. This PR ensures sensitive data never appears in logs regardless of log level.

## Test plan

- [x] `bundle exec rspec` — 202 examples, 0 failures
- [x] `bundle exec rubocop` — 34 files, no offenses
- [x] New spec: HTTP requests are logged when `log_http: true`
- [x] New spec: `Authorization` header value is replaced with `[FILTERED]`
- [x] New spec: request and response bodies are not logged
- [x] New spec: no log output when `log_http: false`
- [x] Jekyll docs build without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)