### PR TITLE
Mask client_secret/private_key in to_hash; add safe inspect to ClientConfig

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,38 @@ Safire::ClientConfig.new(
 
 ---
 
+## Sensitive Attribute Protection
+
+`ClientConfig` protects `client_secret` and `private_key` from accidental exposure in two ways:
+
+### `#to_hash` masking
+
+Sensitive fields are replaced with `'[FILTERED]'` when present; `nil` values remain `nil`.
+
+```ruby
+config = Safire::ClientConfig.new(
+  base_url: 'https://fhir.example.com',
+  client_id: 'my_client',
+  redirect_uri: 'https://myapp.example.com/callback',
+  client_secret: 'my_secret'
+)
+
+config.to_hash[:client_secret]  # => "[FILTERED]"
+config.to_hash[:base_url]       # => "https://fhir.example.com"
+```
+
+### `#inspect` override
+
+Ruby's default `inspect` exposes all instance variables. `ClientConfig` overrides it to mask sensitive fields and omit `nil` attributes, making REPL sessions and error messages safe.
+
+```ruby
+config.inspect
+# => "#<Safire::ClientConfig base_url: \"https://fhir.example.com\", client_id: \"my_client\", ...>"
+# client_secret is shown as [FILTERED], never as the real value
+```
+
+---
+
 ## Creating a Client
 
 ### Using a Hash (Recommended)

--- a/lib/safire/client_config.rb
+++ b/lib/safire/client_config.rb
@@ -76,11 +76,31 @@ module Safire
       end
     end
 
-    private
-
+    SENSITIVE_ATTRIBUTES = %i[client_secret private_key].freeze
     URI_ATTRS = %i[base_url redirect_uri issuer authorization_endpoint token_endpoint jwks_uri].freeze
     OPTIONAL_URI_ATTRS = %i[authorization_endpoint token_endpoint jwks_uri].freeze
-    private_constant :URI_ATTRS, :OPTIONAL_URI_ATTRS
+    private_constant :SENSITIVE_ATTRIBUTES, :URI_ATTRS, :OPTIONAL_URI_ATTRS
+
+    # @api private
+    def inspect
+      attrs = ATTRIBUTES.map do |attr|
+        value = send(attr)
+        next if value.nil?
+
+        masked = SENSITIVE_ATTRIBUTES.include?(attr) ? '[FILTERED]' : value.inspect
+        "#{attr}: #{masked}"
+      end.compact.join(', ')
+      "#<#{self.class} #{attrs}>"
+    end
+
+    protected
+
+    # @return [Array<Symbol>] attributes masked as '[FILTERED]' in #to_hash
+    def sensitive_attributes
+      SENSITIVE_ATTRIBUTES
+    end
+
+    private
 
     # Validates all URI attributes for structure and HTTPS requirement.
     #

--- a/lib/safire/entity.rb
+++ b/lib/safire/entity.rb
@@ -8,9 +8,19 @@ module Safire
       hash = {}
       instance_variables.each do |var|
         key = var.to_s.delete_prefix('@').to_sym
-        hash[key] = instance_variable_get(var)
+        value = instance_variable_get(var)
+        hash[key] = sensitive_attributes.include?(key) && !value.nil? ? '[FILTERED]' : value
       end
       hash.deep_symbolize_keys
+    end
+
+    protected
+
+    # Returns attribute names whose values are masked as '[FILTERED]' in #to_hash.
+    #
+    # @return [Array<Symbol>]
+    def sensitive_attributes
+      []
     end
   end
 end

--- a/spec/safire/client_config_spec.rb
+++ b/spec/safire/client_config_spec.rb
@@ -164,5 +164,61 @@ RSpec.describe Safire::ClientConfig do
       expect(hash[:base_url]).to eq(valid_attrs[:base_url])
       expect(hash[:client_id]).to eq(valid_attrs[:client_id])
     end
+
+    it 'masks client_secret with [FILTERED]' do
+      config = described_class.new(valid_attrs.merge(client_secret: 'super_secret'))
+      expect(config.to_hash[:client_secret]).to eq('[FILTERED]')
+    end
+
+    it 'masks private_key with [FILTERED]' do
+      config = described_class.new(valid_attrs.merge(private_key: 'pem_key_data'))
+      expect(config.to_hash[:private_key]).to eq('[FILTERED]')
+    end
+
+    it 'leaves nil client_secret as nil' do
+      config = described_class.new(valid_attrs)
+      expect(config.to_hash[:client_secret]).to be_nil
+    end
+
+    it 'does not mask non-sensitive attributes' do
+      config = described_class.new(valid_attrs)
+      expect(config.to_hash[:base_url]).to eq(valid_attrs[:base_url])
+    end
+  end
+
+  # ---------- inspect ----------
+
+  describe '#inspect' do
+    it 'does not expose client_secret in output' do
+      config = described_class.new(valid_attrs.merge(client_secret: 'super_secret'))
+      expect(config.inspect).not_to include('super_secret')
+    end
+
+    it 'shows [FILTERED] in place of client_secret' do
+      config = described_class.new(valid_attrs.merge(client_secret: 'super_secret'))
+      expect(config.inspect).to include('[FILTERED]')
+    end
+
+    it 'does not expose private_key in output' do
+      config = described_class.new(valid_attrs.merge(private_key: 'pem_key_data'))
+      expect(config.inspect).not_to include('pem_key_data')
+    end
+
+    it 'shows [FILTERED] in place of private_key' do
+      config = described_class.new(valid_attrs.merge(private_key: 'pem_key_data'))
+      expect(config.inspect).to include('[FILTERED]')
+    end
+
+    it 'includes non-sensitive attributes in output' do
+      config = described_class.new(valid_attrs)
+      expect(config.inspect).to include('base_url')
+      expect(config.inspect).to include('client_id')
+    end
+
+    it 'omits nil attributes' do
+      config = described_class.new(valid_attrs)
+      expect(config.inspect).not_to include('client_secret')
+      expect(config.inspect).not_to include('private_key')
+    end
   end
 end


### PR DESCRIPTION
## Summary

`Entity#to_hash` now accepts a `sensitive_attributes` hook (returns `[]` by default) and replaces any non-nil sensitive value with `'[FILTERED]'`. `ClientConfig` declares `SENSITIVE_ATTRIBUTES = %i[client_secret private_key]`, overrides the hook, and adds a custom `#inspect` that masks those fields and omits `nil` attributes — preventing accidental credential exposure in REPL sessions, logs, and error messages.