### PR TITLE
Add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Report a problem with the Safire gem
+title: '[Bug] '
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened. Include any error messages or stack traces.
+
+## Environment
+
+- **Safire version:**
+- **Ruby version:**
+- **OS:**
+
+## Additional Context
+
+Any other context, logs, or screenshots that may be helpful.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,6 +29,7 @@ What actually happened. Include any error messages or stack traces.
 - **Safire version:**
 - **Ruby version:**
 - **OS:**
+- **FHIR server / EHR (if applicable):**
 
 ## Additional Context
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an improvement or new capability for the Safire gem
+title: '[Feature] '
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+Describe the problem or limitation this feature would address.
+
+## Proposed Solution
+
+Describe the behavior or API you would like to see.
+
+## Alternatives Considered
+
+Any alternative approaches you have thought about.
+
+## Additional Context
+
+Any other context, references, or examples that would help.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,9 @@
 
 Describe what this pull request changes and why.
 
+Specify if it addresses an open issue:
+Closes #
+
 ## Type of Change
 
 - [ ] Bug fix

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+Describe what this pull request changes and why.
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor
+- [ ] Documentation
+- [ ] CI / tooling
+
+## Checklist
+
+- [ ] Tests pass (`bundle exec rspec`)
+- [ ] No RuboCop offenses (`bundle exec rubocop`)
+- [ ] Documentation updated if public API changed
+- [ ] Demo app updated and verified if applicable (`bin/demo`)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,7 @@ Closes #
 - [ ] Refactor
 - [ ] Documentation
 - [ ] CI / tooling
+- [ ] Breaking change (callers must update their code)
 
 ## Checklist
 


### PR DESCRIPTION
This update adds three contribution templates to the repository. When someone opens a bug report or feature request, they will be guided to provide the right information — such as steps to reproduce, environment details, or a description of the problem being solved. When someone opens a pull request, a checklist reminds them to verify that tests pass, code style is clean, documentation is updated if needed, and the demo application still works. These templates lower the barrier for contributors and reduce back-and-forth when reviewing issues and pull requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)