### PR TITLE
Fix double SMART discovery after auth_type= by updating Smart in place

### DIFF
--- a/lib/safire/client.rb
+++ b/lib/safire/client.rb
@@ -109,7 +109,7 @@ module Safire
     def auth_type=(new_auth_type)
       @auth_type = new_auth_type.to_sym
       validate_auth_type
-      @smart_client = nil # Reset cached client to use new auth type
+      @smart_client&.auth_type = @auth_type
     end
 
     def smart_metadata

--- a/lib/safire/protocols/smart.rb
+++ b/lib/safire/protocols/smart.rb
@@ -27,7 +27,8 @@ module Safire
 
       WELL_KNOWN_PATH = '/.well-known/smart-configuration'.freeze
 
-      attr_reader(*ATTRIBUTES, :auth_type)
+      attr_reader(*ATTRIBUTES)
+      attr_accessor :auth_type
 
       # @api private
       def initialize(config, auth_type: :public)
@@ -36,10 +37,16 @@ module Safire
         @auth_type = auth_type.to_sym
         @http_client = Safire.http_client
         @issuer ||= base_url
-        @authorization_endpoint ||= well_known_config.authorization_endpoint
-        @token_endpoint ||= well_known_config.token_endpoint
 
         validate!
+      end
+
+      def authorization_endpoint
+        @authorization_endpoint ||= well_known_config.authorization_endpoint
+      end
+
+      def token_endpoint
+        @token_endpoint ||= well_known_config.token_endpoint
       end
 
       # Retrieves and parses SMART on FHIR configuration metadata from the FHIR server.

--- a/spec/safire/client_spec.rb
+++ b/spec/safire/client_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Safire::Client do
         .to raise_error(Safire::Errors::ConfigurationError, /auth_type.*unsupported/i)
     end
 
-    it 'resets the internal smart_client so new auth type is used' do
+    it 'updates auth_type on the existing smart client without rebuilding it' do
       stub_token_request(headers: { 'Authorization' => /^Basic / })
 
       client = described_class.new(config, auth_type: :public)
@@ -96,6 +96,29 @@ RSpec.describe Safire::Client do
 
       expect(WebMock).to have_requested(:post, token_endpoint)
         .with(headers: { 'Authorization' => /^Basic / })
+    end
+
+    it 'does not re-discover endpoints when auth_type changes' do
+      discovery_config = Safire::ClientConfig.new(
+        base_config_attrs.except(:authorization_endpoint, :token_endpoint)
+                         .merge(client_secret: 'secret')
+      )
+      well_known_url = "#{base_url}/.well-known/smart-configuration"
+      stub_request(:get, well_known_url).to_return(
+        status: 200,
+        body: { 'authorization_endpoint' => "#{base_url}/authorize",
+                'token_endpoint' => token_endpoint,
+                'capabilities' => [] }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+      stub_token_request(headers: { 'Authorization' => /^Basic / })
+
+      client = described_class.new(discovery_config)
+      client.smart_metadata
+      client.auth_type = :confidential_symmetric
+      client.request_access_token(code: 'auth_code', code_verifier: 'verifier')
+
+      expect(WebMock).to have_requested(:get, well_known_url).once
     end
   end
 

--- a/spec/safire/protocols/smart_spec.rb
+++ b/spec/safire/protocols/smart_spec.rb
@@ -221,6 +221,17 @@ RSpec.describe Safire::Protocols::Smart do
     end
   end
 
+  # ---------- auth_type writer ----------
+
+  describe '#auth_type=' do
+    it 'allows auth_type to be updated after initialization' do
+      client = described_class.new(config, auth_type: :public)
+      client.auth_type = :confidential_symmetric
+
+      expect(client.auth_type).to eq(:confidential_symmetric)
+    end
+  end
+
   # ---------- Well-known Discovery ----------
 
   describe '#well_known_config' do


### PR DESCRIPTION
## Summary

`Smart#authorization_endpoint` and `#token_endpoint` are now lazy readers (`@var ||= well_known_config.attr`) instead of being resolved eagerly in `initialize`. `auth_type` is promoted to `attr_accessor` so `Client#auth_type=` can update the existing `Smart` instance in place (`@smart_client&.auth_type = @auth_type`) rather than destroying and rebuilding it. This eliminates the double discovery that previously occurred when `auth_type=` was called after `smart_metadata` had already been fetched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)