### PR TITLE
Refactor error classes to typed keyword constructors

### DIFF
--- a/docs/smart-on-fhir/confidential-asymmetric.md
+++ b/docs/smart-on-fhir/confidential-asymmetric.md
@@ -239,7 +239,6 @@ def callback
   redirect_to patient_path(session[:patient_id])
 rescue Safire::Errors::TokenError => e
   Rails.logger.error("Token exchange failed: #{e.message}")
-  Rails.logger.error("Server response: #{e.details[:body]}") if e.details
   render plain: 'Authorization failed', status: :unauthorized
 end
 ```
@@ -350,7 +349,6 @@ module SmartAuthentication
     Rails.logger.info("Access token refreshed successfully")
   rescue Safire::Errors::TokenError => e
     Rails.logger.error("Token refresh failed: #{e.message}")
-    Rails.logger.error("Server response: #{e.details[:body]}") if e.details
 
     # Clear invalid tokens
     clear_auth_session
@@ -614,14 +612,12 @@ def callback
     code_verifier: session[:code_verifier]
   )
 rescue Safire::Errors::TokenError => e
-  body = e.details&.dig(:body)
-
-  case body
-  when /invalid_client/
+  case e.error_code
+  when 'invalid_client'
     # Server rejected the JWT assertion (wrong key, expired, bad signature)
-    Rails.logger.error("JWT assertion rejected: #{body}")
+    Rails.logger.error("JWT assertion rejected: #{e.message}")
     render plain: 'Client authentication failed', status: :unauthorized
-  when /invalid_grant/
+  when 'invalid_grant'
     # Authorization code expired or already used
     redirect_to launch_path, alert: 'Authorization expired. Please try again.'
   else
@@ -638,7 +634,7 @@ def refresh_access_token
   new_tokens = client.refresh_token(refresh_token: session[:refresh_token])
   # ...
 rescue Safire::Errors::TokenError => e
-  if e.details&.dig(:body)&.include?('invalid_grant')
+  if e.error_code == 'invalid_grant'
     # Refresh token expired - user must re-authorize
     Rails.logger.info("Refresh token expired for user")
     clear_auth_session
@@ -806,13 +802,11 @@ class SmartAuthController < ApplicationController
   end
 
   def handle_token_error(error)
-    body = error.details&.dig(:body)
-
-    case body
-    when /invalid_client/
+    case error.error_code
+    when 'invalid_client'
       Rails.logger.error("JWT assertion rejected by server")
       render plain: 'Client authentication failed', status: :unauthorized
-    when /invalid_grant/
+    when 'invalid_grant'
       redirect_to launch_path, alert: 'Authorization expired. Please try again.'
     else
       Rails.logger.error("Token error: #{error.message}")

--- a/docs/smart-on-fhir/confidential-symmetric.md
+++ b/docs/smart-on-fhir/confidential-symmetric.md
@@ -205,7 +205,6 @@ def callback
   redirect_to patient_path(session[:patient_id])
 rescue Safire::Errors::TokenError => e
   Rails.logger.error("Token exchange failed: #{e.message}")
-  Rails.logger.error("Server response: #{e.details[:body]}") if e.details
   render plain: 'Authorization failed', status: :unauthorized
 end
 ```
@@ -291,7 +290,6 @@ module SmartAuthentication
     Rails.logger.info("Access token refreshed successfully")
   rescue Safire::Errors::TokenError => e
     Rails.logger.error("Token refresh failed: #{e.message}")
-    Rails.logger.error("Server response: #{e.details[:body]}") if e.details
 
     # Clear invalid tokens
     clear_auth_session
@@ -459,7 +457,7 @@ module SmartSecretRotation
       # Try primary secret
       create_client(primary_secret)
     rescue Safire::Errors::TokenError => e
-      if e.details&.dig(:body)&.include?('invalid_client')
+      if e.error_code == 'invalid_client'
         # Fall back to secondary during rotation
         create_client(secondary_secret)
       else
@@ -491,16 +489,13 @@ def callback
     code_verifier: session[:code_verifier]
   )
 rescue Safire::Errors::TokenError => e
-  # Check the server's OAuth error via e.details
-  body = e.details&.dig(:body)
-
-  case body
-  when /invalid_client/
+  case e.error_code
+  when 'invalid_client'
     # Client credentials are wrong
     Rails.logger.error("Invalid client credentials - check client_id and client_secret")
     notify_operations_team("SMART client credentials invalid")
     render plain: 'Configuration error', status: :internal_server_error
-  when /invalid_grant/
+  when 'invalid_grant'
     # Authorization code expired or already used
     redirect_to launch_path, alert: 'Authorization expired. Please try again.'
   else
@@ -517,7 +512,7 @@ def refresh_access_token
   new_tokens = client.refresh_token(refresh_token: session[:refresh_token])
   # ...
 rescue Safire::Errors::TokenError => e
-  if e.details&.dig(:body)&.include?('invalid_grant')
+  if e.error_code == 'invalid_grant'
     # Refresh token expired - user must re-authorize
     Rails.logger.info("Refresh token expired for user")
     clear_auth_session
@@ -685,13 +680,11 @@ class SmartAuthController < ApplicationController
   end
 
   def handle_token_error(error)
-    body = error.details&.dig(:body)
-
-    case body
-    when /invalid_client/
+    case error.error_code
+    when 'invalid_client'
       Rails.logger.error("Invalid client credentials")
       render plain: 'Configuration error', status: :internal_server_error
-    when /invalid_grant/
+    when 'invalid_grant'
       redirect_to launch_path, alert: 'Authorization expired. Please try again.'
     else
       Rails.logger.error("Token error: #{error.message}")

--- a/docs/smart-on-fhir/public-client.md
+++ b/docs/smart-on-fhir/public-client.md
@@ -223,7 +223,6 @@ def callback
   redirect_to patient_path(session[:patient_id])
 rescue Safire::Errors::TokenError => e
   Rails.logger.error("Token exchange failed: #{e.message}")
-  Rails.logger.error("Server response: #{e.details[:body]}") if e.details
   render plain: 'Authorization failed', status: :unauthorized
 end
 ```
@@ -314,7 +313,6 @@ module SmartAuthentication
     Rails.logger.info("Access token refreshed successfully")
   rescue Safire::Errors::TokenError => e
     Rails.logger.error("Token refresh failed: #{e.message}")
-    Rails.logger.error("Server response: #{e.details[:body]}") if e.details
 
     # Clear invalid tokens
     clear_auth_session
@@ -517,14 +515,11 @@ def callback
 
   # ... store tokens ...
 rescue Safire::Errors::TokenError => e
-  # Access the server's error response via e.details
-  body = e.details&.dig(:body)
-
-  case body
-  when /invalid_grant/
+  case e.error_code
+  when 'invalid_grant'
     # Authorization code expired or was already used
     redirect_to launch_path, alert: 'Authorization code expired. Please try again.'
-  when /invalid_client/
+  when 'invalid_client'
     # Client ID not recognized
     Rails.logger.error("Invalid client configuration: #{e.message}")
     render plain: 'Configuration error', status: :internal_server_error
@@ -542,7 +537,6 @@ The automatic refresh concern handles errors gracefully:
 ```ruby
 rescue Safire::Errors::TokenError => e
   Rails.logger.error("Token refresh failed: #{e.message}")
