### PR TITLE
Document why PAT_TOKEN is required for the auto-approve step

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -27,6 +27,10 @@ jobs:
       - name: Auto-approve PR
         uses: hmarr/auto-approve-action@v4
         with:
+          # PAT_TOKEN is required here instead of GITHUB_TOKEN because GitHub
+          # does not allow a workflow to approve its own pull request — a
+          # separate personal access token acting as a distinct reviewer is
+          # needed to satisfy the branch protection approval requirement.
           github-token: ${{ secrets.PAT_TOKEN }}
 
       - name: Auto-merge PR


### PR DESCRIPTION
The auto-merge workflow uses a personal access token (`PAT_TOKEN`) rather than the default `GITHUB_TOKEN` for the pull request approval step. This was not explained anywhere, which could confuse future contributors or make the secret look unnecessary. A comment has been added in the workflow file to clarify that GitHub intentionally prevents a workflow from approving its own pull request, so a separate token acting as a distinct reviewer is required to satisfy branch protection rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)