### PR TITLE
Add SMART Backend Services client_credentials flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 
 # Used by dotenv library to load environment variables.
 .env
+.env.test
+.env.development
+.env.production
 examples/sinatra_app/.env
 examples/sinatra_app/data/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `token_response_valid?` now accepts a `flow:` keyword argument (`:app_launch` default):
   when `flow: :backend_services`, also validates `expires_in` presence (required per
   SMART Backend Services spec)
-- `token_response_valid?` now accepts both `"Bearer"` and `"bearer"` as valid `token_type`
-  values to accommodate both App Launch and Backend Services server responses
+- `token_response_valid?` accepts both `"Bearer"` (SMART App Launch spec) and `"bearer"`
+  (SMART Backend Services spec) as valid `token_type` values; the non-compliance warning
+  now references the expected value for the active flow
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- SMART Backend Services Authorization flow (`client_credentials` grant) via
+  `Safire::Client#request_backend_token` and `Safire::Protocols::Smart#request_backend_token`:
+  - Authenticates exclusively via a signed JWT assertion (RS384 or ES384); no redirect,
+    PKCE, or user interaction required
+  - Scope defaults to `["system/*.rs"]` when none is configured or provided
+  - `private_key` and `kid` can be overridden per call
+- `token_response_valid?` now accepts a `flow:` keyword argument (`:app_launch` default):
+  when `flow: :backend_services`, also validates `expires_in` presence (required per
+  SMART Backend Services spec)
+- `token_response_valid?` now accepts both `"Bearer"` and `"bearer"` as valid `token_type`
+  values to accommodate both App Launch and Backend Services server responses
+
 ### Changed
 
+- `redirect_uri` and `authorization_endpoint` are now optional in `Safire::Protocols::Smart`;
+  both are validated only when `authorization_url` is called (app launch flow)
 - `redirect_uri` is now optional in `Safire::ClientConfig` to support backend services
   clients that operate without a redirect URI; the field is still validated when provided
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :development do
 end
 
 group :test do
+  gem 'dotenv', '~> 3.0'
   gem 'simplecov', require: false
   gem 'simplecov-cobertura', require: false
   gem 'webmock', '~> 3.18'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
       reline (>= 0.3.8)
     diff-lcs (1.6.2)
     docile (1.4.1)
+    dotenv (3.2.0)
     drb (2.2.3)
     erb (5.0.3)
     faraday (2.14.1)
@@ -167,6 +168,7 @@ PLATFORMS
 DEPENDENCIES
   bundler-audit (~> 0.9)
   debug
+  dotenv (~> 3.0)
   pry
   pry-byebug
   rspec (~> 3.12)

--- a/lib/safire/client.rb
+++ b/lib/safire/client.rb
@@ -3,17 +3,20 @@ module Safire
   #
   # This class is the main entry point for integrating SMART on FHIR authorization via Safire.
   # It supports discovery of server metadata and provides a unified interface for building
-  # authorization URLs, exchanging authorization codes, and refreshing tokens.
+  # authorization URLs, exchanging authorization codes, refreshing tokens, and requesting
+  # backend services access tokens (client_credentials grant).
   #
-  # Configuration is provided via {Safire::ClientConfig} or a Hash. At minimum:
+  # Configuration is provided via {Safire::ClientConfig} or a Hash. Key attributes:
   #
   # * :base_url [String] FHIR base URL used for SMART discovery
   # * :client_id [String] OAuth2 client identifier
-  # * :redirect_uri [String] redirect URI registered with the authorization server
-  # * :scopes [Array<String>] default scopes requested during authorization
+  # * :redirect_uri [String] redirect URI registered with the authorization server;
+  #     required for app launch, not required for backend services
+  # * :scopes [Array<String>] default scopes; falls back to +["system/*.rs"]+ for
+  #     backend services when not provided
   # * :client_secret [String, optional] required for confidential_symmetric clients
-  # * :private_key [OpenSSL::PKey, String, optional] private key for confidential_asymmetric clients
-  # * :kid [String, optional] key ID matching the registered public key for asymmetric clients
+  # * :private_key [OpenSSL::PKey, String, optional] private key for asymmetric clients and backend services
+  # * :kid [String, optional] key ID matching the registered public key for asymmetric clients and backend services
   # * :jwt_algorithm [String, optional] JWT signing algorithm (RS384 or ES384). Auto-detected if not provided
   # * :jwks_uri [String, optional] URL to client's JWKS for jku header in JWT assertions
   #
@@ -37,17 +40,11 @@ module Safire
   #
   # @note Future kwargs (not yet implemented):
   #
-  #   flow: [Symbol] the authorization flow for this client.
-  #     SMART values:
-  #       nil / absent  — :app_launch (default): SMART App Launch, authorization_code grant
-  #       :backend_services — SMART Backend Services, client_credentials grant;
-  #         private_key_jwt is implied; client_type validation is skipped
-  #     UDAP values (protocol: :udap):
-  #       :b2b          — client_credentials grant, server-to-server
-  #       :b2c          — authorization_code grant, user-facing
-  #       :tiered_oauth — authorization_code + IdP identity delegation
+  #   flow: [Symbol] the authorization flow for UDAP clients (protocol: :udap):
+  #     :b2b          — client_credentials grant, server-to-server
+  #     :b2c          — authorization_code grant, user-facing
+  #     :tiered_oauth — authorization_code + IdP identity delegation
   #
-  #   Contract methods will be extended per flow in a future PR.
   #   When protocol: :udap is fully implemented, client_type: will default to nil
   #   (not applicable) and the flow: kwarg will drive B2B vs B2C selection.
   #
@@ -94,6 +91,17 @@ module Safire
   # @example Step 3 – Refreshing an access token
   #   client = Safire::Client.new(config)
   #   new_tokens = client.refresh_token(refresh_token: stored_refresh_token)
+  #
+  # @example Backend Services – system-to-system access token (client_credentials grant)
+  #   config = Safire::ClientConfig.new(
+  #     base_url:   'https://fhir.example.com',
+  #     client_id:  'my_client_id',
+  #     private_key: OpenSSL::PKey::RSA.new(File.read('private_key.pem')),
+  #     kid:        'my-key-id',
+  #     scopes:     ['system/Patient.rs']
+  #   )
+  #   client = Safire::Client.new(config, client_type: :confidential_asymmetric)
+  #   token_data = client.request_backend_token
   class Client
     extend Forwardable
 
@@ -116,6 +124,7 @@ module Safire
     def_delegators :protocol_client,
                    :server_metadata, :authorization_url,
                    :request_access_token, :refresh_token,
+                   :request_backend_token,
                    :token_response_valid?, :register_client
 
     attr_reader :config, :protocol, :client_type

--- a/lib/safire/protocols/behaviours.rb
+++ b/lib/safire/protocols/behaviours.rb
@@ -39,6 +39,12 @@ module Safire
         raise NotImplementedError, "#{self.class}#token_response_valid? is not implemented"
       end
 