-  Rails.logger.error("Server response: #{e.details[:body]}") if e.details
 
   # Clear invalid session state
   clear_auth_session

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -26,7 +26,7 @@ Common issues and solutions when integrating SMART on FHIR with Safire.
 
 **Symptoms:**
 ```ruby
-Safire::Errors::DiscoveryError: Failed to discover SMART configuration: "HTTP request failed: the server responded with status 404"
+Safire::Errors::DiscoveryError: Failed to discover SMART configuration from https://fhir.example.com/.well-known/smart-configuration (HTTP 404)
 ```
 
 **Causes:**
@@ -66,7 +66,7 @@ Safire::Errors::DiscoveryError: Failed to discover SMART configuration: "HTTP re
 
 **Symptoms:**
 ```ruby
-Safire::Errors::DiscoveryError: Invalid SMART configuration format: expected JSON object but received "..."
+Safire::Errors::DiscoveryError: Failed to discover SMART configuration from https://fhir.example.com/.well-known/smart-configuration: response is not a JSON object
 ```
 
 **Causes:**
@@ -97,7 +97,7 @@ Safire::Errors::DiscoveryError: Invalid SMART configuration format: expected JSO
 
 **Symptoms:**
 ```ruby
-Safire::Errors::ConfigurationError: SMART Client auth flow requires scopes (Array)
+Safire::Errors::ConfigurationError: Configuration missing: scopes
 ```
 
 **Causes:**
