### PR TITLE
Add docs build check on pull requests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,20 +1,17 @@
 name: Docs
-permissions:
-  contents: read
-  pages: write
-  id-token: write
 
 on:
   push:
     branches: [ main ]
+  pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -23,7 +20,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '4.0.1'
-          bundler-cache: true # This will run bundle install and cache gems automatically
+          bundler-cache: true
 
       - name: Generate YARD docs
         run: bin/docs
@@ -33,24 +30,34 @@ jobs:
         run: bundle install
 
       - name: Setup Pages
+        if: github.event_name != 'pull_request'
         id: pages
         uses: actions/configure-pages@v5
 
       - name: Build with Jekyll
-        # Outputs to the './_site' directory by default
         run: |
           cd docs
-          bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+          bundle exec jekyll build --baseurl "${{ github.event_name != 'pull_request' && steps.pages.outputs.base_path || '' }}"
         env:
           JEKYLL_ENV: production
 
       - name: Upload artifact
-      # Automatically uploads an artifact from the './_site' directory by default
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v4
         with:
           path: ./docs/_site
 
+  deploy:
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
-


### PR DESCRIPTION
Until now, the documentation site was only built and deployed when code was merged into the main branch, meaning a change that breaks the docs would not be caught until after the fact. This update makes the documentation build run automatically on every pull request, so contributors get immediate feedback if their changes would break the docs site. The deployment to GitHub Pages continues to happen only after a successful merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)