### PR TITLE
Raise ConfigurationError instead of ArgumentError for invalid auth_type

### DIFF
--- a/lib/safire/client.rb
+++ b/lib/safire/client.rb
@@ -94,7 +94,7 @@ module Safire
     #
     # @param new_auth_type [Symbol] the new auth type (:public, :confidential_symmetric, :confidential_asymmetric)
     # @return [Symbol] the new auth type
-    # @raise [ArgumentError] if the auth type is not supported
+    # @raise [Safire::Errors::ConfigurationError] if the auth type is not supported
     #
     # @example Discover then switch auth type
     #   client = Safire::Client.new(config)  # defaults to :public
@@ -145,7 +145,11 @@ module Safire
     def validate_auth_type
       return if AUTH_TYPES.include?(auth_type)
 
-      raise ArgumentError, "`#{auth_type}` is not supported. The supported auth types are #{AUTH_TYPES.to_sentence}"
+      raise Errors::ConfigurationError.new(
+        invalid_attribute: :auth_type,
+        invalid_value: auth_type,
+        valid_values: AUTH_TYPES
+      )
     end
   end
 end

--- a/spec/safire/client_spec.rb
+++ b/spec/safire/client_spec.rb
@@ -52,6 +52,13 @@ RSpec.describe Safire::Client do
 
   # ---------- Initialization ----------
 
+  describe '#initialize' do
+    it 'raises ConfigurationError for invalid auth_type keyword' do
+      expect { described_class.new(config, auth_type: :bogus) }
+        .to raise_error(Safire::Errors::ConfigurationError, /auth_type.*bogus/i)
+    end
+  end
+
   describe '#auth_type=' do
     it 'changes the auth type from public to confidential_symmetric' do
       client = described_class.new(config, auth_type: :public)
@@ -67,9 +74,10 @@ RSpec.describe Safire::Client do
       expect(client.auth_type).to eq(:confidential_symmetric)
     end
 
-    it 'raises ArgumentError for unsupported auth types' do
+    it 'raises ConfigurationError for unsupported auth types' do
       client = described_class.new(config)
-      expect { client.auth_type = :unsupported }.to raise_error(ArgumentError, /unsupported/)
+      expect { client.auth_type = :unsupported }
+        .to raise_error(Safire::Errors::ConfigurationError, /auth_type.*unsupported/i)
     end
 
     it 'resets the internal smart_client so new auth type is used' do


### PR DESCRIPTION
## Summary

- `validate_auth_type` in `Safire::Client` previously raised a raw `ArgumentError` with a freeform string, inconsistent with the rest of the gem
- Now raises `Safire::Errors::ConfigurationError` with typed keyword args (`invalid_attribute: :auth_type`, `invalid_value:`, `valid_values:`), so callers can inspect structured attributes
- Updated `@raise` YARD tag on `#auth_type=` accordingly

## Test plan

- [x] New spec: `#initialize` raises `ConfigurationError` for invalid `auth_type:` keyword
- [x] Updated spec: `#auth_type=` raises `ConfigurationError` (was `ArgumentError`) for unsupported types
- [x] Full suite: 266 examples, 0 failures
- [x] Rubocop: no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)