### PR TITLE
Enforce HTTPS-only redirect following in HTTPClient

### DIFF
--- a/lib/safire.rb
+++ b/lib/safire.rb
@@ -5,6 +5,7 @@ require 'base64'
 
 require_relative 'safire/version'
 require_relative 'safire/errors'
+require_relative 'safire/middleware/https_only_redirects'
 require_relative 'safire/http_client'
 require_relative 'safire/entity'
 require_relative 'safire/pkce'

--- a/lib/safire/http_client.rb
+++ b/lib/safire/http_client.rb
@@ -39,6 +39,7 @@ module Safire
       Faraday.new(@options) do |builder|
         builder.request @request_format
         builder.response :follow_redirects
+        builder.use Safire::Middleware::HttpsOnlyRedirects
         builder.response :json
         builder.response :raise_error
         configure_logger(builder)

--- a/lib/safire/middleware/https_only_redirects.rb
+++ b/lib/safire/middleware/https_only_redirects.rb
@@ -1,0 +1,39 @@
+require 'faraday'
+require 'uri'
+
+module Safire
+  module Middleware
+    # Faraday middleware that blocks redirects to non-HTTPS URLs.
+    #
+    # Sits inside the follow_redirects middleware's app stack so it sees every
+    # intermediate 3xx response before the redirect is followed. HTTP redirects
+    # to localhost/127.0.0.1 are allowed (consistent with ClientConfig's
+    # localhost exception for local development).
+    class HttpsOnlyRedirects < Faraday::Middleware
+      LOCALHOST = %w[localhost 127.0.0.1].freeze
+
+      def call(env)
+        @app.call(env).on_complete do |response_env|
+          check_redirect_safety!(response_env)
+        end
+      end
+
+      private
+
+      def check_redirect_safety!(env)
+        return unless (300..308).cover?(env.status)
+
+        location = env.response_headers['location']
+        return unless location
+
+        uri = URI.parse(location)
+        return if uri.scheme == 'https'
+        return if LOCALHOST.include?(uri.host)
+
+        raise Safire::Errors::NetworkError.new(
+          error_description: "Redirect to non-HTTPS URL blocked: #{location}"
+        )
+      end
+    end
+  end
+end

--- a/spec/safire/http_client_spec.rb
+++ b/spec/safire/http_client_spec.rb
@@ -131,6 +131,34 @@ RSpec.describe Safire::HTTPClient do
     end
   end
 
+  describe 'redirect safety' do
+    it 'follows a redirect to an HTTPS URL' do
+      stub_request(:get, base_url)
+        .to_return(status: 301, headers: { 'Location' => "#{base_url}/new" })
+      stub_request(:get, "#{base_url}/new")
+        .to_return(status: 200, body: {}.to_json)
+
+      expect { client.get }.not_to raise_error
+    end
+
+    it 'raises NetworkError when redirect points to HTTP on a non-localhost host' do
+      stub_request(:get, base_url)
+        .to_return(status: 301, headers: { 'Location' => 'http://api.example.com/new' })
+
+      expect { client.get }
+        .to raise_error(Safire::Errors::NetworkError, /non-HTTPS.*blocked/i)
+    end
+
+    it 'follows a redirect to HTTP localhost' do
+      stub_request(:get, base_url)
+        .to_return(status: 301, headers: { 'Location' => 'http://localhost:3000/callback' })
+      stub_request(:get, 'http://localhost:3000/callback')
+        .to_return(status: 200, body: {}.to_json)
+
+      expect { client.get }.not_to raise_error
+    end
+  end
+
   describe 'integration scenarios' do
     it 'handles full CRUD cycle' do
       body = { id: 1, name: 'Item 1' }.to_json

--- a/spec/safire/middleware/https_only_redirects_spec.rb
+++ b/spec/safire/middleware/https_only_redirects_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+RSpec.describe Safire::Middleware::HttpsOnlyRedirects do
+  subject(:middleware) { described_class.new(app) }
+
+  let(:app) { ->(env) { Faraday::Response.new(env) } }
+
+  def build_env(status:, location: nil)
+    headers = {}
+    headers['location'] = location if location
+    Faraday::Env.from(
+      method: :get,
+      url: URI.parse('https://api.example.com/endpoint'),
+      response_headers: Faraday::Utils::Headers.new(headers),
+      status: status
+    )
+  end
+
+  context 'when response is not a redirect' do
+    it 'does not raise on 200' do
+      env = build_env(status: 200)
+      expect { middleware.call(env) }.not_to raise_error
+    end
+
+    it 'does not raise on 404' do
+      env = build_env(status: 404)
+      expect { middleware.call(env) }.not_to raise_error
+    end
+  end
+
+  context 'when redirect Location is HTTPS' do
+    it 'does not raise on 301 to https' do
+      env = build_env(status: 301, location: 'https://api.example.com/new')
+      expect { middleware.call(env) }.not_to raise_error
+    end
+
+    it 'does not raise on 302 to https' do
+      env = build_env(status: 302, location: 'https://other.example.com/')
+      expect { middleware.call(env) }.not_to raise_error
+    end
+  end
+
+  context 'when redirect Location is HTTP on localhost' do
+    it 'does not raise for localhost' do
+      env = build_env(status: 301, location: 'http://localhost:3000/callback')
+      expect { middleware.call(env) }.not_to raise_error
+    end
+
+    it 'does not raise for 127.0.0.1' do
+      env = build_env(status: 302, location: 'http://127.0.0.1:8080/path')
+      expect { middleware.call(env) }.not_to raise_error
+    end
+  end
+
+  context 'when redirect Location is HTTP on a non-localhost host' do
+    it 'raises NetworkError on 301 to http' do
+      env = build_env(status: 301, location: 'http://api.example.com/new')
+      expect { middleware.call(env) }
+        .to raise_error(Safire::Errors::NetworkError, /non-HTTPS.*blocked/i)
+    end
+
+    it 'raises NetworkError on 302 to http' do
+      env = build_env(status: 302, location: 'http://other.example.com/')
+      expect { middleware.call(env) }
+        .to raise_error(Safire::Errors::NetworkError, /non-HTTPS.*blocked/i)
+    end
+
+    it 'includes the blocked URL in the error message' do
+      env = build_env(status: 301, location: 'http://attacker.example.com/steal')
+      expect { middleware.call(env) }
+        .to raise_error(Safire::Errors::NetworkError, %r{http://attacker\.example\.com/steal})
+    end
+  end
+
+  context 'when redirect has no Location header' do
+    it 'does not raise' do
+      env = build_env(status: 301)
+      expect { middleware.call(env) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Safire::Middleware::HttpsOnlyRedirects`, a custom Faraday middleware that intercepts every redirect hop before `follow_redirects` processes it
- Raises `Safire::Errors::NetworkError` when a 3xx `Location` header points to an HTTP URL on a non-localhost host, preventing token leakage over unencrypted connections
- HTTP redirects to `localhost` / `127.0.0.1` are allowed, consistent with `ClientConfig`'s localhost exception for local development

## Test plan

- [x] Unit specs for `HttpsOnlyRedirects`: passes through 2xx/4xx, HTTPS redirects, and HTTP localhost redirects; raises `NetworkError` for HTTP non-localhost redirects; handles missing `Location` header
- [x] Integration specs in `http_client_spec.rb`: HTTPS→HTTPS succeeds, HTTPS→HTTP (non-localhost) raises `NetworkError`, HTTPS→HTTP localhost succeeds
- [x] Full suite: 265 examples, 0 failures
- [x] Rubocop: no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)