### PR TITLE
Wire configured user agent into HTTP headers and document SAFIRE_LOGGER

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -359,6 +359,22 @@ SMART_CLIENT_SECRET=my_client_secret  # For confidential clients
 SMART_SCOPES="openid profile patient/*.read"
 ```
 
+### `SAFIRE_LOGGER` — Redirect Log Output to a File
+
+By default Safire logs to `$stdout`. Set `SAFIRE_LOGGER` to a file path to redirect the default logger's output to a file instead.
+
+```bash
+SAFIRE_LOGGER=/var/log/safire.log
+```
+
+This only affects the **default logger**. If you supply your own logger via `Safire.configure { |c| c.logger = MyLogger }`, `SAFIRE_LOGGER` is ignored entirely.
+
+| `SAFIRE_LOGGER` set? | `config.logger` set? | Log destination |
+|----------------------|----------------------|-----------------|
+| No | No | `$stdout` |
+| Yes (file path) | No | file at that path |
+| Either | Yes | your custom logger |
+
 ---
 
 ## Next Steps

--- a/lib/safire/http_client.rb
+++ b/lib/safire/http_client.rb
@@ -9,7 +9,10 @@ module Safire
       @options = {
         url: normalize_base_url(base_url),
         ssl: ssl_options,
-        headers: { 'User-Agent' => "Safire v#{Safire::VERSION}", 'Accept' => 'application/json' }
+        headers: {
+          'User-Agent' => Safire.configuration&.user_agent || "Safire v#{Safire::VERSION}",
+          'Accept' => 'application/json'
+        }
       }
       @adapter = adapter || Faraday.default_adapter
       @request_format = request_format.to_sym

--- a/spec/safire/http_client_spec.rb
+++ b/spec/safire/http_client_spec.rb
@@ -19,6 +19,25 @@ RSpec.describe Safire::HTTPClient do
       expect(request).to have_been_made.once
     end
 
+    context 'when a custom user_agent is configured' do
+      before do
+        allow(Safire).to receive_messages(
+          configuration: instance_double(Safire::Configuration, user_agent: 'MyApp/1.0 Safire', log_http: true),
+          logger: Logger.new(StringIO.new)
+        )
+      end
+
+      it 'uses the configured user_agent in the User-Agent header' do
+        request = stub_request(:get, base_url)
+                  .with(headers: { 'User-Agent' => 'MyApp/1.0 Safire' })
+                  .to_return(status: 200, body: {}.to_json)
+
+        described_class.new(base_url:).get
+
+        expect(request).to have_been_made.once
+      end
+    end
+
     it 'uses url_encoded request format by default' do
       expect(client.instance_variable_get(:@request_format)).to eq(:url_encoded)
     end
@@ -84,7 +103,7 @@ RSpec.describe Safire::HTTPClient do
     context 'when log_http is true (default)' do
       before do
         allow(Safire).to receive_messages(
-          configuration: instance_double(Safire::Configuration, log_http: true),
+          configuration: instance_double(Safire::Configuration, log_http: true, user_agent: "Safire v#{Safire::VERSION}"),
           logger: test_logger
         )
       end
@@ -116,7 +135,7 @@ RSpec.describe Safire::HTTPClient do
     context 'when log_http is false' do
       before do
         allow(Safire).to receive_messages(
-          configuration: instance_double(Safire::Configuration, log_http: false),
+          configuration: instance_double(Safire::Configuration, log_http: false, user_agent: "Safire v#{Safire::VERSION}"),
           logger: test_logger
         )
       end


### PR DESCRIPTION
## Summary

`HTTPClient` now reads `Safire.configuration&.user_agent` when building the default `User-Agent` header, falling back to `"Safire v#{VERSION}"` when no configuration is present. Previously the header was hardcoded, making `Configuration#user_agent` effectively inert. The docs are updated to explain the `SAFIRE_LOGGER` environment variable — it redirects the default logger's output to a file path, and is ignored entirely when a custom logger is supplied via `Safire.configure`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)