### PR TITLE
Ruby version update in Docs and Gemspec

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -34,7 +34,7 @@ This project adheres to a [Code of Conduct](CODE_OF_CONDUCT.md). By participatin
 
 ### Requirements
 
-- Ruby 4.0.1 or later
+- Ruby 4.0.2 or later
 - Bundler
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Safire is a lean Ruby library that implements [SMART on FHIR](https://hl7.org/fh
 
 ## Installation
 
-Requires Ruby ≥ 4.0.1.
+Requires Ruby ≥ 4.0.2.
 
 ```ruby
 gem 'safire'

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,7 +46,7 @@ Feedback, bug reports, and pull requests are welcome via the [issue tracker](htt
 
 | Component | Version |
 |-----------|---------|
-| Ruby | ≥ 4.0.1 |
+| Ruby | ≥ 4.0.2 |
 | ActiveSupport | ~> 8.0 |
 | Rails (optional) | 7.x, 8.x |
 | SMART App Launch | 2.2.0 (STU2) |

--- a/bin/demo
+++ b/bin/demo
@@ -13,11 +13,8 @@ fi
 
 cd "$DEMO_DIR"
 
-# Check if dependencies are installed
-if [ ! -f "Gemfile.lock" ]; then
-  echo "Installing demo app dependencies..."
-  bundle install
-fi
+echo "Installing demo app dependencies..."
+bundle install
 
 PORT="${PORT:-4567}"
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,7 +18,7 @@ nav_order: 2
 
 ## Install
 
-**Requirements:** Ruby ≥ 4.0.1. OpenSSL is bundled with Ruby — no separate install needed.
+**Requirements:** Ruby ≥ 4.0.2. OpenSSL is bundled with Ruby — no separate install needed.
 
 Add to your Gemfile:
 

--- a/examples/sinatra_app/Gemfile.lock
+++ b/examples/sinatra_app/Gemfile.lock
@@ -7,8 +7,6 @@ PATH
       faraday (~> 2.14)
       faraday-follow_redirects (~> 0.4)
       jwt (~> 2.8)
-      pry
-      pry-byebug
 
 GEM
   remote: https://rubygems.org/

--- a/safire.gemspec
+++ b/safire.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.description           = 'A Ruby gem implementing SMART on FHIR and UDAP protocols for clients.'
   spec.homepage              = 'https://github.com/vanessuniq/safire'
   spec.license               = 'Apache-2.0'
-  spec.required_ruby_version = Gem::Requirement.new('>= 4.0.1')
+  spec.required_ruby_version = Gem::Requirement.new('>= 4.0.2')
 
   spec.metadata['homepage_uri']      = spec.homepage
   spec.metadata['source_code_uri']   = spec.homepage


### PR DESCRIPTION
This PR updates the Ruby version requirements to v4.0.2 in Gemspec and Documentations.