### PR TITLE
Add public ROADMAP.md

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,54 @@
+# Safire Roadmap
+
+## Current Release — v0.0.1
+
+Safire is in early development (pre-release). The API is functional but not yet stable — breaking changes may occur before v1.0.0. Published to [RubyGems](https://rubygems.org/gems/safire).
+
+Feedback, bug reports, and pull requests are welcome via the [issue tracker](https://github.com/vanessuniq/safire/issues).
+
+---
+
+## Implemented Features
+
+### SMART on FHIR App Launch (v2.2.0)
+
+- **Discovery** — lazy fetch of `/.well-known/smart-configuration`; metadata cached per client instance
+- **Public Client** — PKCE-only authorization code flow (RS256/ES256)
+- **Confidential Symmetric Client** — client secret + HTTP Basic Auth + PKCE
+- **Confidential Asymmetric Client** — `private_key_jwt` with RS384/ES384; JWKS URI support; auto-detected algorithm from key type
+- **POST-Based Authorization** — form-encoded authorization requests
+- **JWT Assertion Builder** — signed JWT assertions with configurable `kid` and expiry
+- **PKCE** — automatic code verifier and challenge generation
+
+---
+
+## Planned Features
+
+### SMART on FHIR
+
+- **Backend Services** — `client_credentials` grant for system-to-system flows (no user interaction)
+- **Dynamic Client Registration** — programmatic client registration per [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591)
+
+### UDAP Security
+
+- **UDAP Discovery** — `/.well-known/udap` metadata fetch and validation
+- **UDAP Dynamic Client Registration** — signed software statements and client registration
+- **UDAP JWT Client Auth** — B2B and consumer-facing authorization flows
+- **Tiered OAuth** — identity chaining for multi-system access
+
+### Quality and Compliance
+
+- **Inferno SMART App Launch STU2.2 Test Suite** — full passing run against the [Inferno Framework](https://inferno-framework.github.io/)
+
+---
+
+## Compatibility
+
+| Component | Version |
+|-----------|---------|
+| Ruby | ≥ 4.0.1 |
+| ActiveSupport | ~> 8.0 |
+| Rails (optional) | 7.x, 8.x |
+| SMART App Launch | 2.2.0 (STU2) |
+| UDAP Security | 1.0 (planned) |
+| FHIR | R4, R4B |


### PR DESCRIPTION
This pull request adds a public-facing roadmap so contributors and users can see what is already implemented and what is planned.

The roadmap has four sections. The current release section notes that Safire is at v0.0.1 (pre-release), links to RubyGems, and sets expectations around API stability. The implemented features section gives an accurate account of what is working today — SMART discovery, all three SMART client types, POST-based authorization, JWT assertion, PKCE, per-client HTTP ownership, sensitive data masking, log filtering, configuration validation, and SSL verification warnings. The planned features section covers the next areas of work: SMART Backend Services, SMART Dynamic Client Registration (RFC 7591), the full UDAP protocol suite (Discovery, Dynamic Registration, JWT Client Auth, Tiered OAuth), and a goal to pass the Inferno SMART App Launch STU2.2 test suite. The compatibility section lists the supported Ruby, Rails, ActiveSupport, FHIR, and SMART versions at a glance.

The local PLAN.md (an internal planning file that was never tracked by git) has been deleted. The README and docs homepage already link to this file and will resolve correctly once merged.

## Test plan

- [x] `ROADMAP.md` renders correctly on GitHub
- [x] README link `[ROADMAP.md](ROADMAP.md)` resolves
- [ ] Docs homepage GitHub link resolves after merge to main
- [x] Jekyll docs build successfully (`cd docs && bundle exec jekyll build`)