### PR TITLE
Extract a reusable CI workflow and rename the release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '4.0.1'
+          bundler-cache: true
+
+      - name: Run tests and collect coverage
+        env:
+          COVERAGE: 'true'
+        run: bundle exec rspec
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Run RuboCop
+        run: bundle exec rubocop
+
+      - name: Security audit
+        run: bundle exec bundler-audit check --update

--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Publish Gem
 
 on:
   release:
@@ -9,21 +9,8 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '4.0.1'
-          bundler-cache: true
-
-      - name: Run tests
-        run: bundle exec rspec
-
-      - name: Run RuboCop
-        run: bundle exec rubocop
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
 
   build-and-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,6 +1,4 @@
 name: Ruby
-permissions:
-  contents: read
 
 on:
   push:
@@ -9,34 +7,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ruby-version: ['4.0.1']
-
-    steps:
-    - uses: actions/checkout@v6
-
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true # This will run bundle install and cache gems automatically
-
-    - name: Run tests and collect coverage
-      env:
-        COVERAGE: 'true'
-      run: bundle exec rspec
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-
-    - name: Run RuboCop
-      run: bundle exec rubocop
-
-    - name: Security audit
-      run: bundle exec bundler-audit check --update
+  ci:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit


### PR DESCRIPTION
The test steps — running the test suite, checking code style, scanning for security vulnerabilities, and uploading coverage — were duplicated between the CI workflow and the release workflow. This update extracts those steps into a single shared workflow that both can call, so any future addition to the quality checks only needs to be made in one place. The release workflow has also been renamed from `release.yml` to `publish-gem.yml` with the display name "Publish Gem" to make its purpose immediately clear in the GitHub Actions interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)