### PR TITLE
Fix pre-existing Jekyll Sass deprecation warnings

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -44,6 +44,11 @@ nav_sort: case_insensitive
 footer_content: ""
 
 # Markdown Processors
+sass:
+  quiet_deps: true
+  silence_deprecations:
+    - import
+
 kramdown:
   syntax_highlighter: rouge
   syntax_highlighter_opts:


### PR DESCRIPTION
The documentation site was emitting 87+ Dart Sass deprecation warnings on every build about `@import` rules being deprecated in favour of `@use`. These warnings come from the just-the-docs theme's SCSS entry point files, which use `@import` to load the theme's internal stylesheets.

Since just-the-docs 0.12.0 (the current latest release) has not yet migrated its SCSS to `@use`, the warnings cannot be resolved by upgrading the gem. The fix is to configure Jekyll's Sass processor to silence the `import` deprecation category for third-party dependencies, using the `silence_deprecations` option added to `_config.yml`. The `quiet_deps: true` flag is also added to suppress any additional dependency-level warnings.

The Jekyll build now completes with zero warnings. When just-the-docs releases a version that has migrated to `@use`, both config options can be removed.

## Test plan

- [x] `cd docs && bundle exec jekyll build` completes with no deprecation warnings