@@ -169,11 +169,11 @@ Safire::Errors::ConfigurationError: SMART Client auth flow requires scopes (Arra
 
 ## Token Exchange Errors
 
-### TokenError: Failed to obtain access token
+### TokenError: Token request failed
 
 **Symptoms:**
 ```ruby
-Safire::Errors::TokenError: Failed to obtain access token: "{\"error\":\"invalid_grant\"}"
+Safire::Errors::TokenError: Token request failed — HTTP 400 — invalid_grant — Authorization code has expired
 ```
 
 **Common Causes and Solutions:**
@@ -212,7 +212,7 @@ Safire::Errors::TokenError: Failed to obtain access token: "{\"error\":\"invalid
 
 **Symptoms:**
 ```ruby
-Safire::Errors::TokenError: Missing access token in response: {...}
+Safire::Errors::TokenError: Missing access token in response; received fields: token_type, expires_in
 ```
 
 **Causes:**
@@ -221,16 +221,12 @@ Safire::Errors::TokenError: Missing access token in response: {...}
 
 **Solutions:**
 
-1. Inspect the actual response using the `details` attribute:
+1. Inspect the full error message, which includes all available context:
    ```ruby
    begin
      tokens = client.request_access_token(code: code, code_verifier: verifier)
    rescue Safire::Errors::TokenError => e
      Rails.logger.error("Token error: #{e.message}")
-     if e.details
-       Rails.logger.error("HTTP status: #{e.details[:status]}")
-       Rails.logger.error("Response body: #{e.details[:body]}")
-     end
    end
    ```
 
@@ -238,11 +234,11 @@ Safire::Errors::TokenError: Missing access token in response: {...}
 
 ## Confidential Client Errors
 
-### ConfigurationError: client_secret is needed
+### ConfigurationError: Missing client_secret
 
 **Symptoms:**
 ```ruby
-Safire::Errors::ConfigurationError: client_secret is needed to request access token for confidential_symmetric
+Safire::Errors::ConfigurationError: Configuration missing: client_secret
 ```
 
 **Causes:**
@@ -308,11 +304,11 @@ Safire::Errors::ConfigurationError: client_secret is needed to request access to
    end
    ```
 
-### TokenError: Missing required asymmetric credentials
+### ConfigurationError: Missing required asymmetric credentials
 
 **Symptoms:**
 ```ruby
-Safire::Errors::TokenError: Failed to obtain access token: "Missing required asymmetric credentials: private_key"
+Safire::Errors::ConfigurationError: Configuration missing: private_key
 ```
 
 **Causes:**
@@ -374,11 +370,11 @@ Safire::Errors::TokenError: Failed to obtain access token: "Missing required asy
 
 ## Refresh Token Errors
 
-### TokenError: Failed to refresh access token
+### TokenError: Refresh token request failed
 
 **Symptoms:**
 ```ruby
-Safire::Errors::TokenError: Failed to refresh access token: "{\"error\":\"invalid_grant\"}"
+Safire::Errors::TokenError: Token request failed — HTTP 400 — invalid_grant — Refresh token expired
 ```
 
 **Causes:**
@@ -396,8 +392,7 @@ Safire::Errors::TokenError: Failed to refresh access token: "{\"error\":\"invali
    rescue Safire::Errors::TokenError => e
      Rails.logger.error("Refresh failed: #{e.message}")
 
-     # Check the server's OAuth error in e.details
-     if e.details&.dig(:body)&.include?('invalid_grant')
+     if e.error_code == 'invalid_grant'
        # Refresh token is no longer valid
        clear_session
        redirect_to launch_path, alert: 'Session expired. Please sign in again.'
@@ -582,16 +577,12 @@ rescue Safire::Errors::ConfigurationError => e
   render plain: 'Server configuration error', status: :internal_server_error
 rescue Safire::Errors::TokenError => e
   # Token exchange/refresh errors (invalid grant, expired code, server rejection)
+  # e.message contains status, error_code, and error_description
   Rails.logger.error("Token error: #{e.message}")
-  # Access HTTP status and raw response body via e.details
-  if e.details
-    Rails.logger.error("HTTP #{e.details[:status]}: #{e.details[:body]}")
-  end
   redirect_to launch_path, alert: 'Authorization failed. Please try again.'
 rescue Safire::Errors::NetworkError => e
   # Network/connection errors (timeout, connection refused)
   Rails.logger.error("Network error: #{e.message}")
-  Rails.logger.error("Details: #{e.details.inspect}") if e.details
   render plain: 'Server temporarily unavailable', status: :service_unavailable
 end
 ```
@@ -608,7 +599,6 @@ def ensure_valid_token
   rescue Safire::Errors::TokenError => e
     # Refresh token invalid - need to re-authenticate
     Rails.logger.error("Refresh failed: #{e.message}")
-    Rails.logger.error("Server response: #{e.details[:body]}") if e.details
     clear_session
     redirect_to launch_path
   end

--- a/examples/sinatra_app/app.rb
+++ b/examples/sinatra_app/app.rb
@@ -47,27 +47,7 @@ class SafireDemo < Sinatra::Base
     end
 
     def flash_error_message(context, error)
-      msg = "#{context}: #{error.message}"
-      msg += " — #{format_error_details(error.details)}" if error.respond_to?(:details) && error.details.present?
-      msg
-    end
-
-    def format_error_details(details)
-      return details.to_s unless details.is_a?(Hash)
-
-      parts = []
-      parts << "HTTP #{details[:status]}" if details[:status]
-      parts << extract_body_message(details[:body])
-      parts.compact.join(' — ')
-    end
-
-    def extract_body_message(body)
-      body = JSON.parse(body) if body.is_a?(String)
-      return body['error_description'] || body['error'] if body.is_a?(Hash)
-
-      body.presence&.to_s&.truncate(200)
-    rescue JSON::ParserError
-      body.to_s.truncate(200)
+      "#{context}: #{error.message}"
     end
 
     def asymmetric_credentials_configured?

--- a/lib/safire/client_config.rb
+++ b/lib/safire/client_config.rb
@@ -94,8 +94,12 @@ module Safire
     # @raise [Errors::ConfigurationError] if any URI is malformed or uses HTTP on a non-localhost host
     def validate_uris!
       invalid_uris, non_https_uris = collect_uri_violations
-      messages = build_uri_error_messages(invalid_uris, non_https_uris)
-      raise Errors::ConfigurationError, messages.join('. ') if messages.any?
+      return if invalid_uris.empty? && non_https_uris.empty?
+
+      raise Errors::ConfigurationError.new(
+        invalid_uri_attributes: invalid_uris,
+        non_https_uri_attributes: non_https_uris
+      )
     end
 
     def collect_uri_violations
@@ -124,18 +128,6 @@ module Safire
       :invalid
     end
 
-    def build_uri_error_messages(invalid_uris, non_https_uris)
-      messages = []
-      if invalid_uris.any?
-        messages << "Client configuration has invalid URIs for attributes: #{invalid_uris.to_sentence}"
-      end
-      if non_https_uris.any?
-        messages << "Client configuration requires HTTPS for: #{non_https_uris.to_sentence} " \
-                    '(SMART App Launch 2.2.0 requires TLS; HTTP is only allowed for localhost)'
-      end
-      messages
-    end
-
     # Returns true when the host is a local loopback address.
     # HTTP is permitted for localhost to support development environments.
     def localhost_host?(host)
@@ -151,8 +143,7 @@ module Safire
         return
       end
 
-      raise Errors::ConfigurationError,
-            "Client configuration missing required attributes: #{nil_vars.to_sentence}"
+      raise Errors::ConfigurationError.new(missing_attributes: nil_vars)
     end
   end
 end

--- a/lib/safire/errors.rb
+++ b/lib/safire/errors.rb
@@ -1,67 +1,247 @@
 module Safire
   # Namespace for all Safire error classes.
   #
-  # Every Safire error inherits from {Error} and carries an optional {Error#details details}
-  # attribute with structured context about the failure (HTTP status, response body, etc.).
+  # Every Safire error inherits from {Error} so consumers can rescue
+  # all Safire errors with a single +rescue Safire::Errors::Error+.
+  # Each subclass exposes typed, domain-specific attributes and builds
+  # its own human-readable message.
   #
-  # @example Rescuing and inspecting error details
+  # @example Rescuing a specific error
   #   begin
   #     tokens = client.request_access_token(code: code, code_verifier: verifier)
   #   rescue Safire::Errors::TokenError => e
-  #     puts e.message              # Human-readable error message
-  #     if e.details
-  #       puts e.details[:status]   # HTTP status code (e.g., 401)
-  #       puts e.details[:body]     # Raw response body (JSON string)
-  #     end
+  #     puts e.message        # "Token request failed — HTTP 401 — invalid_grant — Code expired"
+  #     puts e.status         # 401
+  #     puts e.error_code     # "invalid_grant"
+  #   rescue Safire::Errors::Error => e
+  #     puts e.message        # catch-all for any other Safire error
   #   end
   module Errors
-    # Base error class for all Safire errors.
-    #
-    # All Safire errors support an optional +details+ keyword argument that carries
-    # structured context about the failure. When an error originates from an HTTP request,
-    # +details+ is typically a Hash with +:status+ (Integer) and +:body+ (String) keys.
-    #
-    # @!attribute [r] details
-    #   @return [Hash, nil] structured error context; +nil+ when no additional details are available.
-    #     For HTTP-originated errors the hash contains:
-    #     * +:status+ [Integer] — HTTP response status code
-    #     * +:body+ [String] — raw JSON response body from the server
-    class Error < StandardError
-      attr_reader :details
+    # Base class — rescue anchor only. All Safire errors inherit from this.
+    class Error < StandardError; end
 
-      def initialize(message = nil, details: nil)
-        super(message)
-        @details = details
+    # Raised when client configuration is missing or invalid.
+    #
+    # @!attribute [r] missing_attributes
+    #   @return [Array<Symbol>] required attributes that are absent
+    # @!attribute [r] invalid_attribute
+    #   @return [Symbol, nil] attribute whose value is not acceptable
+    # @!attribute [r] invalid_value
+    #   @return [Object, nil] the offending value
+    # @!attribute [r] valid_values
+    #   @return [Array, nil] acceptable values for the attribute
+    # @!attribute [r] invalid_uri_attributes
+    #   @return [Array<Symbol>] attributes whose URIs are malformed
+    # @!attribute [r] non_https_uri_attributes
+    #   @return [Array<Symbol>] attributes whose URIs use HTTP on a non-localhost host
+    class ConfigurationError < Error
+      attr_reader :missing_attributes, :invalid_attribute, :invalid_value, :valid_values,
+                  :invalid_uri_attributes, :non_https_uri_attributes
+
+      def initialize(missing_attributes: [], invalid_attribute: nil, invalid_value: nil,
+                     valid_values: nil, invalid_uri_attributes: [], non_https_uri_attributes: [])
+        @missing_attributes     = Array(missing_attributes)
+        @invalid_attribute      = invalid_attribute
+        @invalid_value          = invalid_value
+        @valid_values           = valid_values
+        @invalid_uri_attributes = Array(invalid_uri_attributes)
+        @non_https_uri_attributes = Array(non_https_uri_attributes)
+        super(build_message)
+      end
+
+      private
+
+      def build_message
+        if @missing_attributes.any?
+          "Configuration missing: #{@missing_attributes.join(', ')}"
+        elsif @invalid_attribute
+          "Invalid #{@invalid_attribute}: #{@invalid_value.inspect}; valid: #{@valid_values&.join(', ')}"
+        else
+          build_uri_message
+        end
+      end
+
+      def build_uri_message
+        parts = []
+        parts << "Configuration has invalid URIs: #{@invalid_uri_attributes.join(', ')}" if @invalid_uri_attributes.any?
+        if @non_https_uri_attributes.any?
+          parts << "Configuration requires HTTPS for: #{@non_https_uri_attributes.join(', ')} " \
+                   '(SMART App Launch 2.2.0 requires TLS; HTTP is only allowed for localhost)'
+        end
+        parts.any? ? parts.join('. ') : 'Configuration error'
       end
     end
 
-    # Raised when client configuration is missing or invalid.
-    class ConfigurationError < Error; end
+    # Raised when SMART configuration discovery fails.
+    #
+    # @!attribute [r] endpoint
+    #   @return [String] the discovery endpoint URL that was requested
+    # @!attribute [r] status
+    #   @return [Integer, nil] HTTP status code returned by the server
+    # @!attribute [r] error_description
+    #   @return [String, nil] description of why discovery failed (e.g. unexpected response format)
+    class DiscoveryError < Error
+      attr_reader :endpoint, :status, :error_description
+
+      def initialize(endpoint:, status: nil, error_description: nil)
+        @endpoint          = endpoint
+        @status            = status
+        @error_description = error_description
+        super(build_message)
+      end
+
+      private
+
+      def build_message
+        msg = "Failed to discover SMART configuration from #{@endpoint}"
+        msg += " (HTTP #{@status})" if @status
+        msg += ": #{@error_description}" if @error_description
+        msg
+      end
+    end
+
+    # Raised for token exchange or refresh failures.
+    #
+    # Two usage paths:
+    # - HTTP failure: provide +status+, +error_code+, and/or +error_description+
+    # - Structural failure (missing +access_token+): provide +received_fields+
+    #
+    # @!attribute [r] status
+    #   @return [Integer, nil] HTTP status code
+    # @!attribute [r] error_code
+    #   @return [String, nil] OAuth2 +error+ field (e.g. +"invalid_grant"+)
+    # @!attribute [r] error_description
+    #   @return [String, nil] OAuth2 +error_description+ field
+    # @!attribute [r] received_fields
+    #   @return [Array<String>, nil] field names present in an invalid token response (no values)
+    class TokenError < Error
+      attr_reader :status, :error_code, :error_description, :received_fields
+
+      def initialize(status: nil, error_code: nil, error_description: nil, received_fields: nil)
+        @status            = status
+        @error_code        = error_code
+        @error_description = error_description
+        @received_fields   = received_fields
+        super(build_message)
+      end
+
+      private
+
+      def build_message
+        if @received_fields
+          "Missing access token in response; received fields: #{@received_fields.join(', ')}"
+        else
+          parts = ['Token request failed']
+          parts << "HTTP #{@status}" if @status
+          parts << @error_code if @error_code
+          parts << @error_description if @error_description
+          parts.join(' — ')
+        end
+      end
+    end
 
     # Raised when an authorization request fails.
-    # The +details+ attribute may contain the HTTP status and OAuth2 error response body.
-    class AuthError < Error; end
+    #
+    # @!attribute [r] status
+    #   @return [Integer, nil] HTTP status code
+    # @!attribute [r] error_code
+    #   @return [String, nil] OAuth2 +error+ field
+    # @!attribute [r] error_description
+    #   @return [String, nil] OAuth2 +error_description+ field
+    class AuthError < Error
+      attr_reader :status, :error_code, :error_description
 
-    # Raised when SMART configuration discovery fails or returns an invalid response.
-    # The +details+ attribute may contain the HTTP status and response body from the
-    # +.well-known/smart-configuration+ endpoint.
-    class DiscoveryError < Error; end
+      def initialize(status: nil, error_code: nil, error_description: nil)
+        @status            = status
+        @error_code        = error_code
+        @error_description = error_description
+        super(build_message)
+      end
 
-    # Raised for token-related errors.
-    class TokenError < Error; end
+      private
 
-    # Raised for certificate-related errors (e.g., UDAP flows).
-    class CertificateError < Error; end
+      def build_message
+        parts = ['Authorization request failed']
+        parts << "HTTP #{@status}" if @status
+        parts << @error_code if @error_code
+        parts << @error_description if @error_description
+        parts.join(' — ')
+      end
+    end
 
-    # Raised for protocol-level errors.
-    class ProtocolError < Error; end
+    # Raised for X.509 certificate errors (e.g., in UDAP flows).
+    #
+    # @!attribute [r] reason
+    #   @return [String, nil] why the certificate is invalid (e.g. +"expired"+, +"untrusted"+)
+    # @!attribute [r] subject
+    #   @return [String, nil] certificate subject string (safe to log)
+    class CertificateError < Error
+      attr_reader :reason, :subject
 
-    # Raised when an HTTP request fails at the network level (connection refused, timeout, etc.).
-    # The +details+ attribute contains +:status+ and +:body+ extracted from the HTTP response
-    # when available.
-    class NetworkError < Error; end
+      def initialize(reason: nil, subject: nil)
+        @reason  = reason
+        @subject = subject
+        super(build_message)
+      end
+
+      private
+
+      def build_message
+        parts = ['Certificate error']
+        parts << @reason if @reason
+        parts << "(subject: #{@subject})" if @subject
+        parts.join(' — ')
+      end
+    end
+
+    # Raised when an HTTP request fails at the network or transport level
+    # (connection refused, timeout, SSL handshake failure, etc.).
+    #
+    # @!attribute [r] error_description
+    #   @return [String, nil] the underlying transport error message
+    class NetworkError < Error
+      attr_reader :error_description
+
+      def initialize(error_description: nil)
+        @error_description = error_description
+        super(build_message)
+      end
+
+      private
+
+      def build_message
+        return 'HTTP request failed' unless @error_description
+
+        "HTTP request failed: #{@error_description}"
+      end
+    end
 
     # Raised for input validation errors.
-    class ValidationError < Error; end
+    #
+    # @!attribute [r] attribute
+    #   @return [Symbol, nil] the attribute that failed validation
+    # @!attribute [r] reason
+    #   @return [String, nil] why validation failed
+    class ValidationError < Error
+      attr_reader :attribute, :reason
+
+      def initialize(attribute: nil, reason: nil)
+        @attribute = attribute
+        @reason    = reason
+        super(build_message)
+      end
+
+      private
+
+      def build_message
+        if @attribute && @reason
+          "Validation failed for #{@attribute}: #{@reason}"
+        elsif @attribute
+          "Validation failed for #{@attribute}"
+        else
+          'Validation error'
+        end
+      end
+    end
   end
 end

--- a/lib/safire/http_client.rb
+++ b/lib/safire/http_client.rb
@@ -53,24 +53,15 @@ module Safire
       end
     end
 
-    def request(method, path, body: nil, params: {}, headers: {}) # rubocop:disable Metrics/AbcSize
+    def request(method, path, body: nil, params: {}, headers: {})
       @connection.send(method) do |req|
         req.url path.sub(%r{^/}, '') # Remove leading slash if present since base_url ends with slash
         req.params.update(params) if params.present?
         req.headers.update(headers) if headers.present?
         req.body = body if body
       end
-    rescue Faraday::Error, Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
-      raise Safire::Errors::NetworkError.new(
-        "HTTP request failed: #{e.message}",
-        details: { status: e.response&.dig(:status), body: safe_body(e.response&.dig(:body)) }
-      )
-    end
-
-    def safe_body(body)
-      return body unless body.is_a?(String) && body.length > 2000
-
-      "#{body[0..2000]}... (truncated, total #{body.length} characters)"
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
+      raise Safire::Errors::NetworkError.new(error_description: e.message)
     end
 
     def normalize_base_url(url)

--- a/lib/safire/protocols/smart.rb
+++ b/lib/safire/protocols/smart.rb
@@ -112,16 +112,11 @@ module Safire
         return @well_known_config if @well_known_config
 
         response = @http_client.get(well_known_endpoint)
-        metadata = parse_metadata(response.body)
-
-        @well_known_config = SmartMetadata.new(metadata)
-      rescue StandardError => e
-        msg = "Failed to discover SMART configuration: #{e.message.inspect}"
-        details = e.try(:details)
-        log_msg = "SMART discovery for endpoint `#{well_known_endpoint}` failed: #{msg}"
-        log_msg += " (details: #{details.inspect})" if details
-        Safire.logger.error(log_msg)
-        raise Errors::DiscoveryError.new(msg, details: details)
+        @well_known_config = SmartMetadata.new(parse_discovery_body(response.body))
+      rescue Faraday::Error => e
+        status = e.response&.dig(:status)
+        Safire.logger.error("SMART discovery failed for `#{well_known_endpoint}`: HTTP #{status}")
+        raise Errors::DiscoveryError.new(endpoint: well_known_endpoint, status: status)
       end
 
       # Builds the authorization request data for the authorization code flow.
@@ -183,10 +178,8 @@ module Safire
         )
 
         parse_token_response(response.body)
