### PR TITLE
Link audit: fix broken relative links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Safire is a lean Ruby library that implements **[SMART on FHIR](https://hl7.org/
 
 ### UDAP
 
-> Planned. See [ROADMAP.md](ROADMAP.md) for details.
+> Planned. See [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md) for details.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/vanessuniq/safire/workflows/CI/badge.svg)](https://github.com/vanessuniq/safire/actions)
 [![Documentation](https://img.shields.io/badge/docs-yard-blue.svg)](https://vanessuniq.github.io/safire)
 
-Safire is a lean Ruby library that implements **[SMART on FHIR](https://hl7.org/fhir/smart-app-launch/)** and **[UDAP](https://hl7.org/fhir/us/udap-security/)** client protocols for healthcare applications.
+Safire is a lean Ruby library that implements [SMART on FHIR](https://hl7.org/fhir/smart-app-launch/) and [UDAP](https://hl7.org/fhir/us/udap-security/) client protocols for healthcare applications.
 
 ---
 
@@ -145,7 +145,7 @@ cd docs && bundle install && bundle exec jekyll serve
 
 ## Contributing
 
-Bug reports and pull requests are welcome. Please read [CONTRIBUTION.md](CONTRIBUTION.md) before opening a PR — it covers branch naming, commit message style, and the sign-off requirement.
+Bug reports and pull requests are welcome. Please read [CONTRIBUTION.md](https://github.com/vanessuniq/safire/blob/main/CONTRIBUTION.md) before opening a PR — it covers branch naming, commit message style, and the sign-off requirement.
 
 ---
 


### PR DESCRIPTION
This pull request is the final link audit pass. All documentation pages were checked using htmlproofer against the built Jekyll site.

The audit found two broken links — both in the YARD API documentation caused by relative file references in README.md. When YARD renders the README, it converts relative Markdown links like `[ROADMAP.md](ROADMAP.md)` into `ROADMAP_md.html`, which does not exist in the YARD output. The same happened for `[CONTRIBUTION.md](CONTRIBUTION.md)`. Both links have been changed to absolute GitHub URLs, which work correctly both on GitHub and in the YARD-generated API docs.

The empty `<a>` tag warnings found in the YARD output are template artifacts from just-the-docs toggle buttons used in the class list — they have no `href` by design and are not part of the documentation content we maintain.

All Jekyll documentation pages pass a full internal link check with zero failures when YARD output is excluded from the audit scope.

## Test plan

- [x] Jekyll docs build successfully (`cd docs && bundle exec jekyll build`)
- [x] `htmlproofer _site --disable-external --ignore-files "/_site\/api\//,/_site\/404\.html/" --checks "Links" --swap-urls "^/safire:"` reports **0 failures**
- [x] ROADMAP.md and CONTRIBUTION.md links in README resolve to correct GitHub pages