+      # Requests an access token using the client credentials grant (SMART Backend Services).
+      # @abstract
+      def request_backend_token(...)
+        raise NotImplementedError, "#{self.class}#request_backend_token is not implemented"
+      end
+
       # Dynamically registers this client with the authorization server (RFC 7591).
       #
       # SMART App Launch 2.2.0 encourages implementers to consider the OAuth 2.0

--- a/lib/safire/protocols/smart.rb
+++ b/lib/safire/protocols/smart.rb
@@ -241,7 +241,7 @@ module Safire
           valid = false
         end
 
-        token_type_valid?(response) && valid
+        token_type_valid?(response, flow:) && valid
       end
 
       private
@@ -313,7 +313,7 @@ module Safire
         raise Errors::TokenError.new(received_fields: token_response.keys)
       end
 
-      def token_type_valid?(response)
+      def token_type_valid?(response, flow: :app_launch)
         if response['token_type'].blank?
           Safire.logger.warn(
             "SMART token response non-compliance: required field 'token_type' is missing"
@@ -323,9 +323,14 @@ module Safire
 
         return true if %w[Bearer bearer].include?(response['token_type'])
 
+        expected = if flow == :backend_services
+                     "'bearer' (SMART Backend Services spec)"
+                   else
+                     "'Bearer' (SMART App Launch spec)"
+                   end
         Safire.logger.warn(
           "SMART token response non-compliance: token_type is #{response['token_type'].inspect}; " \
-          "expected 'Bearer' or 'bearer'"
+          "expected #{expected}"
         )
         false
       end
@@ -363,6 +368,9 @@ module Safire
       end
 
       def backend_services_token_params(scopes:, private_key:, kid:)
+        # Per SMART Backend Services spec, client identity is conveyed via the JWT
+        # iss/sub claims (RFC 7523 §3); client_id is intentionally omitted from the
+        # POST body, consistent with the SMART IG reference token request example.
         {
           grant_type: 'client_credentials',
           scope: [scopes].flatten.join(' ')

--- a/lib/safire/protocols/smart.rb
+++ b/lib/safire/protocols/smart.rb
@@ -1,6 +1,7 @@
 module Safire
   module Protocols
-    # SMART on FHIR OAuth2 implementation for authorization code, access token, and refresh token flows.
+    # SMART on FHIR OAuth2 implementation for app launch (authorization code, token exchange, refresh)
+    # and backend services (client credentials) flows.
     #
     # This is an internal class used exclusively by {Safire::Client}. Do not instantiate it directly —
     # use {Safire::Client} instead.
@@ -25,7 +26,9 @@ module Safire
       ].freeze
 
       # Attributes that are not required during validation
-      OPTIONAL_ATTRIBUTES = %i[scopes client_secret private_key kid jwt_algorithm jwks_uri].freeze
+      OPTIONAL_ATTRIBUTES = %i[
+        redirect_uri authorization_endpoint scopes client_secret private_key kid jwt_algorithm jwks_uri
+      ].freeze
 
       WELL_KNOWN_PATH = '/.well-known/smart-configuration'.freeze
 
@@ -90,11 +93,14 @@ module Safire
       #   * :state [String] state parameter for CSRF protection; store and verify on callback
       #   * :code_verifier [String] PKCE code verifier for the token exchange
       #   * :params [Hash] (POST only) authorization parameters to submit as the request body
-      # @raise [Errors::ConfigurationError] if no scopes are configured or if method is invalid
+      # @raise [Errors::ConfigurationError] if method is invalid, scopes are missing,
+      #   or +redirect_uri+ / +authorization_endpoint+ are not configured or resolvable via discovery
       def authorization_url(launch: nil, custom_scopes: nil, method: :get)
         method = method.to_sym
-        validate_presence_of_scopes(custom_scopes)
+        custom_scopes ||= scopes
         validate_authorization_method(method)
+        validate_presence_of_scopes(custom_scopes)
+        validate_app_launch_attrs!
 
         Safire.logger.info("Generating authorization URL for SMART #{client_type} (method: #{method})...")
 
@@ -154,6 +160,40 @@ module Safire
           token_endpoint,
           body: refresh_token_params(refresh_token:, scopes:, private_key:, kid:),
           headers: oauth2_headers(client_secret)
+        )
+
+        parse_token_response(response.body)
+      rescue Faraday::Error => e
+        raise token_error_from(e)
+      end
+
+      # Requests an access token using the client credentials grant (SMART Backend Services).
+      #
+      # Implements the SMART Backend Services Authorization flow per
+      # https://hl7.org/fhir/smart-app-launch/backend-services.html
+      #
+      # No user interaction, redirect, or PKCE is involved. The client authenticates
+      # exclusively via a signed JWT assertion (RS384 or ES384).
+      #
+      # @param scopes [Array<String>, nil] scope override; uses configured scopes if nil,
+      #   falling back to +["system/*.rs"]+ when neither is provided
+      # @param private_key [OpenSSL::PKey] private key for JWT assertion; uses configured key if not provided.
+      #   Required — must be present either in configuration or passed here.
+      # @param kid [String] key ID for JWT assertion header; uses configured kid if not provided.
+      #   Required — must be present either in configuration or passed here.
+      # @return [Hash] token response from the authorization server
+      # @raise [Safire::Errors::ConfigurationError] if private_key or kid are missing
+      # @raise [Safire::Errors::TokenError] if the server returns an error or invalid response
+      # @raise [Safire::Errors::NetworkError] on network failure
+      def request_backend_token(scopes: nil, private_key: self.private_key, kid: self.kid)
+        scopes ||= self.scopes.presence || ['system/*.rs']
+
+        Safire.logger.info('Requesting backend services access token (client_credentials grant)...')
+
+        response = @http_client.post(
+          token_endpoint,
+          body: backend_services_token_params(scopes:, private_key:, kid:),
+          headers: { content_type: 'application/x-www-form-urlencoded' }
         )
 
         parse_token_response(response.body)
@@ -222,8 +262,17 @@ module Safire
         end
       end
 
-      def validate_presence_of_scopes(custom_scopes = nil)
-        return if (scopes || custom_scopes).present?
+      def validate_app_launch_attrs!
+        missing = []
+        missing << :redirect_uri if redirect_uri.blank?
+        missing << :authorization_endpoint if authorization_endpoint.blank?
+        return if missing.empty?
+
+        raise Errors::ConfigurationError.new(missing_attributes: missing)
+      end
+
+      def validate_presence_of_scopes(scopes_value)
+        return if scopes_value.present?
 
         raise Errors::ConfigurationError.new(missing_attributes: [:scopes])
       end
@@ -276,7 +325,7 @@ module Safire
           client_id:,
           redirect_uri:,
           launch:,
-          scope: [custom_scopes || scopes].flatten.join(' '),
+          scope: [custom_scopes].flatten.join(' '),
           state: SecureRandom.hex(16),
           aud: issuer.to_s,
           code_challenge_method: 'S256',
@@ -300,6 +349,13 @@ module Safire
         }
         params[:scope] = [scopes].flatten.join(' ') if scopes.present?
         params.merge(client_auth_params(private_key:, kid:))
