### PR TITLE
Fix Safire.logger ignoring configuration.logger

### DIFF
--- a/lib/safire.rb
+++ b/lib/safire.rb
@@ -30,11 +30,15 @@ module Safire
     end
 
     def logger
-      @logger ||= configuration&.logger || default_logger
+      log = configuration&.logger || default_logger
+      log.level = configuration.log_level if configuration&.log_level && log.respond_to?(:level=)
+      log
     end
 
     def default_logger
-      @default_logger ||= Logger.new(ENV['SAFIRE_LOGGER'] || $stdout)
+      @default_logger ||= Logger.new(ENV['SAFIRE_LOGGER'] || $stdout).tap do |l|
+        l.level = Logger::INFO
+      end
     end
 
     def http_client
@@ -112,6 +116,4 @@ module Safire
       @log_http   = true
     end
   end
-
-  Safire.logger.level = Safire.configuration&.log_level || Logger::INFO
 end

--- a/spec/safire_spec.rb
+++ b/spec/safire_spec.rb
@@ -1,6 +1,44 @@
 require 'spec_helper'
 
 RSpec.describe Safire do
+  describe '.logger' do
+    let(:custom_logger) { Logger.new(StringIO.new) }
+
+    before { described_class.instance_variable_set(:@default_logger, nil) }
+
+    after do
+      described_class.instance_variable_set(:@configuration, nil)
+      described_class.instance_variable_set(:@default_logger, nil)
+    end
+
+    context 'when no configure block has run' do
+      it 'returns a Logger instance' do
+        expect(described_class.logger).to be_a(Logger)
+      end
+    end
+
+    context 'when config.logger is set' do
+      before { described_class.configure { |c| c.logger = custom_logger } }
+
+      it 'returns the configured logger' do
+        expect(described_class.logger).to be(custom_logger)
+      end
+
+      it 'wins even after default_logger was already accessed' do
+        described_class.default_logger
+        expect(described_class.logger).to be(custom_logger)
+      end
+    end
+
+    context 'when config.log_level is set' do
+      before { described_class.configure { |c| c.log_level = Logger::DEBUG } }
+
+      it 'applies log_level to the logger' do
+        expect(described_class.logger.level).to eq(Logger::DEBUG)
+      end
+    end
+  end
+
   describe '.token_response_valid?' do
     before { allow(described_class.logger).to receive(:warn) }
 
@@ -16,43 +54,26 @@ RSpec.describe Safire do
       end
     end
 
-    context 'when access_token is missing' do
-      it 'returns false and logs a warning' do
-        result = described_class.token_response_valid?(valid_response.except('access_token'))
-        expect(result).to be(false)
-        expect(described_class.logger).to have_received(:warn).with(/'access_token' is missing/)
+    %w[access_token scope token_type].each do |field|
+      context "when #{field} is missing" do
+        it 'returns false and logs a warning' do
+          result = described_class.token_response_valid?(valid_response.except(field))
+          expect(result).to be(false)
+          expect(described_class.logger).to have_received(:warn).with(/'#{field}' is missing/)
+        end
       end
     end
 
-    context 'when scope is missing' do
-      it 'returns false and logs a warning' do
-        result = described_class.token_response_valid?(valid_response.except('scope'))
-        expect(result).to be(false)
-        expect(described_class.logger).to have_received(:warn).with(/'scope' is missing/)
-      end
-    end
-
-    context 'when token_type is missing' do
-      it 'returns false and logs a warning' do
-        result = described_class.token_response_valid?(valid_response.except('token_type'))
-        expect(result).to be(false)
-        expect(described_class.logger).to have_received(:warn).with(/'token_type' is missing/)
-      end
-    end
-
-    context 'when token_type is lowercase "bearer"' do
-      it 'returns false and logs a warning' do
-        result = described_class.token_response_valid?(valid_response.merge('token_type' => 'bearer'))
-        expect(result).to be(false)
-        expect(described_class.logger).to have_received(:warn).with(/token_type.*bearer.*Bearer/)
-      end
-    end
-
-    context 'when token_type is "BEARER"' do
-      it 'returns false and logs a warning' do
-        result = described_class.token_response_valid?(valid_response.merge('token_type' => 'BEARER'))
-        expect(result).to be(false)
-        expect(described_class.logger).to have_received(:warn).with(/token_type/)
+    [
+      ['lowercase "bearer"', 'bearer', /token_type.*bearer.*Bearer/],
+      ['"BEARER"', 'BEARER', /token_type/]
+    ].each do |description, value, warning_pattern|
+      context "when token_type is #{description}" do
+        it 'returns false and logs a warning' do
+          result = described_class.token_response_valid?(valid_response.merge('token_type' => value))
+          expect(result).to be(false)
+          expect(described_class.logger).to have_received(:warn).with(warning_pattern)
+        end
       end
     end
 
@@ -67,18 +88,12 @@ RSpec.describe Safire do
     end
 
     context 'when response is not a Hash' do
-      it 'returns false and logs a warning' do
-        result = described_class.token_response_valid?('not a hash')
-        expect(result).to be(false)
-        expect(described_class.logger).to have_received(:warn).with(/not a JSON object/)
-      end
-    end
-
-    context 'when response is nil' do
-      it 'returns false and logs a warning' do
-        result = described_class.token_response_valid?(nil)
-        expect(result).to be(false)
-        expect(described_class.logger).to have_received(:warn).with(/not a JSON object/)
+      [nil, 'not a hash'].each do |invalid|
+        it "returns false for #{invalid.inspect} and logs a warning" do
+          result = described_class.token_response_valid?(invalid)
+          expect(result).to be(false)
+          expect(described_class.logger).to have_received(:warn).with(/not a JSON object/)
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

- `logger` was memoized via `@logger ||=` on first call, which was triggered by a require-time side-effect. Any `Safire.configure { |c| c.logger = ... }` block called afterward was silently ignored.
- Removed `@logger` memoization; `logger` now re-evaluates on every call
- `configuration.log_level` is applied to the logger when present (with `respond_to?(:level=)` guard for custom logger compatibility)
- `default_logger` sets `Logger::INFO` as baseline via `tap`
- Removed the require-time side-effect (`Safire.logger.level = ...`)
- Added `.logger` specs covering all four behaviors (TDD)
- DRY'd `safire_spec.rb`: loops for repeated missing-field, invalid token-type, and non-Hash patterns
