### PR TITLE
OIDC token for Codecov upload instead of stored secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,10 @@ name: CI
 
 on:
   workflow_call:
-    secrets:
-      CODECOV_TOKEN:
-        required: false
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   test:
@@ -28,8 +26,8 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
-        # with:
-        #   token: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          use_oidc: true
 
       - name: Run RuboCop
         run: bundle exec rubocop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+        # with:
+        #   token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run RuboCop
         run: bundle exec rubocop

--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   test:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   ci:


### PR DESCRIPTION
## Summary

This PR uses OIDC token for Codecov upload instead of stored secret

## Type of Change

- [x] CI / tooling