+      end
+
+      def backend_services_token_params(scopes:, private_key:, kid:)
+        {
+          grant_type: 'client_credentials',
+          scope: [scopes].flatten.join(' ')
+        }.merge(jwt_assertion_params(private_key:, kid:))
       end
 
       def client_auth_params(private_key:, kid:)

--- a/lib/safire/protocols/smart.rb
+++ b/lib/safire/protocols/smart.rb
@@ -207,19 +207,21 @@ module Safire
         raise token_error_from(e)
       end
 
-      # Validates a token response for SMART App Launch 2.2.0 compliance.
+      # Validates a token response for SMART compliance.
       #
-      # Checks all required token response fields per SMART App Launch 2.2.0 §Token Response:
-      # - +access_token+ must be present (SHALL)
-      # - +token_type+ must be present and exactly +"Bearer"+ (SHALL, case-sensitive)
-      # - +scope+ must be present (SHALL)
+      # Checks all required token response fields based on the authorization flow:
+      # - +access_token+ must be present (all flows, SHALL)
+      # - +token_type+ must be present and +"Bearer"+ or +"bearer"+ (all flows, SHALL)
+      # - +scope+ must be present (all flows, SHALL)
+      # - +expires_in+ must be present when +flow: :backend_services+ (required per Backend Services spec)
       #
       # Logs a warning via {Safire.logger} for each violation found and returns false.
       # Never raises an exception.
       #
       # @param response [Hash] the token response returned by the server
+      # @param flow [Symbol] the authorization flow; +:app_launch+ (default) or +:backend_services+
       # @return [Boolean] true if the response is compliant, false otherwise
-      def token_response_valid?(response)
+      def token_response_valid?(response, flow: :app_launch)
         unless response.is_a?(Hash)
           Safire.logger.warn('SMART token response non-compliance: response is not a JSON object')
           return false
@@ -227,7 +229,10 @@ module Safire
 
         valid = true
 
