### PR TITLE
Refactor Smart to accept ClientConfig only

### DIFF
--- a/lib/safire/client.rb
+++ b/lib/safire/client.rb
@@ -85,7 +85,7 @@ module Safire
 
     def initialize(config, auth_type: :public)
       @config = build_config(config)
-      @auth_type = auth_type
+      @auth_type = auth_type.to_sym
 
       validate_auth_type
     end
@@ -133,7 +133,7 @@ module Safire
     private
 
     def smart_client
-      @smart_client ||= Protocols::Smart.new(config.to_hash, auth_type:)
+      @smart_client ||= Protocols::Smart.new(config, auth_type:)
     end
 
     def build_config(config)

--- a/lib/safire/protocols/smart.rb
+++ b/lib/safire/protocols/smart.rb
@@ -1,73 +1,21 @@
 module Safire
   module Protocols
-    # SMART on FHIR OAuth2 client for authorization code, access token, and refresh token flows.
+    # SMART on FHIR OAuth2 implementation for authorization code, access token, and refresh token flows.
     #
-    # This class wraps the core SMART on FHIR authorization sequence:
-    # - Builds an authorization URL with PKCE and state for CSRF protection.
-    # - Exchanges an authorization code for an access token.
-    # - Exchanges a refresh token for a new access token.
+    # This is an internal class used exclusively by {Safire::Client}. Do not instantiate it directly —
+    # use {Safire::Client} instead.
     #
-    # Configuration is provided as a Hash and validated on initialization. All of the
-    # following keys are required unless noted:
+    # Accepts a {Safire::ClientConfig} and an +auth_type+ symbol. Reads all configuration
+    # attributes directly from the +ClientConfig+ object. Discovery of authorization and token
+    # endpoints from the FHIR server's +/.well-known/smart-configuration+ metadata is performed
+    # automatically when those endpoints are not present in the config.
     #
-    # * :base_url [String] FHIR server base URL
-    # * :client_id [String] OAuth2 client identifier
-    # * :client_secret [String, optional] client secret for confidential symmetric clients
-    # * :redirect_uri [String] redirect URI registered with the authorization server
-    # * :scopes [Array<String>, optional] default scopes requested during authorization
-    # * :issuer [String, optional] issuer identifier. Defaults to base_url if not provided
-    # * :authorization_endpoint [String, optional] SMART authorization endpoint URL
-    # * :token_endpoint [String, optional] SMART token endpoint URL
-    # * :private_key [OpenSSL::PKey, String, optional] private key for confidential asymmetric clients
-    # * :kid [String, optional] key ID matching the registered public key for asymmetric clients
-    # * :jwt_algorithm [String, optional] JWT signing algorithm (RS384 or ES384). Auto-detected if not provided
-    # * :jwks_uri [String, optional] URL to client's JWKS for jku header in JWT assertions
-    #
-    # authorization_endpoint and token_endpoint will be retrieved from the server's smart configuration if not provided.
-    #
-    # The `auth_type` controls how the client authenticates:
-    #
-    # * :public — public client; `client_id` is sent in token and refresh requests
-    # * :confidential_symmetric — confidential client using client_secret with HTTP Basic auth
-    # * :confidential_asymmetric — confidential client using private_key_jwt authentication (JWT assertion)
-    #
-    # Token responses returned by {#request_access_token} and {#refresh_token} are
-    # parsed JSON objects with **string keys**, and are validated to include
-    # `"access_token"`; otherwise a {Safire::Errors::TokenError} is raised.
+    # @note For internal use by {Safire::Client} only.
+    # @api private
     #
     # @raise [Safire::Errors::ConfigurationError]
     #   if required configuration attributes are missing or invalid
