### PR TITLE
Warn when ssl_options: { verify: false } passed to HTTPClient

### DIFF
--- a/lib/safire/http_client.rb
+++ b/lib/safire/http_client.rb
@@ -66,7 +66,7 @@ module Safire
     end
 
     def warn_if_ssl_verification_disabled(ssl_options)
-      return unless ssl_options[:verify] == false
+      return unless ssl_options.is_a?(Hash) && ssl_options[:verify] == false
 
       Safire.logger.warn(
         '[Safire] ssl_options: { verify: false } disables TLS certificate verification — ' \

--- a/lib/safire/http_client.rb
+++ b/lib/safire/http_client.rb
@@ -13,6 +13,7 @@ module Safire
       }
       @adapter = adapter || Faraday.default_adapter
       @request_format = request_format.to_sym
+      warn_if_ssl_verification_disabled(ssl_options)
       @connection = build_connection
     end
 
@@ -62,6 +63,15 @@ module Safire
       end
     rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
       raise Safire::Errors::NetworkError.new(error_description: e.message)
+    end
+
+    def warn_if_ssl_verification_disabled(ssl_options)
+      return unless ssl_options[:verify] == false
+
+      Safire.logger.warn(
+        '[Safire] ssl_options: { verify: false } disables TLS certificate verification — ' \
+        'do not use in production'
+      )
     end
 
     def normalize_base_url(url)

--- a/spec/safire/http_client_spec.rb
+++ b/spec/safire/http_client_spec.rb
@@ -48,6 +48,35 @@ RSpec.describe Safire::HTTPClient do
     end
   end
 
+  describe 'SSL verification warning' do
+    before { allow(Safire.logger).to receive(:warn) }
+
+    context 'when ssl_options: { verify: false }' do
+      it 'logs a security warning' do
+        described_class.new(base_url:, ssl_options: { verify: false })
+        expect(Safire.logger).to have_received(:warn)
+          .with(/ssl.*verify.*false.*TLS.*verification.*disabled/i)
+      end
+    end
+
+    context 'when verify is not explicitly false' do
+      it 'does not warn with no ssl_options' do
+        described_class.new(base_url:)
+        expect(Safire.logger).not_to have_received(:warn)
+      end
+
+      it 'does not warn with verify: true' do
+        described_class.new(base_url:, ssl_options: { verify: true })
+        expect(Safire.logger).not_to have_received(:warn)
+      end
+
+      it 'does not warn with other ssl_options' do
+        described_class.new(base_url:, ssl_options: { ca_file: '/path/to/ca' })
+        expect(Safire.logger).not_to have_received(:warn)
+      end
+    end
+  end
+
   describe 'HTTP request logging' do
     let(:log_output) { StringIO.new }
     let(:test_logger) { Logger.new(log_output) }

--- a/spec/safire/http_client_spec.rb
+++ b/spec/safire/http_client_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Safire::HTTPClient do
       it 'logs a security warning' do
         described_class.new(base_url:, ssl_options: { verify: false })
         expect(Safire.logger).to have_received(:warn)
-          .with(/ssl.*verify.*false.*TLS.*verification.*disabled/i)
+          .with(/verify.*false.*TLS.*verification/i)
       end
     end
 


### PR DESCRIPTION
## Summary

When `ssl_options: { verify: false }` is passed to `HTTPClient`, TLS certificate verification is silently disabled — a security risk with no indication to the developer. This PR emits a `Safire.logger.warn` at construction time when `verify: false` is detected, clearly flagging the risk without blocking the caller.

## Test plan
- [x] CI passes (rspec + rubocop)