-      rescue StandardError => e
-        msg = "Failed to obtain access token: #{e.message.inspect}"
-        details = e.try(:details)
-        raise Errors::TokenError.new(msg, details: details)
+      rescue Faraday::Error => e
+        raise token_error_from(e)
       end
 
       # Exchanges a refresh token for a new access token.
@@ -213,10 +206,8 @@ module Safire
         )
 
         parse_token_response(response.body)
-      rescue StandardError => e
-        msg = "Failed to refresh access token: #{e.message.inspect}"
-        details = e.try(:details)
-        raise Errors::TokenError.new(msg, details: details)
+      rescue Faraday::Error => e
+        raise token_error_from(e)
       end
 
       private
@@ -225,15 +216,17 @@ module Safire
         missing = (ATTRIBUTES - OPTIONAL_ATTRIBUTES).select { |attr| send(attr).blank? }
         return if missing.empty?
 
-        raise Errors::ConfigurationError,
-              "SMART Client configuration missing attributes: #{missing.to_sentence}"
+        raise Errors::ConfigurationError.new(missing_attributes: missing)
       end
 
       def validate_authorization_method(method)
         return if %i[get post].include?(method)
 
-        raise Errors::ConfigurationError,
-              "Invalid authorization method: #{method.inspect}. Supported methods are :get and :post"
+        raise Errors::ConfigurationError.new(
+          invalid_attribute: :method,
+          invalid_value: method,
+          valid_values: %i[get post]
+        )
       end
 
       def build_authorization_response(method, params, code_verifier)