-    #
-    # @example Initialize a public SMART client
-    #   smart_client = Safire::Protocols::Smart.new({
-    #     client_id: 'my_client_id',
-    #     redirect_uri: 'https://myapp.example.com/callback',
-    #     scopes: ['launch/patient', 'openid', 'fhirUser', 'patient/*.read'],
-    #     issuer: 'https://fhir.example.com',
-    #     authorization_endpoint: 'https://fhir.example.com/authorize',
-    #     token_endpoint: 'https://fhir.example.com/token'
-    #   })
-    #
-    # @example Generate an authorization URL
-    #   auth_data = smart_client.authorization_url
-    #   auth_data[:auth_url]      # redirect the user to this URL
-    #   auth_data[:state]         # store and verify on callback
-    #   auth_data[:code_verifier] # store for the token request
-    #
-    # @example Exchange authorization code for tokens
-    #   token_data = smart_client.request_access_token(
-    #     code: 'abc123',
-    #     code_verifier: auth_data[:code_verifier]
-    #   )
-    #   token_data["access_token"]
-    #
-    # @example Refresh an access token
-    #   new_tokens = smart_client.refresh_token(
-    #     refresh_token: token_data["refresh_token"]
-    #   )
-    #   new_tokens["access_token"]
-
-    class Smart < Entity
+    class Smart
       ATTRIBUTES = %i[
         base_url client_id client_secret redirect_uri scopes issuer
         authorization_endpoint token_endpoint
@@ -81,8 +29,9 @@ module Safire
 
       attr_reader(*ATTRIBUTES, :auth_type)
 
+      # @api private
       def initialize(config, auth_type: :public)
-        super(config, ATTRIBUTES)
+        ATTRIBUTES.each { |attr| instance_variable_set("@#{attr}", config.public_send(attr)) }
 
         @auth_type = auth_type.to_sym
         @http_client = Safire.http_client
@@ -95,8 +44,8 @@ module Safire
 
       # Retrieves and parses SMART on FHIR configuration metadata from the FHIR server.
       #
-      # This method sends a GET request to the server’s
-      # `/.well-known/smart-configuration` endpoint, validates the response format,
+      # This method sends a GET request to the server's
+      # +/.well-known/smart-configuration+ endpoint, validates the response format,
       # and builds a {Safire::Protocols::SmartMetadata} object containing the
       # authorization and token endpoints, among other SMART metadata fields.
       #
@@ -106,8 +55,7 @@ module Safire
       # @return [Safire::Protocols::SmartMetadata]
       #   Parsed SMART configuration metadata object.
       # @raise [Safire::Errors::DiscoveryError]
-      #   If the discovery request fails or the response is not valid JSON.
-      #   The error's {Safire::Errors::Error#details details} may contain +:status+ and +:body+.
+      #   If the discovery request fails or the response is not a valid JSON object.
       def well_known_config
         return @well_known_config if @well_known_config
 
@@ -120,8 +68,6 @@ module Safire
       end
 
       # Builds the authorization request data for the authorization code flow.
-      #
-      # See {Safire::Protocols::Smart} for configuration details and supported auth types.
       #
       # @param launch [String, nil] optional launch parameter
       # @param custom_scopes [Array<String>, nil] optional custom scopes to override the configured ones
@@ -151,7 +97,6 @@ module Safire
 
       # Exchanges the authorization code for an access token.
       #
-      # See {Safire::Protocols::Smart} for authentication modes and client configuration.
       # @param code [String] authorization code from the authorization server
       # @param code_verifier [String] PKCE code verifier from the authorization step
       # @param client_secret [String, nil] optional; used for confidential symmetric clients when not already configured
@@ -166,7 +111,6 @@ module Safire
       #   * "authorization_details"   [Hash] additional authorization details, if provided (optional)
       #   * Context parameters such as "patient" or "encounter" MAY be present, depending on server behavior.
       # @raise [Safire::Errors::TokenError] if the request fails or response is invalid.
-      #   The error's {Safire::Errors::Error#details details} may contain +:status+ and +:body+.
       def request_access_token(code:, code_verifier:, client_secret: self.client_secret,
                                private_key: self.private_key, kid: self.kid)
         Safire.logger.info('Requesting access token using authorization code...')
@@ -185,16 +129,14 @@ module Safire
       # Exchanges a refresh token for a new access token.
       #
       # @param refresh_token [String] the refresh token issued by the authorization server (required)
-      # @param scopes [Array<String>, nil] optional reduced scope list
-      #   If omitted, the same scopes as the original token are requested.
+      # @param scopes [Array<String>, nil] optional reduced scope list;
+      #   if omitted, the same scopes as the original token are requested
       # @param client_secret [String, nil] optional; used for confidential symmetric clients when not already configured
       # @param private_key [OpenSSL::PKey, String, nil] optional; private key for asymmetric auth (overrides configured)
       # @param kid [String, nil] optional; key ID for asymmetric auth (overrides configured)
       # @return [Hash] token response parsed from the authorization server.
-      #   See {Safire::Protocols::Smart#request_access_token} for token response format.
-      #
+      #   See {#request_access_token} for token response format.
       # @raise [Safire::Errors::TokenError] if the refresh request fails or the response is invalid.
-      #   The error's {Safire::Errors::Error#details details} may contain +:status+ and +:body+.
       def refresh_token(refresh_token:, scopes: nil, client_secret: self.client_secret,
                         private_key: self.private_key, kid: self.kid)
         Safire.logger.info('Refreshing access token...')
@@ -314,9 +256,8 @@ module Safire
       end
 
       def oauth2_headers(secret)
-        headers = {
-          content_type: 'application/x-www-form-urlencoded'
-        }
+        headers = { content_type: 'application/x-www-form-urlencoded' }
+
         if auth_type == :confidential_symmetric
           headers[:Authorization] = authentication_header(secret.presence || client_secret)
         end

--- a/spec/safire/client_spec.rb
+++ b/spec/safire/client_spec.rb
@@ -57,6 +57,11 @@ RSpec.describe Safire::Client do
       expect { described_class.new(config, auth_type: :bogus) }
         .to raise_error(Safire::Errors::ConfigurationError, /auth_type.*bogus/i)
     end
+
+    it 'symbolizes a string auth_type keyword' do
+      client = described_class.new(config, auth_type: 'confidential_symmetric')
+      expect(client.auth_type).to eq(:confidential_symmetric)
+    end
   end
 
   describe '#auth_type=' do

--- a/spec/safire/protocols/smart_spec.rb
+++ b/spec/safire/protocols/smart_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe Safire::Protocols::Smart do
   # ---------- Test Data ----------
 
-  let(:config) do
+  let(:config_attrs) do
     {
       client_id: 'test_client_id',
       redirect_uri: 'https://app.example.com/callback',
@@ -14,14 +14,18 @@ RSpec.describe Safire::Protocols::Smart do
       token_endpoint: 'https://fhir.example.com/token'
     }
   end
-  let(:confidential_config) { config.merge(client_secret: 'test_client_secret') }
+
+  let(:config) { Safire::ClientConfig.new(config_attrs) }
+  let(:confidential_config) { Safire::ClientConfig.new(config_attrs.merge(client_secret: 'test_client_secret')) }
   let(:rsa_private_key) { OpenSSL::PKey::RSA.generate(2048) }
   let(:asymmetric_config) do
-    config.merge(
-      private_key: rsa_private_key,
-      kid: 'test-key-id',
-      jwt_algorithm: 'RS384',
-      jwks_uri: 'https://app.example.com/.well-known/jwks.json'
+    Safire::ClientConfig.new(
+      config_attrs.merge(
+        private_key: rsa_private_key,
+        kid: 'test-key-id',
+        jwt_algorithm: 'RS384',
+        jwks_uri: 'https://app.example.com/.well-known/jwks.json'
+      )
     )
   end
 
@@ -60,7 +64,7 @@ RSpec.describe Safire::Protocols::Smart do
   end
 
   def stub_token_post(body_matcher:, status:, body:, headers: {})
-    stub_request(:post, config[:token_endpoint]).with(
+    stub_request(:post, config_attrs[:token_endpoint]).with(
       body: body_matcher,
       headers: { 'Content-Type' => 'application/x-www-form-urlencoded' }.merge(headers)
     ).to_return(
@@ -70,7 +74,7 @@ RSpec.describe Safire::Protocols::Smart do
     )
   end
 
-  def stub_well_known(base_url: config[:base_url], status: 200, body: smart_metadata_body)
+  def stub_well_known(base_url: config_attrs[:base_url], status: 200, body: smart_metadata_body)
     well_known_url = "#{base_url.to_s.chomp('/')}#{described_class::WELL_KNOWN_PATH}"
     stub_request(:get, well_known_url).to_return(
       status: status, body: body.to_json, headers: { 'Content-Type' => 'application/json' }
@@ -104,9 +108,9 @@ RSpec.describe Safire::Protocols::Smart do
       {
         'grant_type' => 'authorization_code',
         'code' => authorization_code,
-        'redirect_uri' => config[:redirect_uri],
+        'redirect_uri' => config_attrs[:redirect_uri],
         'code_verifier' => code_verifier,
-        'client_id' => config[:client_id]
+        'client_id' => config_attrs[:client_id]
       }
     end
 
@@ -114,7 +118,7 @@ RSpec.describe Safire::Protocols::Smart do
       {
         'grant_type' => 'authorization_code',
         'code' => authorization_code,
-        'redirect_uri' => config[:redirect_uri],
+        'redirect_uri' => config_attrs[:redirect_uri],
         'code_verifier' => code_verifier
         # no client_id
       }
@@ -125,7 +129,7 @@ RSpec.describe Safire::Protocols::Smart do
       hash_including(
         'grant_type' => 'authorization_code',
         'code' => authorization_code,
-        'redirect_uri' => config[:redirect_uri],
+        'redirect_uri' => config_attrs[:redirect_uri],
         'code_verifier' => code_verifier,
         'client_assertion_type' => 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
         'client_assertion' => kind_of(String)
@@ -140,7 +144,7 @@ RSpec.describe Safire::Protocols::Smart do
       {
         'grant_type' => 'refresh_token',
         'refresh_token' => refresh_token_value,
-        'client_id' => config[:client_id]
+        'client_id' => config_attrs[:client_id]
       }
     end
 
@@ -166,25 +170,25 @@ RSpec.describe Safire::Protocols::Smart do
   # ---------- Initialization ----------
 
   describe '#initialize' do
-    it 'creates a public client with valid config' do
+    it 'creates a public client from a ClientConfig' do
       client = described_class.new(config, auth_type: :public)
       expect(client.auth_type).to eq(:public)
-      described_class::ATTRIBUTES.each { |attr| expect(client.send(attr)).to eq(config[attr]) }
+      described_class::ATTRIBUTES.each { |attr| expect(client.send(attr)).to eq(config.send(attr)) }
     end
 
     it 'creates a confidential symmetric client' do
       client = described_class.new(confidential_config, auth_type: :confidential_symmetric)
       expect(client.auth_type).to eq(:confidential_symmetric)
-      expect(client.client_secret).to eq(confidential_config[:client_secret])
+      expect(client.client_secret).to eq(confidential_config.client_secret)
     end
 
     it 'creates a confidential asymmetric client' do
       client = described_class.new(asymmetric_config, auth_type: :confidential_asymmetric)
       expect(client.auth_type).to eq(:confidential_asymmetric)
-      expect(client.private_key).to eq(asymmetric_config[:private_key])
-      expect(client.kid).to eq(asymmetric_config[:kid])
-      expect(client.jwt_algorithm).to eq(asymmetric_config[:jwt_algorithm])
-      expect(client.jwks_uri).to eq(asymmetric_config[:jwks_uri])
+      expect(client.private_key).to eq(asymmetric_config.private_key)
+      expect(client.kid).to eq(asymmetric_config.kid)
+      expect(client.jwt_algorithm).to eq(asymmetric_config.jwt_algorithm)
+      expect(client.jwks_uri).to eq(asymmetric_config.jwks_uri)
     end
 
     it 'defaults auth_type to public' do
@@ -196,21 +200,22 @@ RSpec.describe Safire::Protocols::Smart do
     end
 
     it 'allows scopes and client_secret to be optional' do
-      client = described_class.new(config.except(:scopes, :client_secret))
+      client = described_class.new(Safire::ClientConfig.new(config_attrs.except(:scopes, :client_secret)))
       expect(client.scopes).to be_nil
       expect(client.client_secret).to be_nil
     end
 
     it 'raises ConfigurationError when a required attribute is missing' do
       %i[client_id redirect_uri base_url].each do |attr|
-        expect { described_class.new(config.except(attr)) }
+        expect { described_class.new(Safire::ClientConfig.new(config_attrs.except(attr))) }
           .to raise_error(Safire::Errors::ConfigurationError, /#{attr}/)
       end
     end
 
     it 'fetches endpoints from well-known when not provided' do
       stub_well_known
-      client = described_class.new(config.except(:authorization_endpoint, :token_endpoint))
+      cfg = Safire::ClientConfig.new(config_attrs.except(:authorization_endpoint, :token_endpoint))
+      client = described_class.new(cfg)
       expect(client.authorization_endpoint).to eq(smart_metadata_body['authorization_endpoint'])
       expect(client.token_endpoint).to eq(smart_metadata_body['token_endpoint'])
     end
@@ -219,7 +224,7 @@ RSpec.describe Safire::Protocols::Smart do
   # ---------- Well-known Discovery ----------
 
   describe '#well_known_config' do
-    let(:well_known_url) { "#{config[:base_url]}#{described_class::WELL_KNOWN_PATH}" }
+    let(:well_known_url) { "#{config_attrs[:base_url]}#{described_class::WELL_KNOWN_PATH}" }
 
     it 'fetches and exposes metadata' do
       stub_well_known
@@ -252,7 +257,7 @@ RSpec.describe Safire::Protocols::Smart do
     it 'handles base_url with or without trailing slash' do
       stub_well_known(base_url: 'https://fhir.example.com/')
       expect do
-        described_class.new(config.merge(base_url: 'https://fhir.example.com/')).well_known_config
+        described_class.new(Safire::ClientConfig.new(config_attrs.merge(base_url: 'https://fhir.example.com/'))).well_known_config
       end.not_to raise_error
 
       stub_well_known(base_url: 'https://fhir.example.com')
@@ -279,7 +284,7 @@ RSpec.describe Safire::Protocols::Smart do
     shared_examples 'includes core oauth and pkce' do
       it 'includes response_type/client_id/redirect_uri/aud' do
         expect(query_params.values_at('response_type', 'client_id', 'redirect_uri', 'aud'))
-          .to eq(['code', config[:client_id], config[:redirect_uri], config[:base_url]])
+          .to eq(['code', config_attrs[:client_id], config_attrs[:redirect_uri], config_attrs[:base_url]])
       end
 
       it 'includes S256 challenge' do
@@ -293,11 +298,11 @@ RSpec.describe Safire::Protocols::Smart do
     it_behaves_like 'includes core oauth and pkce'
 
     it 'includes configured scopes' do
-      expect(query_params['scope']).to eq(config[:scopes].join(' '))
+      expect(query_params['scope']).to eq(config_attrs[:scopes].join(' '))
     end
 
     it 'raises when no scopes configured' do
-      expect { described_class.new(config.except(:scopes)).authorization_url }
+      expect { described_class.new(Safire::ClientConfig.new(config_attrs.except(:scopes))).authorization_url }
         .to raise_error(Safire::Errors::ConfigurationError, /scopes/)
     end
 
@@ -324,9 +329,9 @@ RSpec.describe Safire::Protocols::Smart do
       data = described_class.new(config).authorization_url(custom_scopes: cs)
       expect(data[:auth_url]).to include('patient%2F%2A.read')
 
-      cfg2 = config.merge(redirect_uri: 'https://app.example.com/callback?param=value')
+      cfg2 = Safire::ClientConfig.new(config_attrs.merge(redirect_uri: 'https://app.example.com/callback?param=value'))
       data2 = described_class.new(cfg2).authorization_url
-      expect(data2[:auth_url]).to include(CGI.escape(cfg2[:redirect_uri]))
+      expect(data2[:auth_url]).to include(CGI.escape(cfg2.redirect_uri))
     end
 
     context 'when method: :post' do
@@ -337,7 +342,7 @@ RSpec.describe Safire::Protocols::Smart do
       end
 
       it 'auth_url is the bare authorization endpoint with no query string' do
-        expect(post_auth_data[:auth_url]).to eq(config[:authorization_endpoint])
+        expect(post_auth_data[:auth_url]).to eq(config_attrs[:authorization_endpoint])
         expect(post_auth_data[:auth_url]).not_to include('?')
       end
 
@@ -345,9 +350,9 @@ RSpec.describe Safire::Protocols::Smart do
         p = post_auth_data[:params]
         expect(p).to include(
           response_type: 'code',
-          client_id: config[:client_id],
-          redirect_uri: config[:redirect_uri],
-          aud: config[:base_url],
+          client_id: config_attrs[:client_id],
+          redirect_uri: config_attrs[:redirect_uri],
+          aud: config_attrs[:base_url],
           code_challenge_method: 'S256'
         )
         expect(p[:code_challenge]).to match(/\A[A-Za-z0-9_-]{43}\z/)
@@ -363,7 +368,7 @@ RSpec.describe Safire::Protocols::Smart do
     context 'when method is provided as a string' do
       it 'accepts "post" and returns params hash' do
         data = described_class.new(config).authorization_url(method: 'post')
-        expect(data[:auth_url]).to eq(config[:authorization_endpoint])
+        expect(data[:auth_url]).to eq(config_attrs[:authorization_endpoint])
         expect(data[:params]).to be_a(Hash)
       end
 
@@ -411,14 +416,14 @@ RSpec.describe Safire::Protocols::Smart do
       it 'includes client_id in request body' do
         token_response
 
-        expect(WebMock).to have_requested(:post, config[:token_endpoint])
-          .with(body: hash_including('client_id' => config[:client_id]))
+        expect(WebMock).to have_requested(:post, config_attrs[:token_endpoint])
+          .with(body: hash_including('client_id' => config_attrs[:client_id]))
       end
 
       it 'does not include Authorization header' do
         token_response
 
-        expect(WebMock).to(have_requested(:post, config[:token_endpoint])
+        expect(WebMock).to(have_requested(:post, config_attrs[:token_endpoint])
           .with { |req| !req.headers.key?('Authorization') })
       end
     end
@@ -429,7 +434,7 @@ RSpec.describe Safire::Protocols::Smart do
                        .request_access_token(code: authorization_code, code_verifier: code_verifier)
       end
 
-      let(:auth_header) { basic_auth_header(confidential_config[:client_id], confidential_config[:client_secret]) }
+      let(:auth_header) { basic_auth_header(confidential_config.client_id, confidential_config.client_secret) }
 
       before do
         stub_token_post(
@@ -444,7 +449,7 @@ RSpec.describe Safire::Protocols::Smart do
 
       it 'uses Basic auth and omits client_id' do
         token_response
-        expect(WebMock).to(have_requested(:post, config[:token_endpoint]).with do |req|
+        expect(WebMock).to(have_requested(:post, config_attrs[:token_endpoint]).with do |req|
           have_basic_auth(auth_header).matches?(req) && body_excludes_keys(:client_id).matches?(req)
         end)
       end
@@ -464,7 +469,7 @@ RSpec.describe Safire::Protocols::Smart do
 
       it 'includes client_assertion_type and client_assertion, omits client_id' do
         token_response
-        expect(WebMock).to(have_requested(:post, config[:token_endpoint]).with do |req|
+        expect(WebMock).to(have_requested(:post, config_attrs[:token_endpoint]).with do |req|
           body = URI.decode_www_form(req.body).to_h
           body['client_assertion_type'] == 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer' &&
             body['client_assertion'].present? &&
@@ -474,35 +479,37 @@ RSpec.describe Safire::Protocols::Smart do
 
       it 'sends a valid JWT assertion' do
         token_response
-        expect(WebMock).to(have_requested(:post, config[:token_endpoint]).with do |req|
+        expect(WebMock).to(have_requested(:post, config_attrs[:token_endpoint]).with do |req|
           body = URI.decode_www_form(req.body).to_h
           jwt = body['client_assertion']
           decoded = JWT.decode(jwt, rsa_private_key.public_key, true, algorithm: 'RS384')
-          decoded[0]['iss'] == config[:client_id] &&
-            decoded[0]['sub'] == config[:client_id] &&
-            decoded[0]['aud'] == config[:token_endpoint] &&
-            decoded[1]['kid'] == asymmetric_config[:kid]
+          decoded[0]['iss'] == config_attrs[:client_id] &&
+            decoded[0]['sub'] == config_attrs[:client_id] &&
+            decoded[0]['aud'] == config_attrs[:token_endpoint] &&
+            decoded[1]['kid'] == asymmetric_config.kid
         end)
       end
 
       it 'does not include Authorization header' do
         token_response
-        expect(WebMock).to(have_requested(:post, config[:token_endpoint])
+        expect(WebMock).to(have_requested(:post, config_attrs[:token_endpoint])
           .with { |req| !req.headers.key?('Authorization') })
       end
     end
 
     context 'when confidential_asymmetric with missing credentials' do
       it 'raises ConfigurationError when private_key is missing' do
+        cfg = Safire::ClientConfig.new(config_attrs.merge(kid: 'key-id'))
         expect do
-          described_class.new(config.merge(kid: 'key-id'), auth_type: :confidential_asymmetric)
+          described_class.new(cfg, auth_type: :confidential_asymmetric)
                          .request_access_token(code: authorization_code, code_verifier: code_verifier)
         end.to raise_error(Safire::Errors::ConfigurationError, /private_key/)
       end
 
       it 'raises ConfigurationError when kid is missing' do
+        cfg = Safire::ClientConfig.new(config_attrs.merge(private_key: rsa_private_key))
         expect do
-          described_class.new(config.merge(private_key: rsa_private_key), auth_type: :confidential_asymmetric)
+          described_class.new(cfg, auth_type: :confidential_asymmetric)
                          .request_access_token(code: authorization_code, code_verifier: code_verifier)
         end.to raise_error(Safire::Errors::ConfigurationError, /kid/)
       end
@@ -514,9 +521,9 @@ RSpec.describe Safire::Protocols::Smart do
           body_matcher: {
             'grant_type' => 'authorization_code',
             'code' => 'auth_code_abc123',
-            'redirect_uri' => config[:redirect_uri],
+            'redirect_uri' => config_attrs[:redirect_uri],
             'code_verifier' => 'test_code_verifier_xyz789',
-            'client_id' => config[:client_id]
+            'client_id' => config_attrs[:client_id]
           },
           status: 200,
           body: { 'token_type' => 'Bearer', 'expires_in' => 3600 }
@@ -534,9 +541,9 @@ RSpec.describe Safire::Protocols::Smart do
           body_matcher: {
             'grant_type' => 'authorization_code',
             'code' => 'bad',
-            'redirect_uri' => config[:redirect_uri],
+            'redirect_uri' => config_attrs[:redirect_uri],
             'code_verifier' => 'v',
-            'client_id' => config[:client_id]
+            'client_id' => config_attrs[:client_id]
           },
           status: 400,
           body: { 'error' => 'invalid_grant' }
@@ -550,7 +557,7 @@ RSpec.describe Safire::Protocols::Smart do
 
     context 'when network error' do
       it 'raises NetworkError' do
-        stub_request(:post, config[:token_endpoint]).to_raise(Faraday::ConnectionFailed)
+        stub_request(:post, config_attrs[:token_endpoint]).to_raise(Faraday::ConnectionFailed)
         expect do
           described_class.new(config, auth_type: :public)
                          .request_access_token(code: 'x', code_verifier: 'y')
@@ -599,7 +606,7 @@ RSpec.describe Safire::Protocols::Smart do
     end
 
     context 'when confidential_symmetric' do
-      let(:auth_header) { basic_auth_header(confidential_config[:client_id], confidential_config[:client_secret]) }
+      let(:auth_header) { basic_auth_header(confidential_config.client_id, confidential_config.client_secret) }
 
       before do
         stub_token_post(
@@ -615,7 +622,7 @@ RSpec.describe Safire::Protocols::Smart do
                              .refresh_token(refresh_token: refresh_token_value)
         expect(res).to eq(refreshed_token_response_body)
 
-        expect(WebMock).to(have_requested(:post, config[:token_endpoint]).with do |req|
+        expect(WebMock).to(have_requested(:post, config_attrs[:token_endpoint]).with do |req|
           have_basic_auth(auth_header).matches?(req) && body_excludes_keys(:client_id).matches?(req)
         end)
       end
@@ -631,7 +638,7 @@ RSpec.describe Safire::Protocols::Smart do
                              .refresh_token(refresh_token: refresh_token_value)
         expect(res).to eq(refreshed_token_response_body)
 
-        expect(WebMock).to(have_requested(:post, config[:token_endpoint]).with do |req|
+        expect(WebMock).to(have_requested(:post, config_attrs[:token_endpoint]).with do |req|
           body = URI.decode_www_form(req.body).to_h
           body['client_assertion_type'] == 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer' &&
             body['client_assertion'].present? &&
@@ -642,7 +649,9 @@ RSpec.describe Safire::Protocols::Smart do
 
     it 'raises TokenError on invalid refresh token' do
       stub_token_post(
-        body_matcher: { 'grant_type' => 'refresh_token', 'refresh_token' => 'bad', 'client_id' => config[:client_id] },
+        body_matcher: {
+          'grant_type' => 'refresh_token', 'refresh_token' => 'bad', 'client_id' => config_attrs[:client_id]
+        },
         status: 400,
         body: { 'error' => 'invalid_grant' }
       )
@@ -653,7 +662,9 @@ RSpec.describe Safire::Protocols::Smart do
 
     it 'raises TokenError when access_token missing' do
       stub_token_post(
-        body_matcher: { 'grant_type' => 'refresh_token', 'refresh_token' => 'x', 'client_id' => config[:client_id] },
+        body_matcher: {
+          'grant_type' => 'refresh_token', 'refresh_token' => 'x', 'client_id' => config_attrs[:client_id]
+        },
         status: 200,
         body: { 'token_type' => 'Bearer' }
       )
@@ -663,7 +674,7 @@ RSpec.describe Safire::Protocols::Smart do
     end
 
     it 'raises NetworkError on network error' do
-      stub_request(:post, config[:token_endpoint]).to_raise(Faraday::TimeoutError)
+      stub_request(:post, config_attrs[:token_endpoint]).to_raise(Faraday::TimeoutError)
       expect do
         described_class.new(config, auth_type: :public).refresh_token(refresh_token: 'x')
       end.to raise_error(Safire::Errors::NetworkError)


### PR DESCRIPTION
## Summary

`Protocols::Smart` now accepts only `Safire::ClientConfig` (dropping raw Hash support), reads attributes via `public_send`, and no longer inherits from `Entity` — the inheritance was misleading since `to_hash` was unused after the constructor change. The class and `#initialize` are marked `@api private` to signal internal use. `Client#initialize` now calls `auth_type.to_sym` for consistency with the setter, and `smart_client` passes `config` directly without `.to_hash`. Specs updated accordingly with `ClientConfig` objects throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)