### PR TITLE
Give each Smart instance its own HTTPClient instead of sharing a module-level singleton

### DIFF
--- a/lib/safire.rb
+++ b/lib/safire.rb
@@ -42,10 +42,6 @@ module Safire
       end
     end
 
-    def http_client
-      @http_client ||= Safire::HTTPClient.new
-    end
-
     # Validates a token response for SMART App Launch 2.2.0 compliance.
     #
     # This is a caller-invoked helper — Safire's token exchange methods do not call this

--- a/lib/safire/protocols/smart.rb
+++ b/lib/safire/protocols/smart.rb
@@ -35,7 +35,7 @@ module Safire
         ATTRIBUTES.each { |attr| instance_variable_set("@#{attr}", config.public_send(attr)) }
 
         @auth_type = auth_type.to_sym
-        @http_client = Safire.http_client
+        @http_client = Safire::HTTPClient.new
         @issuer ||= base_url
 
         validate!

--- a/spec/safire/protocols/smart_spec.rb
+++ b/spec/safire/protocols/smart_spec.rb
@@ -212,6 +212,14 @@ RSpec.describe Safire::Protocols::Smart do
       end
     end
 
+    it 'gives each instance its own distinct HTTPClient' do
+      client1 = described_class.new(config)
+      client2 = described_class.new(config)
+
+      expect(client1.instance_variable_get(:@http_client))
+        .not_to be(client2.instance_variable_get(:@http_client))
+    end
+
     it 'fetches endpoints from well-known when not provided' do
       stub_well_known
       cfg = Safire::ClientConfig.new(config_attrs.except(:authorization_endpoint, :token_endpoint))


### PR DESCRIPTION
## Summary

Previously, `Protocols::Smart` obtained its HTTP client via `Safire.http_client`, a memoized singleton on the module. This meant all `Smart` (and by extension, `Client`) instances shared a single `HTTPClient` object, making true isolation between clients impossible. The fix is a one-line change: `Smart#initialize` now calls `Safire::HTTPClient.new` directly, giving each instance its own connection. The now-dead `Safire.http_client` singleton method is removed from `lib/safire.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)