@@ -249,35 +242,32 @@ module Safire
       def validate_presence_of_scopes(custom_scopes = nil)
         return if (scopes || custom_scopes).present?
 
-        raise Errors::ConfigurationError,
-              'SMART Client auth flow requires scopes (Array)'
+        raise Errors::ConfigurationError.new(missing_attributes: [:scopes])
       end
 
       def validate_client_secret(secret)
         return if secret.present?
 
-        raise Errors::ConfigurationError, "client_secret is needed to request access token for #{auth_type}"
+        raise Errors::ConfigurationError.new(missing_attributes: [:client_secret])
       end
 
-      def parse_json_response(data, error_class, context)
-        unless data.is_a?(Hash)
-          raise error_class,
-                "Invalid #{context} format: expected JSON object but received #{data.inspect}"
-        end
+      def parse_discovery_body(body)
+        return body if body.is_a?(Hash)
 
-        data
+        raise Errors::DiscoveryError.new(
+          endpoint: well_known_endpoint,
+          error_description: 'response is not a JSON object'
+        )
       end
 
       def parse_token_response(token_response)
-        parse_json_response(token_response, Errors::TokenError, 'token response').tap do |parsed|
-          unless parsed['access_token'].present?
-            raise Errors::TokenError, "Missing access token in response: #{parsed.inspect}"
-          end
+        unless token_response.is_a?(Hash)
+          raise Errors::TokenError.new(error_description: 'response is not a JSON object')
         end
-      end
 
-      def parse_metadata(metadata)
-        parse_json_response(metadata, Errors::DiscoveryError, 'SMART configuration')
+        return token_response if token_response['access_token'].present?
+
+        raise Errors::TokenError.new(received_fields: token_response.keys)
       end
 
       def authorization_params(launch:, custom_scopes:, code_verifier:)
@@ -364,7 +354,21 @@ module Safire
         missing << :kid if kid.blank?
         return if missing.empty?
 
-        raise Errors::ConfigurationError, "Missing required asymmetric credentials: #{missing.to_sentence}"
+        raise Errors::ConfigurationError.new(missing_attributes: missing)
+      end
+
+      def token_error_from(faraday_error)
+        response = faraday_error.response
+        status   = response&.dig(:status)
+        body     = JSON.parse(response&.dig(:body))
+
+        Errors::TokenError.new(
+          status:,
+          error_code: body.is_a?(Hash) ? body['error'] : nil,
+          error_description: body.is_a?(Hash) ? body['error_description'] : nil
+        )
+      rescue JSON::ParserError
+        Errors::TokenError.new(status:)
       end
 
       def well_known_endpoint

--- a/spec/integration/confidential_asymmetric_flow_spec.rb
+++ b/spec/integration/confidential_asymmetric_flow_spec.rb
@@ -387,7 +387,7 @@ RSpec.describe 'Confidential Asymmetric Client End-to-End Flow', type: :integrat
   end
 
   describe 'Error Handling' do