-        %w[access_token scope].each do |field|
+        required_fields = %w[access_token scope]
+        required_fields << 'expires_in' if flow == :backend_services
+
+        required_fields.each do |field|
           next if response[field].present?
 
           Safire.logger.warn(
@@ -316,11 +321,11 @@ module Safire
           return false
         end
 
-        return true if response['token_type'] == 'Bearer'
+        return true if %w[Bearer bearer].include?(response['token_type'])
 
         Safire.logger.warn(
           "SMART token response non-compliance: token_type is #{response['token_type'].inspect}; " \
-          "expected 'Bearer' (SMART App Launch 2.2.0 requires token_type \"Bearer\")"
+          "expected 'Bearer' or 'bearer'"
         )
         false
       end

--- a/lib/safire/protocols/smart.rb
+++ b/lib/safire/protocols/smart.rb
@@ -119,13 +119,14 @@ module Safire
       # @param kid [String, nil] optional; key ID for asymmetric auth (overrides configured)
       # @return [Hash] token response parsed from the authorization server, including:
       #   * "access_token" [String] new access token issued by the authorization server (required)
-      #   * "token_type"  [String] token type, fixed value "bearer" (required)
-      #   * "expires_in"  [Integer] lifetime of the access token in seconds (required)
+      #   * "token_type"  [String] token type, exactly +"Bearer"+ (required, case-sensitive per SMART spec)
+      #   * "expires_in"  [Integer] lifetime of the access token in seconds (RECOMMENDED)
       #   * "scope"       [String] authorized scopes for this token (required)
       #   * "refresh_token"           [String] refresh token, if issued (optional)
       #   * "authorization_details"   [Hash] additional authorization details, if provided (optional)
       #   * Context parameters such as "patient" or "encounter" MAY be present, depending on server behavior.
       # @raise [Safire::Errors::TokenError] if the request fails or response is invalid.
+      # @raise [Safire::Errors::NetworkError] on connection failure, timeout, or SSL error.
       def request_access_token(code:, code_verifier:, client_secret: self.client_secret,
                                private_key: self.private_key, kid: self.kid)
         Safire.logger.info('Requesting access token using authorization code...')
@@ -152,6 +153,7 @@ module Safire
       # @return [Hash] token response parsed from the authorization server.
       #   See {#request_access_token} for token response format.
       # @raise [Safire::Errors::TokenError] if the refresh request fails or the response is invalid.
+      # @raise [Safire::Errors::NetworkError] on connection failure, timeout, or SSL error.
       def refresh_token(refresh_token:, scopes: nil, client_secret: self.client_secret,
                         private_key: self.private_key, kid: self.kid)
         Safire.logger.info('Refreshing access token...')
@@ -181,10 +183,14 @@ module Safire
       #   Required — must be present either in configuration or passed here.
       # @param kid [String] key ID for JWT assertion header; uses configured kid if not provided.
       #   Required — must be present either in configuration or passed here.
-      # @return [Hash] token response from the authorization server
+      # @return [Hash] token response from the authorization server, including:
+      #   * "access_token" [String] access token (required)
+      #   * "token_type"  [String] token type, value +"Bearer"+ (required)
+      #   * "expires_in"  [Integer] lifetime of the access token in seconds (required per Backend Services spec)
+      #   * "scope"       [String] authorized scopes (required)
       # @raise [Safire::Errors::ConfigurationError] if private_key or kid are missing
       # @raise [Safire::Errors::TokenError] if the server returns an error or invalid response
-      # @raise [Safire::Errors::NetworkError] on network failure
+      # @raise [Safire::Errors::NetworkError] on connection failure, timeout, or SSL error
       def request_backend_token(scopes: nil, private_key: self.private_key, kid: self.kid)
         scopes ||= self.scopes.presence || ['system/*.rs']
 

--- a/spec/integration/backend_services_flow_spec.rb
+++ b/spec/integration/backend_services_flow_spec.rb
@@ -1,0 +1,207 @@
+require 'spec_helper'
+
+RSpec.describe 'SMART Backend Services End-to-End Flow', type: :integration do
+  #
+  # Tests the SMART Backend Services (system-to-system) flow per
+  # https://hl7.org/fhir/smart-app-launch/backend-services.html
+  #
+  # Flow:
+  # 1. (Optional) Discovery: Fetch /.well-known/smart-configuration
+  # 2. Token Request: POST client_credentials grant + JWT assertion
+  #
+  # No redirect_uri, no PKCE, no authorization code.
+  # scope is REQUIRED per the specification.
+  #
+
+  # ---------- Test Data ----------
+
+  let(:base_url)        { 'https://fhir.example.com' }
+  let(:token_endpoint)  { "#{base_url}/token" }
+  let(:client_id)       { 'backend_system_client' }
+  let(:scopes)          { %w[system/Patient.rs system/Observation.rs] }
+  let(:kid)             { 'backend-rsa-key-001' }
+  let(:rsa_private_key) { OpenSSL::PKey::RSA.generate(2048) }
+
+  let(:smart_metadata) do
+    {
+      'issuer' => base_url,
+      'token_endpoint' => token_endpoint,
+      'grant_types_supported' => %w[authorization_code client_credentials],
+      'token_endpoint_auth_methods_supported' => %w[private_key_jwt],
+      'token_endpoint_auth_signing_alg_values_supported' => %w[RS384 ES384],
+      'capabilities' => %w[client-confidential-asymmetric client-backend-services permission-v2],
+      'scopes_supported' => %w[system/*.rs system/Patient.rs system/Observation.rs]
+    }
+  end
+
+  let(:backend_token_response) do
+    { 'access_token' => 'backend_access_token_xyz', 'token_type' => 'Bearer',
+      'expires_in' => 300, 'scope' => scopes.join(' ') }
+  end
+
+  let(:backend_config_attrs) do
+    {
+      base_url:,
+      client_id:,
+      token_endpoint:,
+      scopes:,
+      private_key: rsa_private_key,
+      kid:
+    }
+  end
+
+  let(:backend_config) { Safire::ClientConfig.new(backend_config_attrs) }
+  let(:client) { Safire::Client.new(backend_config) }
+
+  # ---------- Helpers ----------
+
+  def stub_discovery
+    stub_request(:get, "#{base_url}/.well-known/smart-configuration")
+      .to_return(status: 200, body: smart_metadata.to_json,
+                 headers: { 'Content-Type' => 'application/json' })
+  end
+
+  def stub_token_post(body_matcher: hash_including('grant_type' => 'client_credentials'),
+                      response_body: backend_token_response)
+    stub_request(:post, token_endpoint)
+      .with(body: body_matcher)
+      .to_return(status: 200, body: response_body.to_json,
+                 headers: { 'Content-Type' => 'application/json' })
+  end
+
+  before { stub_discovery }
+
+  # ---------- Discovery ----------
+
+  describe 'Discovery' do
+    it 'fetches SMART metadata advertising backend services support' do
+      config = Safire::ClientConfig.new(backend_config_attrs.except(:token_endpoint))
+      metadata = Safire::Client.new(config).server_metadata
+
+      expect(metadata).to be_a(Safire::Protocols::SmartMetadata)
+      expect(metadata.token_endpoint).to eq(token_endpoint)
+      expect(metadata.grant_types_supported).to include('client_credentials')
+      expect(metadata.token_endpoint_auth_methods_supported).to include('private_key_jwt')
+    end
+  end
+
+  # ---------- Backend Token Request ----------
+
+  describe 'Backend Token Request' do
+    before { stub_token_post }
+
+    it 'exchanges JWT assertion for an access token (token_endpoint hardcoded)' do
+      tokens = client.request_backend_token
+
+      expect(tokens['access_token']).to eq('backend_access_token_xyz')
+      expect(tokens['token_type']).to eq('Bearer')
+      expect(tokens['expires_in']).to eq(300)
+      expect(tokens['scope']).to eq(scopes.join(' '))
+    end
+
+    it 'exchanges JWT assertion for an access token (token_endpoint via discovery)' do
+      discovery_config = Safire::ClientConfig.new(backend_config_attrs.except(:token_endpoint))
+      tokens = Safire::Client.new(discovery_config).request_backend_token
+
+      expect(tokens['access_token']).to eq('backend_access_token_xyz')
+    end
+
+    it 'sends correct request body — no redirect_uri, no code, no PKCE, no Authorization header' do
+      client.request_backend_token
+
+      expect(WebMock).to(have_requested(:post, token_endpoint).with do |req|
+        body = URI.decode_www_form(req.body).to_h
+        body['grant_type'] == 'client_credentials' &&
+          body['scope'] == scopes.join(' ') &&
+          body['client_assertion_type'] == 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer' &&
+          body['client_assertion'].present? &&
+          !body.key?('redirect_uri') &&
+          !body.key?('code') &&
+          !body.key?('code_verifier') &&
+          !req.headers.key?('Authorization')
+      end)
+    end
+
+    it 'generates a valid JWT assertion with correct claims' do
+      client.request_backend_token
+
+      expect(WebMock).to(have_requested(:post, token_endpoint).with do |req|
+        body    = URI.decode_www_form(req.body).to_h
+        decoded = JWT.decode(body['client_assertion'], rsa_private_key.public_key, true, algorithm: 'RS384')
+        payload, header = decoded
+
+        header['alg'] == 'RS384' &&
+          header['kid'] == kid &&
+          payload['iss'] == client_id &&
+          payload['sub'] == client_id &&
+          payload['aud'] == token_endpoint &&
+          payload['jti'].present? &&
+          payload['exp'].is_a?(Integer) &&
+          payload['exp'] > Time.now.to_i
+      end)
+    end
+
+    it 'supports EC keys with ES384 algorithm' do
+      ec_key    = OpenSSL::PKey::EC.generate('secp384r1')
+      ec_config = Safire::ClientConfig.new(backend_config_attrs.merge(private_key: ec_key, jwt_algorithm: 'ES384'))
+      Safire::Client.new(ec_config).request_backend_token
+
+      expect(WebMock).to(have_requested(:post, token_endpoint).with do |req|
+        body    = URI.decode_www_form(req.body).to_h
+        decoded = JWT.decode(body['client_assertion'], ec_key, true, algorithm: 'ES384')
+        decoded[1]['alg'] == 'ES384' && decoded[1]['kid'] == kid
+      end)
+    end
+
+    it 'overrides configured scopes when scopes: is provided' do
+      stub_token_post(
+        body_matcher: hash_including('scope' => 'system/Patient.rs'),
+        response_body: backend_token_response.merge('scope' => 'system/Patient.rs')
+      )
+      tokens = client.request_backend_token(scopes: %w[system/Patient.rs])
+
+      expect(WebMock).to have_requested(:post, token_endpoint)
+        .with(body: hash_including('scope' => 'system/Patient.rs'))
+      expect(tokens['scope']).to eq('system/Patient.rs')
+    end
+  end
+
+  # ---------- Error Handling ----------
+
+  describe 'Error Handling' do
+    it 'raises ConfigurationError when scopes are missing' do
+      cfg = Safire::ClientConfig.new(backend_config_attrs.except(:scopes))
+      expect { Safire::Client.new(cfg).request_backend_token }
+        .to raise_error(Safire::Errors::ConfigurationError, /scopes/)
+    end
+
+    it 'raises ConfigurationError when private_key is missing' do
+      cfg = Safire::ClientConfig.new(backend_config_attrs.except(:private_key))
+      expect { Safire::Client.new(cfg).request_backend_token }
+        .to raise_error(Safire::Errors::ConfigurationError, /private_key/)
+    end
+
+    it 'raises ConfigurationError when kid is missing' do
+      cfg = Safire::ClientConfig.new(backend_config_attrs.except(:kid))
+      expect { Safire::Client.new(cfg).request_backend_token }
+        .to raise_error(Safire::Errors::ConfigurationError, /kid/)
+    end
+
+    it 'raises TokenError when the server returns an error response' do
+      stub_request(:post, token_endpoint)
+        .to_return(
+          status: 401,
+          body: { 'error' => 'invalid_client', 'error_description' => 'JWT signature invalid' }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      expect { client.request_backend_token }
+        .to raise_error(Safire::Errors::TokenError, /Token request failed/)
+    end
+
+    it 'raises NetworkError on connection failure' do
+      stub_request(:post, token_endpoint).to_raise(Faraday::ConnectionFailed)
+      expect { client.request_backend_token }
+        .to raise_error(Safire::Errors::NetworkError)
+    end
+  end
+end

--- a/spec/integration/backend_services_flow_spec.rb
+++ b/spec/integration/backend_services_flow_spec.rb
@@ -164,17 +164,23 @@ RSpec.describe 'SMART Backend Services End-to-End Flow', type: :integration do
         .with(body: hash_including('scope' => 'system/Patient.rs'))
       expect(tokens['scope']).to eq('system/Patient.rs')
     end
+
+    it 'defaults to system/*.rs when no scopes are configured' do
+      stub_token_post(
+        body_matcher: hash_including('scope' => 'system/*.rs'),
+        response_body: backend_token_response.merge('scope' => 'system/*.rs')
+      )
+      cfg = Safire::ClientConfig.new(backend_config_attrs.except(:scopes))
+      Safire::Client.new(cfg).request_backend_token
+
+      expect(WebMock).to have_requested(:post, token_endpoint)
+        .with(body: hash_including('scope' => 'system/*.rs'))
+    end
   end
 
   # ---------- Error Handling ----------
 
   describe 'Error Handling' do
-    it 'raises ConfigurationError when scopes are missing' do
-      cfg = Safire::ClientConfig.new(backend_config_attrs.except(:scopes))
-      expect { Safire::Client.new(cfg).request_backend_token }
-        .to raise_error(Safire::Errors::ConfigurationError, /scopes/)
-    end
-
     it 'raises ConfigurationError when private_key is missing' do
       cfg = Safire::ClientConfig.new(backend_config_attrs.except(:private_key))
       expect { Safire::Client.new(cfg).request_backend_token }

--- a/spec/integration/backend_services_live_spec.rb
+++ b/spec/integration/backend_services_live_spec.rb
@@ -24,17 +24,19 @@ RSpec.describe 'SMART Backend Services Flow (Live Server)', :live, type: :integr
   let(:client_id)   { ENV.fetch('SAFIRE_LIVE_BACKEND_CLIENT_ID', nil) }
   let(:kid)         { ENV.fetch('SAFIRE_LIVE_BACKEND_KID', nil) }
   let(:algorithm)   { ENV.fetch('SAFIRE_LIVE_BACKEND_ALGORITHM', 'RS384') }
-  let(:scopes)      { (ENV.fetch('SAFIRE_LIVE_BACKEND_SCOPES', 'system/*.rs')).split }
+  let(:scopes)      { ENV.fetch('SAFIRE_LIVE_BACKEND_SCOPES', 'system/*.rs').split }
   let(:private_key) do
     pem = ENV.fetch('SAFIRE_LIVE_BACKEND_PRIVATE_KEY_PEM', nil)
     OpenSSL::PKey.read(pem) if pem
   end
 
   before(:all) do
-    skip 'Set SAFIRE_LIVE_BACKEND_BASE_URL to run backend services live tests' unless ENV['SAFIRE_LIVE_BACKEND_BASE_URL']
+    unless ENV['SAFIRE_LIVE_BACKEND_BASE_URL']
+      skip 'Set SAFIRE_LIVE_BACKEND_BASE_URL to run backend services live tests'
+    end
 
     WebMock.allow_net_connect!
-    uri = URI("#{ENV['SAFIRE_LIVE_BACKEND_BASE_URL']}/.well-known/smart-configuration")
+    uri = URI("#{ENV.fetch('SAFIRE_LIVE_BACKEND_BASE_URL', nil)}/.well-known/smart-configuration")
     Net::HTTP.get_response(uri)
   rescue StandardError => e
     skip "Backend services server not reachable: #{e.message}"

--- a/spec/integration/backend_services_live_spec.rb
+++ b/spec/integration/backend_services_live_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+#
+# Live Integration Tests for SMART Backend Services
+#
+# These tests validate the Safire gem against a real SMART on FHIR server.
+# They are tagged with :live and skipped by default.
+#
+# To run:
+#   bundle exec rspec --tag live spec/integration/backend_services_live_spec.rb
+#
+# Required environment variables for token exchange tests:
+#   SAFIRE_LIVE_BACKEND_BASE_URL        — FHIR server base URL
+#   SAFIRE_LIVE_BACKEND_CLIENT_ID       — registered backend client ID
+#   SAFIRE_LIVE_BACKEND_KID             — key ID matching the registered JWKS
+#   SAFIRE_LIVE_BACKEND_PRIVATE_KEY_PEM — PEM-encoded RSA or EC private key (inline)
+#
+# Optional:
+#   SAFIRE_LIVE_BACKEND_SCOPES          — space-separated scopes (default: 'system/*.rs')
+#   SAFIRE_LIVE_BACKEND_ALGORITHM       — JWT algorithm (default: 'RS384')
+#
+RSpec.describe 'SMART Backend Services Flow (Live Server)', :live, type: :integration do
+  let(:base_url)    { ENV.fetch('SAFIRE_LIVE_BACKEND_BASE_URL', nil) }
+  let(:client_id)   { ENV.fetch('SAFIRE_LIVE_BACKEND_CLIENT_ID', nil) }
+  let(:kid)         { ENV.fetch('SAFIRE_LIVE_BACKEND_KID', nil) }
+  let(:algorithm)   { ENV.fetch('SAFIRE_LIVE_BACKEND_ALGORITHM', 'RS384') }
+  let(:scopes)      { (ENV.fetch('SAFIRE_LIVE_BACKEND_SCOPES', 'system/*.rs')).split }
+  let(:private_key) do
+    pem = ENV.fetch('SAFIRE_LIVE_BACKEND_PRIVATE_KEY_PEM', nil)
+    OpenSSL::PKey.read(pem) if pem
+  end
+
+  before(:all) do
+    skip 'Set SAFIRE_LIVE_BACKEND_BASE_URL to run backend services live tests' unless ENV['SAFIRE_LIVE_BACKEND_BASE_URL']
+
+    WebMock.allow_net_connect!
+    uri = URI("#{ENV['SAFIRE_LIVE_BACKEND_BASE_URL']}/.well-known/smart-configuration")
+    Net::HTTP.get_response(uri)
+  rescue StandardError => e
+    skip "Backend services server not reachable: #{e.message}"
+  end
+
+  after(:all) { WebMock.disable_net_connect! }
+
+  describe 'SMART Discovery' do
+    it 'fetches metadata advertising client_credentials grant and private_key_jwt auth' do
+      config   = Safire::ClientConfig.new(base_url:, client_id: 'probe')
+      metadata = Safire::Client.new(config).server_metadata
+
+      expect(metadata).to be_a(Safire::Protocols::SmartMetadata)
+      expect(metadata.token_endpoint).to be_present
+      expect(metadata.token_endpoint).to start_with('https://')
+      expect(metadata.grant_types_supported).to include('client_credentials')
+      expect(metadata.token_endpoint_auth_methods_supported).to include('private_key_jwt')
+    end
+  end
+
+  describe 'Token Exchange' do
+    let(:config) do
+      Safire::ClientConfig.new(
+        base_url:,
+        client_id:,
+        scopes:,
+        private_key:,
+        kid:,
+        jwt_algorithm: algorithm
+      )
+    end
+
+    before do
+      skip 'Set SAFIRE_LIVE_BACKEND_CLIENT_ID to run token exchange tests' unless client_id
+      skip 'Set SAFIRE_LIVE_BACKEND_KID to run token exchange tests' unless kid
+      skip 'Set SAFIRE_LIVE_BACKEND_PRIVATE_KEY_PEM to run token exchange tests' unless private_key
+    end
+
+    it 'exchanges a JWT assertion for an access token on a real server' do
+      tokens = Safire::Client.new(config).request_backend_token
+
+      expect(tokens['access_token']).to be_present
+      expect(tokens['token_type']).to eq('Bearer')
+      expect(tokens['scope']).to be_present
+      expect(tokens['expires_in']).to be_a(Integer)
+    end
+
+    it 'accepts a scope override at call time' do
+      tokens = Safire::Client.new(config).request_backend_token(scopes: scopes.first(1))
+
+      expect(tokens['access_token']).to be_present
+    end
+  end
+end

--- a/spec/safire/client_spec.rb
+++ b/spec/safire/client_spec.rb
@@ -304,6 +304,76 @@ RSpec.describe Safire::Client do
     end
   end
 
+  # ---------- Backend Token ----------
+
+  describe '#request_backend_token' do
+    let(:backend_config_attrs) do
+      {
+        client_id: 'backend_client_id',
+        base_url: base_url,
+        token_endpoint: token_endpoint,
+        private_key: rsa_private_key,
+        kid: 'backend-key-id',
+        scopes: %w[system/Patient.rs system/Observation.rs]
+      }
+    end
+
+    let(:backend_config) { Safire::ClientConfig.new(backend_config_attrs) }
+
+    let(:backend_token_response) do
+      { 'access_token' => 'backend_token_abc', 'token_type' => 'Bearer',
+        'expires_in' => 300, 'scope' => 'system/Patient.rs system/Observation.rs' }
+    end
+
+    before do
+      stub_request(:post, token_endpoint)
+        .with(body: hash_including('grant_type' => 'client_credentials'))
+        .to_return(
+          status: 200,
+          body: backend_token_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+    end
+
+    it 'delegates to the protocol and returns the token response' do
+      result = described_class.new(backend_config).request_backend_token
+      expect(result['access_token']).to eq('backend_token_abc')
+      expect(result['token_type']).to eq('Bearer')
+    end
+
+    it 'sends client_credentials grant with scope and JWT assertion' do
+      described_class.new(backend_config).request_backend_token
+
+      expect(WebMock).to have_requested(:post, token_endpoint)
+        .with(body: hash_including(
+          'grant_type' => 'client_credentials',
+          'scope' => 'system/Patient.rs system/Observation.rs',
+          'client_assertion_type' => 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
+        ))
+    end
+
+    it 'accepts a scopes override' do
+      stub_request(:post, token_endpoint)
+        .with(body: hash_including('scope' => 'system/Patient.rs'))
+        .to_return(
+          status: 200,
+          body: backend_token_response.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      described_class.new(backend_config).request_backend_token(scopes: %w[system/Patient.rs])
+
+      expect(WebMock).to have_requested(:post, token_endpoint)
+        .with(body: hash_including('scope' => 'system/Patient.rs'))
+    end
+
+    it 'raises ConfigurationError when scopes are missing' do
+      cfg = Safire::ClientConfig.new(backend_config_attrs.except(:scopes))
+      expect { described_class.new(cfg).request_backend_token }
+        .to raise_error(Safire::Errors::ConfigurationError, /scopes/)
+    end
+  end
+
   # ---------- Dynamic Client Registration ----------
 
   describe '#register_client' do

--- a/spec/safire/client_spec.rb
+++ b/spec/safire/client_spec.rb
@@ -302,6 +302,12 @@ RSpec.describe Safire::Client do
       expect(result).to be(false)
       expect(Safire.logger).to have_received(:warn).at_least(:once)
     end
+
+    it 'forwards flow: :backend_services and validates expires_in' do
+      result = described_class.new(config).token_response_valid?(valid_response, flow: :backend_services)
+      expect(result).to be(false)
+      expect(Safire.logger).to have_received(:warn).with(/'expires_in' is missing/)
+    end
   end
 
   # ---------- Backend Token ----------

--- a/spec/safire/client_spec.rb
+++ b/spec/safire/client_spec.rb
@@ -367,10 +367,12 @@ RSpec.describe Safire::Client do
         .with(body: hash_including('scope' => 'system/Patient.rs'))
     end
 
-    it 'raises ConfigurationError when scopes are missing' do
+    it 'defaults to system/*.rs scope when no scopes are configured' do
       cfg = Safire::ClientConfig.new(backend_config_attrs.except(:scopes))
-      expect { described_class.new(cfg).request_backend_token }
-        .to raise_error(Safire::Errors::ConfigurationError, /scopes/)
+      described_class.new(cfg).request_backend_token
+
+      expect(WebMock).to have_requested(:post, token_endpoint)
+        .with(body: hash_including('scope' => 'system/*.rs'))
     end
   end
 

--- a/spec/safire/protocols/behaviours_spec.rb
+++ b/spec/safire/protocols/behaviours_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Safire::Protocols::Behaviours do
 
   %i[
     server_metadata authorization_url request_access_token
-    refresh_token token_response_valid? register_client
+    refresh_token token_response_valid? register_client request_backend_token
   ].each do |method|
     it "##{method} raises NotImplementedError by default" do
       expect { instance.public_send(method) }.to raise_error(NotImplementedError)

--- a/spec/safire/protocols/smart_spec.rb
+++ b/spec/safire/protocols/smart_spec.rb
@@ -902,10 +902,10 @@ RSpec.describe Safire::Protocols::Smart do
     end
 
     context 'when token_type is an unrecognized value' do
-      it 'returns false and logs a warning' do
+      it 'returns false and logs a warning referencing the App Launch spec' do
         result = client.token_response_valid?(valid_response.merge('token_type' => 'BEARER'))
         expect(result).to be(false)
-        expect(Safire.logger).to have_received(:warn).with(/token_type/)
+        expect(Safire.logger).to have_received(:warn).with(/token_type.*SMART App Launch spec/)
       end
     end
 
@@ -955,6 +955,15 @@ RSpec.describe Safire::Protocols::Smart do
           result = client.token_response_valid?(valid_response, flow: :backend_services)
           expect(result).to be(false)
           expect(Safire.logger).to have_received(:warn).with(/'expires_in' is missing/)
+        end
+      end
+
+      context 'when token_type is an unrecognized value' do
+        it 'returns false and logs a warning referencing the Backend Services spec' do
+          response = backend_response.merge('token_type' => 'BEARER')
+          result = client.token_response_valid?(response, flow: :backend_services)
+          expect(result).to be(false)
+          expect(Safire.logger).to have_received(:warn).with(/token_type.*SMART Backend Services spec/)
         end
       end
     end

--- a/spec/safire/protocols/smart_spec.rb
+++ b/spec/safire/protocols/smart_spec.rb
@@ -893,25 +893,28 @@ RSpec.describe Safire::Protocols::Smart do
       end
     end
 
+    context 'when token_type is "bearer" (lowercase)' do
+      it 'returns true — both "Bearer" and "bearer" are accepted' do
+        result = client.token_response_valid?(valid_response.merge('token_type' => 'bearer'))
+        expect(result).to be(true)
+        expect(Safire.logger).not_to have_received(:warn)
+      end
+    end
+
+    context 'when token_type is an unrecognized value' do
+      it 'returns false and logs a warning' do
+        result = client.token_response_valid?(valid_response.merge('token_type' => 'BEARER'))
+        expect(result).to be(false)
+        expect(Safire.logger).to have_received(:warn).with(/token_type/)
+      end
+    end
+
     %w[access_token scope token_type].each do |field|
       context "when #{field} is missing" do
         it 'returns false and logs a warning' do
           result = client.token_response_valid?(valid_response.except(field))
           expect(result).to be(false)
           expect(Safire.logger).to have_received(:warn).with(/'#{field}' is missing/)
-        end
-      end
-    end
-
-    [
-      ['lowercase "bearer"', 'bearer', /token_type.*bearer.*Bearer/],
-      ['"BEARER"', 'BEARER', /token_type/]
-    ].each do |description, value, warning_pattern|
-      context "when token_type is #{description}" do
-        it 'returns false and logs a warning' do
-          result = client.token_response_valid?(valid_response.merge('token_type' => value))
-          expect(result).to be(false)
-          expect(Safire.logger).to have_received(:warn).with(warning_pattern)
         end
       end
     end
@@ -932,6 +935,36 @@ RSpec.describe Safire::Protocols::Smart do
           result = client.token_response_valid?(invalid)
           expect(result).to be(false)
           expect(Safire.logger).to have_received(:warn).with(/not a JSON object/)
+        end
+      end
+    end
+
+    context 'with flow: :backend_services' do
+      let(:backend_response) { valid_response.merge('expires_in' => 300) }
+
+      context 'when expires_in is present' do
+        it 'returns true' do
+          result = client.token_response_valid?(backend_response, flow: :backend_services)
+          expect(result).to be(true)
+          expect(Safire.logger).not_to have_received(:warn)
+        end
+      end
+
+      context 'when expires_in is missing' do
+        it 'returns false and logs a warning' do
+          result = client.token_response_valid?(valid_response, flow: :backend_services)
+          expect(result).to be(false)
+          expect(Safire.logger).to have_received(:warn).with(/'expires_in' is missing/)
+        end
+      end
+    end
+
+    context 'with flow: :app_launch (default)' do
+      context 'when expires_in is absent' do
+        it 'returns true — expires_in is not required for app launch' do
+          result = client.token_response_valid?(valid_response)
+          expect(result).to be(true)
+          expect(Safire.logger).not_to have_received(:warn)
         end
       end
     end

--- a/spec/safire/protocols/smart_spec.rb
+++ b/spec/safire/protocols/smart_spec.rb
@@ -208,10 +208,15 @@ RSpec.describe Safire::Protocols::Smart do
     end
 
     it 'raises ConfigurationError when a required attribute is missing' do
-      %i[client_id redirect_uri base_url].each do |attr|
+      %i[client_id base_url].each do |attr|
         expect { described_class.new(Safire::ClientConfig.new(config_attrs.except(attr))) }
           .to raise_error(Safire::Errors::ConfigurationError, /#{attr}/)
       end
+    end
+
+    it 'initializes successfully without redirect_uri and authorization_endpoint' do
+      cfg = Safire::ClientConfig.new(config_attrs.except(:redirect_uri, :authorization_endpoint))
+      expect { described_class.new(cfg) }.not_to raise_error
     end
 
     it 'gives each instance its own distinct HTTPClient' do
@@ -405,6 +410,23 @@ RSpec.describe Safire::Protocols::Smart do
       it 'raises ConfigurationError' do
         expect { described_class.new(config).authorization_url(method: :patch) }
           .to raise_error(Safire::Errors::ConfigurationError, /method/)
+      end
+    end
+
+    context 'when redirect_uri is not configured' do
+      it 'raises ConfigurationError' do
+        cfg = Safire::ClientConfig.new(config_attrs.except(:redirect_uri))
+        expect { described_class.new(cfg).authorization_url }
+          .to raise_error(Safire::Errors::ConfigurationError, /redirect_uri/)
+      end
+    end
+
+    context 'when authorization_endpoint cannot be resolved' do
+      it 'raises ConfigurationError' do
+        cfg = Safire::ClientConfig.new(config_attrs.except(:authorization_endpoint))
+        stub_well_known(body: smart_metadata_body.except('authorization_endpoint'))
+        expect { described_class.new(cfg).authorization_url }
+          .to raise_error(Safire::Errors::ConfigurationError, /authorization_endpoint/)
       end
     end
   end
@@ -700,6 +722,149 @@ RSpec.describe Safire::Protocols::Smart do
       expect do
         described_class.new(config, client_type: :public).refresh_token(refresh_token: 'x')
       end.to raise_error(Safire::Errors::NetworkError)
+    end
+  end
+
+  # ---------- Backend Token ----------
+
+  describe '#request_backend_token' do
+    let(:backend_token_response) do
+      { 'access_token' => 'backend_token_abc', 'token_type' => 'Bearer',
+        'expires_in' => 300, 'scope' => 'system/Patient.rs system/Observation.rs' }
+    end
+
+    let(:backend_assertion_matcher) do
+      hash_including(
+        'grant_type' => 'client_credentials',
+        'scope' => 'system/Patient.rs system/Observation.rs',
+        'client_assertion_type' => 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+        'client_assertion' => kind_of(String)
+      )
+    end
+
+    let(:backend_config_attrs) do
+      {
+        client_id: 'backend_client_id',
+        base_url: 'https://fhir.example.com',
+        token_endpoint: 'https://fhir.example.com/token',
+        private_key: rsa_private_key,
+        kid: 'backend-key-id',
+        scopes: %w[system/Patient.rs system/Observation.rs]
+      }
+    end
+
+    let(:backend_config) { Safire::ClientConfig.new(backend_config_attrs) }
+
+    context 'with RSA private key and configured scopes' do
+      before do
+        stub_token_post(body_matcher: backend_assertion_matcher, status: 200, body: backend_token_response)
+      end
+
+      it 'returns the access token response' do
+        result = described_class.new(backend_config).request_backend_token
+        expect(result['access_token']).to eq('backend_token_abc')
+        expect(result['token_type']).to eq('Bearer')
+      end
+
+      it 'sends client_credentials grant with scope and JWT assertion' do
+        described_class.new(backend_config).request_backend_token
+
+        expect(WebMock).to(have_requested(:post, config_attrs[:token_endpoint]).with do |req|
+          body = URI.decode_www_form(req.body).to_h
+          body['grant_type'] == 'client_credentials' &&
+            body['scope'] == 'system/Patient.rs system/Observation.rs' &&
+            body['client_assertion_type'] == 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer' &&
+            body['client_assertion'].present?
+        end)
+      end
+
+      it 'does not include an Authorization header' do
+        described_class.new(backend_config).request_backend_token
+
+        expect(WebMock).to(have_requested(:post, config_attrs[:token_endpoint])
+          .with { |req| !req.headers.key?('Authorization') })
+      end
+
+      it 'sends a valid JWT assertion with correct claims' do
+        described_class.new(backend_config).request_backend_token
+
+        expect(WebMock).to(have_requested(:post, config_attrs[:token_endpoint]).with do |req|
+          body    = URI.decode_www_form(req.body).to_h
+          decoded = JWT.decode(body['client_assertion'], rsa_private_key.public_key, true, algorithm: 'RS384')
+          payload, header = decoded
+
+          payload['iss'] == 'backend_client_id' &&
+            payload['sub'] == 'backend_client_id' &&
+            payload['aud'] == config_attrs[:token_endpoint] &&
+            payload['jti'].present? &&
+            payload['exp'].is_a?(Integer) &&
+            header['kid'] == 'backend-key-id'
+        end)
+      end
+    end
+
+    context 'with scope override' do
+      before do
+        stub_token_post(
+          body_matcher: hash_including('scope' => 'system/Patient.rs'),
+          status: 200,
+          body: backend_token_response
+        )
+      end
+
+      it 'uses the provided scopes instead of configured ones' do
+        described_class.new(backend_config).request_backend_token(scopes: %w[system/Patient.rs])
+
+        expect(WebMock).to have_requested(:post, config_attrs[:token_endpoint])
+          .with(body: hash_including('scope' => 'system/Patient.rs'))
+      end
+    end
+
+    context 'when no scopes are configured and none provided' do
+      it 'raises ConfigurationError' do
+        cfg = Safire::ClientConfig.new(backend_config_attrs.except(:scopes))
+        expect { described_class.new(cfg).request_backend_token }
+          .to raise_error(Safire::Errors::ConfigurationError, /scopes/)
+      end
+    end
+
+    context 'when private_key is missing' do
+      it 'raises ConfigurationError' do
+        cfg = Safire::ClientConfig.new(backend_config_attrs.except(:private_key))
+        expect { described_class.new(cfg).request_backend_token }
+          .to raise_error(Safire::Errors::ConfigurationError, /private_key/)
+      end
+    end
+
+    context 'when kid is missing' do
+      it 'raises ConfigurationError' do
+        cfg = Safire::ClientConfig.new(backend_config_attrs.except(:kid))
+        expect { described_class.new(cfg).request_backend_token }
+          .to raise_error(Safire::Errors::ConfigurationError, /kid/)
+      end
+    end
+
+    context 'when server returns an error' do
+      before do
+        stub_request(:post, config_attrs[:token_endpoint]).to_return(
+          status: 401,
+          body: { 'error' => 'invalid_client', 'error_description' => 'JWT signature invalid' }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+
+      it 'raises TokenError' do
+        expect { described_class.new(backend_config).request_backend_token }
+          .to raise_error(Safire::Errors::TokenError, /Token request failed/)
+      end
+    end
+
+    context 'when a network error occurs' do
+      it 'raises NetworkError' do
+        stub_request(:post, config_attrs[:token_endpoint]).to_raise(Faraday::ConnectionFailed)
+        expect { described_class.new(backend_config).request_backend_token }
+          .to raise_error(Safire::Errors::NetworkError)
+      end
     end
   end
 

--- a/spec/safire/protocols/smart_spec.rb
+++ b/spec/safire/protocols/smart_spec.rb
@@ -821,10 +821,17 @@ RSpec.describe Safire::Protocols::Smart do
     end
 
     context 'when no scopes are configured and none provided' do
-      it 'raises ConfigurationError' do
+      it 'defaults to system/*.rs scope' do
+        stub_token_post(
+          body_matcher: hash_including('scope' => 'system/*.rs'),
+          status: 200,
+          body: backend_token_response.merge('scope' => 'system/*.rs')
+        )
         cfg = Safire::ClientConfig.new(backend_config_attrs.except(:scopes))
-        expect { described_class.new(cfg).request_backend_token }
-          .to raise_error(Safire::Errors::ConfigurationError, /scopes/)
+        described_class.new(cfg).request_backend_token
+
+        expect(WebMock).to have_requested(:post, config_attrs[:token_endpoint])
+          .with(body: hash_including('scope' => 'system/*.rs'))
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,11 +22,13 @@ if ENV['COVERAGE']
   end
 end
 
-require 'dotenv'
 require 'pry'
 require 'webmock/rspec'
 
-Dotenv.load('.env.test')
+if File.exist?('.env.test')
+  require 'dotenv'
+  Dotenv.load('.env.test')
+end
 
 WebMock.disable_net_connect!
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,8 +22,11 @@ if ENV['COVERAGE']
   end
 end
 
+require 'dotenv'
 require 'pry'
 require 'webmock/rspec'
+
+Dotenv.load('.env.test')
 
 WebMock.disable_net_connect!
 


### PR DESCRIPTION
This PR adds support for the SMART Backend Services Authorization profile, enabling autonomous system-to-system FHIR access using the OAuth 2.0 client credentials grant and mandatory JWT assertion authentication — no user interaction, redirect URI, or PKCE required.

## Changes

- **`Safire::Client#request_backend_token`** and **`Safire::Protocols::Smart#request_backend_token`**: new public method implementing the [SMART Backend Services](https://hl7.org/fhir/smart-app-launch/backend-services.html) flow; authenticates via RS384/ES384 JWT assertion; scope defaults to `["system/*.rs"]` when not configured
- **`redirect_uri` and `authorization_endpoint`** made optional in `Smart`; validated only when `authorization_url` is called (app launch flow)
- **`token_response_valid?`** extended with a `flow:` keyword argument (`:app_launch` default); when `flow: :backend_services`, also validates `expires_in` (required per Backend Services spec); now accepts both `"Bearer"` and `"bearer"` as valid `token_type` values
- Full test coverage: WebMock unit and E2E specs, live integration spec (skipped without env vars), verified against the SMART Health IT sandbox

## Test plan

- [x] `bundle exec rspec` — 333 examples, 0 failures
- [x] `bundle exec rubocop` — no offenses
- [x] `bundle exec rspec --tag live spec/integration/backend_services_live_spec.rb` against a real SMART server (optional; requires env vars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)