### PR TITLE
Make redirect_uri optional in ClientConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `redirect_uri` is now optional in `Safire::ClientConfig` to support backend services
+  clients that operate without a redirect URI; the field is still validated when provided
+
 ## [0.1.0] - 2026-03-25
 
 ### Added

--- a/lib/safire/client_config.rb
+++ b/lib/safire/client_config.rb
@@ -78,7 +78,7 @@ module Safire
 
     SENSITIVE_ATTRIBUTES = %i[client_secret private_key].freeze
     URI_ATTRS = %i[base_url redirect_uri issuer authorization_endpoint token_endpoint jwks_uri].freeze
-    OPTIONAL_URI_ATTRS = %i[authorization_endpoint token_endpoint jwks_uri].freeze
+    OPTIONAL_URI_ATTRS = %i[redirect_uri authorization_endpoint token_endpoint jwks_uri].freeze
     private_constant :SENSITIVE_ATTRIBUTES, :URI_ATTRS, :OPTIONAL_URI_ATTRS
 
     # @api private
@@ -155,7 +155,7 @@ module Safire
     end
 
     def validate!
-      required_attrs = %i[base_url client_id redirect_uri]
+      required_attrs = %i[base_url client_id]
       nil_vars = required_attrs.select { |attr| send(attr).nil? }
 
       if nil_vars.empty?

--- a/spec/safire/client_config_spec.rb
+++ b/spec/safire/client_config_spec.rb
@@ -16,7 +16,11 @@ RSpec.describe Safire::ClientConfig do
       expect { described_class.new(valid_attrs) }.not_to raise_error
     end
 
-    %i[base_url client_id redirect_uri].each do |attr|
+    it 'initializes successfully without redirect_uri' do
+      expect { described_class.new(valid_attrs.except(:redirect_uri)) }.not_to raise_error
+    end
+
+    %i[base_url client_id].each do |attr|
       it "raises ConfigurationError when #{attr} is missing" do
         expect { described_class.new(valid_attrs.except(attr)) }
           .to raise_error(Safire::Errors::ConfigurationError, /#{attr}/)


### PR DESCRIPTION
Backend services clients operate without a redirect URI — there is no browser redirect in a system-to-system flow. This PR removes `redirect_uri` from `ClientConfig`'s required attributes so backend services clients can be instantiated without one. The field is still validated when provided (format and HTTPS enforcement are unchanged). The `Protocols::Smart` class will enforce its presence for app_launch flows in the next PR.

## Test plan

- [x] `bundle exec rspec spec/safire/client_config_spec.rb` — all 31 examples pass
- [x] `bundle exec rspec` — full suite (299 examples) passes
- [x] `bundle exec rubocop` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)