-    it 'raises TokenError when private_key is missing' do
+    it 'raises ConfigurationError when private_key is missing' do
       config = Safire::ClientConfig.new(
         base_url:,
         client_id:,
@@ -400,10 +400,10 @@ RSpec.describe 'Confidential Asymmetric Client End-to-End Flow', type: :integrat
 
       expect do
         client.request_access_token(code: 'test_code', code_verifier: 'test_verifier')
-      end.to raise_error(Safire::Errors::TokenError, /Missing required asymmetric credentials/)
+      end.to raise_error(Safire::Errors::ConfigurationError, /private_key|kid/)
     end
 
-    it 'raises TokenError when kid is missing' do
+    it 'raises ConfigurationError when kid is missing' do
       config = Safire::ClientConfig.new(
         base_url:,
         client_id:,
@@ -417,7 +417,7 @@ RSpec.describe 'Confidential Asymmetric Client End-to-End Flow', type: :integrat
 
       expect do
         client.request_access_token(code: 'test_code', code_verifier: 'test_verifier')
-      end.to raise_error(Safire::Errors::TokenError, /Missing required asymmetric credentials/)
+      end.to raise_error(Safire::Errors::ConfigurationError, /private_key|kid/)
     end
 
     it 'raises TokenError when server returns invalid_client error' do
@@ -444,7 +444,7 @@ RSpec.describe 'Confidential Asymmetric Client End-to-End Flow', type: :integrat
 
       expect do
         client.request_access_token(code: 'test_code', code_verifier: 'test_verifier')
-      end.to raise_error(Safire::Errors::TokenError, /Failed to obtain access token/)
+      end.to raise_error(Safire::Errors::TokenError, /Token request failed/)
     end
 
     it 'raises TokenError when refresh token is invalid' do
@@ -471,7 +471,7 @@ RSpec.describe 'Confidential Asymmetric Client End-to-End Flow', type: :integrat
 
       expect do
         client.refresh_token(refresh_token: 'expired_token')
-      end.to raise_error(Safire::Errors::TokenError, /Failed to refresh access token/)
+      end.to raise_error(Safire::Errors::TokenError, /Token request failed/)
     end
   end
 end

--- a/spec/integration/confidential_symmetric_flow_spec.rb
+++ b/spec/integration/confidential_symmetric_flow_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe 'Confidential Symmetric Client End-to-End Flow', type: :integrati
 
       expect do
         client.request_access_token(code: 'test_code', code_verifier: 'test_verifier')
-      end.to raise_error(Safire::Errors::TokenError, /Failed to obtain access token/)
+      end.to raise_error(Safire::Errors::TokenError, /Token request failed/)
     end
 
     it 'raises TokenError when refresh token is invalid' do
@@ -364,7 +364,7 @@ RSpec.describe 'Confidential Symmetric Client End-to-End Flow', type: :integrati
 
       expect do
         client.refresh_token(refresh_token: 'expired_token')
-      end.to raise_error(Safire::Errors::TokenError, /Failed to refresh access token/)
+      end.to raise_error(Safire::Errors::TokenError, /Token request failed/)
     end
   end
 end

--- a/spec/integration/public_client_flow_spec.rb
+++ b/spec/integration/public_client_flow_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe 'Public Client End-to-End Flow', type: :integration do
 
       expect do
         client.request_access_token(code: 'invalid_code', code_verifier: 'test_verifier')
-      end.to raise_error(Safire::Errors::TokenError, /Failed to obtain access token/)
+      end.to raise_error(Safire::Errors::TokenError, /Token request failed/)
     end
 
     it 'raises TokenError when refresh token is invalid' do
@@ -327,7 +327,7 @@ RSpec.describe 'Public Client End-to-End Flow', type: :integration do
 
       expect do
         client.refresh_token(refresh_token: 'invalid_refresh_token')
-      end.to raise_error(Safire::Errors::TokenError, /Failed to refresh access token/)
+      end.to raise_error(Safire::Errors::TokenError, /Token request failed/)
     end
   end
 end

--- a/spec/safire/errors_spec.rb
+++ b/spec/safire/errors_spec.rb
@@ -82,6 +82,10 @@ RSpec.describe Safire::Errors do
       it 'has nil status' do
         expect(error.status).to be_nil
       end
+
+      it 'has nil error_description' do
+        expect(error.error_description).to be_nil
+      end
     end
 
     context 'with endpoint and status' do
@@ -93,6 +97,23 @@ RSpec.describe Safire::Errors do
 
       it 'includes status in the message' do
         expect(error.message).to match(/404/)
+      end
+    end
+
+    context 'with endpoint and error_description' do
+      subject(:error) do
+        described_class.new(
+          endpoint: 'https://fhir.example.com/.well-known/smart-configuration',
+          error_description: 'response is not a JSON object'
+        )
+      end
+
+      it 'exposes error_description' do
+        expect(error.error_description).to eq('response is not a JSON object')
+      end
+
+      it 'includes error_description in the message' do
+        expect(error.message).to match(/response is not a JSON object/)
       end
     end
   end
@@ -150,20 +171,15 @@ RSpec.describe Safire::Errors do
       expect(described_class.superclass).to eq(Safire::Errors::Error)
     end
 
-    context 'with status and OAuth2 fields' do
-      subject(:error) do
-        described_class.new(status: 503, error_code: 'server_error', error_description: 'Service unavailable')
+    context 'with error_description' do
+      subject(:error) { described_class.new(error_description: 'Connection refused') }
+
+      it 'exposes error_description' do
+        expect(error.error_description).to eq('Connection refused')
       end
 
-      it 'exposes status, error_code, and error_description' do
-        expect(error.status).to eq(503)
-        expect(error.error_code).to eq('server_error')
-        expect(error.error_description).to eq('Service unavailable')
-      end
-
-      it 'builds a message from typed attributes' do
-        expect(error.message).to match(/503/)
-        expect(error.message).to match(/server_error/)
+      it 'includes the description in the message' do
+        expect(error.message).to match(/Connection refused/)
       end
     end
 
@@ -174,16 +190,100 @@ RSpec.describe Safire::Errors do
     end
   end
 
+  describe Safire::Errors::AuthError do
+    it 'is a Safire::Errors::Error' do
+      expect(described_class.superclass).to eq(Safire::Errors::Error)
+    end
+
+    context 'with status and OAuth2 fields' do
+      subject(:error) do
+        described_class.new(status: 400, error_code: 'invalid_request', error_description: 'Missing redirect_uri')
+      end
+
+      it 'exposes status, error_code, and error_description' do
+        expect(error.status).to eq(400)
+        expect(error.error_code).to eq('invalid_request')
+        expect(error.error_description).to eq('Missing redirect_uri')
+      end
+
+      it 'builds a message from typed attributes' do
+        expect(error.message).to match(/400/)
+        expect(error.message).to match(/invalid_request/)
+        expect(error.message).to match(/Missing redirect_uri/)
+      end
+    end
+
+    context 'with no arguments' do
+      it 'has a generic fallback message' do
+        expect(described_class.new.message).to match(/[Aa]uthorization/)
+      end
+    end
+  end
+
+  describe Safire::Errors::CertificateError do
+    it 'is a Safire::Errors::Error' do
+      expect(described_class.superclass).to eq(Safire::Errors::Error)
+    end
+
+    context 'with reason and subject' do
+      subject(:error) { described_class.new(reason: 'expired', subject: 'CN=my-client,O=Example') }
+
+      it 'exposes reason and subject' do
+        expect(error.reason).to eq('expired')
+        expect(error.subject).to eq('CN=my-client,O=Example')
+      end
+
+      it 'builds a message from typed attributes' do
+        expect(error.message).to match(/expired/)
+        expect(error.message).to match(/CN=my-client/)
+      end
+    end
+
+    context 'with no arguments' do
+      it 'has a generic fallback message' do
+        expect(described_class.new.message).to match(/[Cc]ertificate/)
+      end
+    end
+  end
+
+  describe Safire::Errors::ValidationError do
+    it 'is a Safire::Errors::Error' do
+      expect(described_class.superclass).to eq(Safire::Errors::Error)
+    end
+
+    context 'with attribute and reason' do
+      subject(:error) { described_class.new(attribute: :base_url, reason: 'must use HTTPS') }
+
+      it 'exposes attribute and reason' do
+        expect(error.attribute).to eq(:base_url)
+        expect(error.reason).to eq('must use HTTPS')
+      end
+
+      it 'builds a message from typed attributes' do
+        expect(error.message).to match(/base_url/)
+        expect(error.message).to match(/HTTPS/)
+      end
+    end
+
+    context 'with no arguments' do
+      it 'has a generic fallback message' do
+        expect(described_class.new.message).to match(/[Vv]alidation/)
+      end
+    end
+  end
+
   describe 'rescue hierarchy' do
     it 'can rescue all typed errors as Safire::Errors::Error' do
-      [
+      errors = [
         Safire::Errors::ConfigurationError.new,
         Safire::Errors::DiscoveryError.new(endpoint: 'https://example.com'),
         Safire::Errors::TokenError.new,
-        Safire::Errors::NetworkError.new
-      ].each do |error|
-        expect(error).to be_a(Safire::Errors::Error)
-      end
+        Safire::Errors::NetworkError.new,
+        Safire::Errors::AuthError.new,
+        Safire::Errors::CertificateError.new,
+        Safire::Errors::ValidationError.new
+      ]
+      expect(errors).to all(be_a(Safire::Errors::Error))
     end
   end
 end

--- a/spec/safire/errors_spec.rb
+++ b/spec/safire/errors_spec.rb
@@ -1,0 +1,189 @@
+require 'spec_helper'
+
+RSpec.describe Safire::Errors do
+  describe Safire::Errors::Error do
+    it 'is a StandardError' do
+      expect(described_class.superclass).to eq(StandardError)
+    end
+
+    it 'can be raised and rescued as StandardError' do
+      expect { raise described_class }.to raise_error(StandardError)
+    end
+  end
+
+  describe Safire::Errors::ConfigurationError do
+    it 'is a Safire::Errors::Error' do
+      expect(described_class.superclass).to eq(Safire::Errors::Error)
+    end
+
+    context 'with missing_attributes' do
+      subject(:error) { described_class.new(missing_attributes: %i[base_url client_id]) }
+
+      it 'exposes missing_attributes' do
+        expect(error.missing_attributes).to eq(%i[base_url client_id])
+      end
+
+      it 'builds a message from missing_attributes' do
+        expect(error.message).to match(/base_url/)
+        expect(error.message).to match(/client_id/)
+      end
+
+      it 'does not require a message argument' do
+        expect { described_class.new(missing_attributes: [:base_url]) }.not_to raise_error
+      end
+    end
+
+    context 'with invalid_attribute' do
+      subject(:error) do
+        described_class.new(
+          invalid_attribute: :method,
+          invalid_value: :ftp,
+          valid_values: %i[get post]
+        )
+      end
+
+      it 'exposes invalid_attribute, invalid_value, and valid_values' do
+        expect(error.invalid_attribute).to eq(:method)
+        expect(error.invalid_value).to eq(:ftp)
+        expect(error.valid_values).to eq(%i[get post])
+      end
+
+      it 'builds a message from the invalid attribute context' do
+        expect(error.message).to match(/method/)
+        expect(error.message).to match(/ftp/)
+        expect(error.message).to match(/get/)
+        expect(error.message).to match(/post/)
+      end
+    end
+
+    context 'with no arguments' do
+      it 'has a generic fallback message' do
+        expect(described_class.new.message).to eq('Configuration error')
+      end
+    end
+  end
+
+  describe Safire::Errors::DiscoveryError do
+    it 'is a Safire::Errors::Error' do
+      expect(described_class.superclass).to eq(Safire::Errors::Error)
+    end
+
+    context 'with endpoint only' do
+      subject(:error) { described_class.new(endpoint: 'https://fhir.example.com/.well-known/smart-configuration') }
+
+      it 'exposes endpoint' do
+        expect(error.endpoint).to eq('https://fhir.example.com/.well-known/smart-configuration')
+      end
+
+      it 'builds a message including the endpoint' do
+        expect(error.message).to match(/fhir\.example\.com/)
+      end
+
+      it 'has nil status' do
+        expect(error.status).to be_nil
+      end
+    end
+
+    context 'with endpoint and status' do
+      subject(:error) { described_class.new(endpoint: 'https://fhir.example.com/.well-known/smart-configuration', status: 404) }
+
+      it 'exposes status' do
+        expect(error.status).to eq(404)
+      end
+
+      it 'includes status in the message' do
+        expect(error.message).to match(/404/)
+      end
+    end
+  end
+
+  describe Safire::Errors::TokenError do
+    it 'is a Safire::Errors::Error' do
+      expect(described_class.superclass).to eq(Safire::Errors::Error)
+    end
+
+    context 'when HTTP failure (status + OAuth2 fields)' do
+      subject(:error) do
+        described_class.new(status: 401, error_code: 'invalid_grant', error_description: 'Code expired')
+      end
+
+      it 'exposes status, error_code, and error_description' do
+        expect(error.status).to eq(401)
+        expect(error.error_code).to eq('invalid_grant')
+        expect(error.error_description).to eq('Code expired')
+      end
+
+      it 'builds a message from typed attributes' do
+        expect(error.message).to match(/401/)
+        expect(error.message).to match(/invalid_grant/)
+        expect(error.message).to match(/Code expired/)
+      end
+    end
+
+    context 'when structural failure (missing access_token)' do
+      subject(:error) { described_class.new(received_fields: %w[token_type expires_in]) }
+
+      it 'exposes received_fields' do
+        expect(error.received_fields).to eq(%w[token_type expires_in])
+      end
+
+      it 'builds a message with field names but no values' do
+        expect(error.message).to match(/token_type/)
+        expect(error.message).to match(/expires_in/)
+      end
+
+      it 'does not include sensitive values in the message' do
+        error_with_values = described_class.new(received_fields: %w[token_type])
+        expect(error_with_values.message).not_to match(/Bearer/)
+      end
+    end
+
+    context 'with no arguments' do
+      it 'has a generic fallback message' do
+        expect(described_class.new.message).to match(/[Tt]oken/)
+      end
+    end
+  end
+
+  describe Safire::Errors::NetworkError do
+    it 'is a Safire::Errors::Error' do
+      expect(described_class.superclass).to eq(Safire::Errors::Error)
+    end
+
+    context 'with status and OAuth2 fields' do
+      subject(:error) do
+        described_class.new(status: 503, error_code: 'server_error', error_description: 'Service unavailable')
+      end
+
+      it 'exposes status, error_code, and error_description' do
+        expect(error.status).to eq(503)
+        expect(error.error_code).to eq('server_error')
+        expect(error.error_description).to eq('Service unavailable')
+      end
+
+      it 'builds a message from typed attributes' do
+        expect(error.message).to match(/503/)
+        expect(error.message).to match(/server_error/)
+      end
+    end
+
+    context 'with no arguments' do
+      it 'has a generic fallback message' do
+        expect(described_class.new.message).to match(/[Hh][Tt][Tt][Pp]|[Nn]etwork/)
+      end
+    end
+  end
+
+  describe 'rescue hierarchy' do
+    it 'can rescue all typed errors as Safire::Errors::Error' do
+      [
+        Safire::Errors::ConfigurationError.new,
+        Safire::Errors::DiscoveryError.new(endpoint: 'https://example.com'),
+        Safire::Errors::TokenError.new,
+        Safire::Errors::NetworkError.new
+      ].each do |error|
+        expect(error).to be_a(Safire::Errors::Error)
+      end
+    end
+  end
+end

--- a/spec/safire/protocols/smart_spec.rb
+++ b/spec/safire/protocols/smart_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe Safire::Protocols::Smart do
       stub_request(:get, well_known_url).to_return(status: 200, body: '[]',
                                                    headers: { 'Content-Type' => 'application/json' })
       expect { described_class.new(config).well_known_config }
-        .to raise_error(Safire::Errors::DiscoveryError, /expected JSON object/)
+        .to raise_error(Safire::Errors::DiscoveryError, /response is not a JSON object/)
     end
 
     it 'handles base_url with or without trailing slash' do
@@ -298,7 +298,7 @@ RSpec.describe Safire::Protocols::Smart do
 
     it 'raises when no scopes configured' do
       expect { described_class.new(config.except(:scopes)).authorization_url }
-        .to raise_error(Safire::Errors::ConfigurationError, /requires scopes/)
+        .to raise_error(Safire::Errors::ConfigurationError, /scopes/)
     end
 
     it 'uses custom scopes when provided' do
@@ -377,7 +377,7 @@ RSpec.describe Safire::Protocols::Smart do
     context 'when method is invalid' do
       it 'raises ConfigurationError' do
         expect { described_class.new(config).authorization_url(method: :patch) }
-          .to raise_error(Safire::Errors::ConfigurationError, /Invalid authorization method/)
+          .to raise_error(Safire::Errors::ConfigurationError, /method/)
       end
     end
   end
@@ -493,18 +493,18 @@ RSpec.describe Safire::Protocols::Smart do
     end
 
     context 'when confidential_asymmetric with missing credentials' do
-      it 'raises TokenError when private_key is missing' do
+      it 'raises ConfigurationError when private_key is missing' do
         expect do
           described_class.new(config.merge(kid: 'key-id'), auth_type: :confidential_asymmetric)
                          .request_access_token(code: authorization_code, code_verifier: code_verifier)
-        end.to raise_error(Safire::Errors::TokenError, /Missing required asymmetric credentials/)
+        end.to raise_error(Safire::Errors::ConfigurationError, /private_key/)
       end
 
-      it 'raises TokenError when kid is missing' do
+      it 'raises ConfigurationError when kid is missing' do
         expect do
           described_class.new(config.merge(private_key: rsa_private_key), auth_type: :confidential_asymmetric)
                          .request_access_token(code: authorization_code, code_verifier: code_verifier)
-        end.to raise_error(Safire::Errors::TokenError, /Missing required asymmetric credentials/)
+        end.to raise_error(Safire::Errors::ConfigurationError, /kid/)
       end
     end
 
@@ -529,7 +529,7 @@ RSpec.describe Safire::Protocols::Smart do
     end
 
     context 'when server OAuth error' do
-      it 'raises TokenError' do
+      it 'raises TokenError with status and error_code' do
         stub_token_post(
           body_matcher: {
             'grant_type' => 'authorization_code',
@@ -544,17 +544,17 @@ RSpec.describe Safire::Protocols::Smart do
         expect do
           described_class.new(config, auth_type: :public)
                          .request_access_token(code: 'bad', code_verifier: 'v')
-        end.to raise_error(Safire::Errors::TokenError, /Failed to obtain access token/)
+        end.to raise_error(Safire::Errors::TokenError, /Token request failed/)
       end
     end
 
     context 'when network error' do
-      it 'raises TokenError' do
+      it 'raises NetworkError' do
         stub_request(:post, config[:token_endpoint]).to_raise(Faraday::ConnectionFailed)
         expect do
           described_class.new(config, auth_type: :public)
                          .request_access_token(code: 'x', code_verifier: 'y')
-        end.to raise_error(Safire::Errors::TokenError)
+        end.to raise_error(Safire::Errors::NetworkError)
       end
     end
   end
@@ -648,7 +648,7 @@ RSpec.describe Safire::Protocols::Smart do
       )
       expect do
         described_class.new(config, auth_type: :public).refresh_token(refresh_token: 'bad')
-      end.to raise_error(Safire::Errors::TokenError, /Failed to refresh access token/)
+      end.to raise_error(Safire::Errors::TokenError, /Token request failed/)
     end
 
     it 'raises TokenError when access_token missing' do
@@ -662,11 +662,11 @@ RSpec.describe Safire::Protocols::Smart do
       end.to raise_error(Safire::Errors::TokenError, /Missing access token/)
     end
 
-    it 'raises TokenError on network error' do
+    it 'raises NetworkError on network error' do
       stub_request(:post, config[:token_endpoint]).to_raise(Faraday::TimeoutError)
       expect do
         described_class.new(config, auth_type: :public).refresh_token(refresh_token: 'x')
-      end.to raise_error(Safire::Errors::TokenError)
+      end.to raise_error(Safire::Errors::NetworkError)
     end
   end
 end


### PR DESCRIPTION
## Summary

Replaces the generic `details: {}` hash on error classes with typed, domain-specific keyword attributes. Each error class now accepts only its own specific kwargs and builds its own human-readable message internally. `HTTPClient` is narrowed to rescue only transport-level Faraday errors (`ConnectionFailed`, `TimeoutError`, `SSLError`) and raise `NetworkError`; HTTP 4xx/5xx responses propagate to `smart.rb`, which rescues `Faraday::Error` at each call site and raises a structured `TokenError` via `token_error_from`. All `ConfigurationError` raise sites across `smart.rb` and `client_config.rb` use keyword constructors. Docs and example app updated to use `e.message` / `e.error_code` instead of the removed `e.details`.

## Test plan
- [x] CI passes (rspec + rubocop)