### PR TITLE
BS-3: Backend Services documentation, discovery support, and demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `token_response_valid?` accepts both `"Bearer"` (SMART App Launch spec) and `"bearer"`
   (SMART Backend Services spec) as valid `token_type` values; the non-compliance warning
   now references the expected value for the active flow
+- `SmartMetadata#supports_backend_services?` returns `true` when the server advertises the
+  `client_credentials` grant type and supports `private_key_jwt` authentication
+  (i.e. `grant_types_supported` includes `"client_credentials"` and
+  `supports_asymmetric_auth?` is `true`)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,12 @@ require 'safire'
 
 # Step 1 — Create a client (Hash config or Safire::ClientConfig.new)
 client = Safire::Client.new(
-  base_url:     'https://launch.smarthealthit.org/v/r4/sim/eyJoIjoiMSJ9/fhir',
-  client_id:    'my_client_id',
-  redirect_uri: 'https://myapp.example.com/callback',
-  scopes:       ['openid', 'profile', 'patient/*.read']
+  {
+    base_url:     'https://launch.smarthealthit.org/v/r4/sim/eyJoIjoiMSJ9/fhir',
+    client_id:    'my_client_id',
+    redirect_uri: 'https://myapp.example.com/callback',
+    scopes:       ['openid', 'profile', 'patient/*.read']
+  }
 )
 
 # Step 2 — Discover SMART metadata (lazy — only called when needed)
@@ -110,11 +112,13 @@ No user interaction, redirect URI, or PKCE required — the client authenticates
 
 ```ruby
 client = Safire::Client.new(
-  base_url:    'https://fhir.example.com',
-  client_id:   'my_backend_client',
-  private_key: OpenSSL::PKey::RSA.new(File.read('private_key.pem')),
-  kid:         'my-key-id-123',
-  scopes:      ['system/Patient.rs', 'system/Observation.rs']
+  {
+    base_url:    'https://fhir.example.com',
+    client_id:   'my_backend_client',
+    private_key: OpenSSL::PKey::RSA.new(File.read('private_key.pem')),
+    kid:         'my-key-id-123',
+    scopes:      ['system/Patient.rs', 'system/Observation.rs']
+  }
 )
 
 token_data = client.request_backend_token

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Safire is a lean Ruby library that implements [SMART on FHIR](https://hl7.org/fh
 - Confidential Asymmetric Client (`private_key_jwt` with RS384/ES384)
 - POST-Based Authorization
 
+### SMART on FHIR Backend Services
+
+- System-to-system access token request (`client_credentials` grant)
+- JWT assertion authentication (RS384/ES384) — no user interaction, redirect, or PKCE
+- Scope defaults to `system/*.rs` when not configured
+
 ### UDAP
 
 > Planned. See [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md) for details.
@@ -98,6 +104,33 @@ client = Safire::Client.new(
 # Authorization and token exchange are identical — Safire builds the JWT assertion automatically
 ```
 
+### Backend Services (system-to-system)
+
+No user interaction, redirect URI, or PKCE required — the client authenticates entirely via a signed JWT assertion:
+
+```ruby
+client = Safire::Client.new(
+  base_url:    'https://fhir.example.com',
+  client_id:   'my_backend_client',
+  private_key: OpenSSL::PKey::RSA.new(File.read('private_key.pem')),
+  kid:         'my-key-id-123',
+  scopes:      ['system/Patient.rs', 'system/Observation.rs']
+)
+
+token_data = client.request_backend_token
+# token_data => { "access_token" => "...", "token_type" => "Bearer", "expires_in" => 300, ... }
+
+# Override scope or credentials per call
+token_data = client.request_backend_token(
+  scopes:      ['system/Patient.rs'],
+  private_key: OpenSSL::PKey::RSA.new(File.read('new_key.pem')),
+  kid:         'new-key-id'
+)
+
+# Validate the token response (flow: :backend_services also checks expires_in)
+client.token_response_valid?(token_data, flow: :backend_services)
+```
+
 ---
 
 ## Configuration
@@ -122,7 +155,7 @@ bin/demo
 # Visit http://localhost:4567
 ```
 
-Demonstrates SMART discovery, all authorization flows, and token refresh. See [`examples/sinatra_app/README.md`](examples/sinatra_app/README.md) for details.
+Demonstrates SMART discovery, all authorization flows, token refresh, and backend services token requests. See [`examples/sinatra_app/README.md`](examples/sinatra_app/README.md) for details.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Safire Roadmap
 
-## Current Release — v0.0.1
+## Current Release — v0.1.0
 
 Safire is in early development (pre-release). The API is functional but not yet stable — breaking changes may occur before v1.0.0. Published to [RubyGems](https://rubygems.org/gems/safire).
 
@@ -20,13 +20,16 @@ Feedback, bug reports, and pull requests are welcome via the [issue tracker](htt
 - **JWT Assertion Builder** — signed JWT assertions with configurable `kid` and expiry
 - **PKCE** — automatic code verifier and challenge generation
 
+### SMART on FHIR Backend Services
+
+- **Backend Services** — `client_credentials` grant for system-to-system flows; JWT assertion (RS384/ES384); no user interaction, redirect, or PKCE required; scope defaults to `system/*.rs` when not configured
+
 ---
 
 ## Planned Features
 
 ### SMART on FHIR
 
-- **Backend Services** — `client_credentials` grant for system-to-system flows (no user interaction)
 - **Dynamic Client Registration** — programmatic client registration per [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591)
 
 ### UDAP Security

--- a/docs/adr/ADR-008-warn-return-false-for-compliance-validation.md
+++ b/docs/adr/ADR-008-warn-return-false-for-compliance-validation.md
@@ -25,7 +25,7 @@ The question is: what should compliance checks do when they find a violation?
 
 **Option B — Warn and return false:** log a warning via `Safire.logger` for each violation found, then return `false`. Never raise.
 
-Option A treats a non-compliant server as an unrecoverable error. In practice, some production FHIR servers have minor token response non-compliance (e.g. `token_type: "bearer"` in lowercase rather than `"Bearer"`) but are otherwise functional. Raising an exception would prevent Safire from working with those servers entirely, with no way for callers to override the decision.
+Option A treats a non-compliant server as an unrecoverable error. In practice, some production FHIR servers have minor token response non-compliance (e.g. returning `token_type: "BEARER"` instead of the spec-required value) but are otherwise functional. Raising an exception would prevent Safire from working with those servers entirely, with no way for callers to override the decision.
 
 Option B lets the caller decide what to do: they can check the return value, observe the warnings in their logs, and choose to proceed or abort. This is consistent with how Ruby standard library methods (e.g. `URI.parse`, `JSON.parse` with `rescue nil`) handle validation — surface the issue, let the caller decide.
 
@@ -38,9 +38,9 @@ There is also a clear boundary: **the caller controls the config** (configuratio
 Compliance validation methods use the **warn + return false** pattern:
 
 ```ruby
-def token_response_valid?(response)
+def token_response_valid?(response, flow: :app_launch)
   # ...
-  Safire.logger.warn("SMART token response non-compliance: token_type is #{...}; expected 'Bearer'")
+  Safire.logger.warn("SMART token response non-compliance: token_type is #{...}; expected 'Bearer' (SMART App Launch spec)")
   false
 end
 
@@ -72,3 +72,4 @@ Configuration validation (`ClientConfig#validate!`, `Smart#validate!`) raises `C
 **Trade-offs:**
 - Callers who do not call `token_response_valid?` get no compliance signal at all — non-compliant responses are silently accepted; this is intentional (opt-in, not opt-out)
 - The distinction between "warn + return false" and "raise" must be maintained consistently — new validation methods should follow the same rule: server behaviour → warn; caller configuration → raise
+- `token_response_valid?` accepts a `flow:` keyword argument (`:app_launch` default, `:backend_services`) that adjusts which fields are required and what the warning messages say. For example, `token_type` must be `"Bearer"` (App Launch spec) or `"bearer"` (Backend Services spec), and `expires_in` is RECOMMENDED for App Launch but REQUIRED for Backend Services. Callers opt in to the stricter backend-services validation by passing `flow: :backend_services`

--- a/docs/configuration/client-setup.md
+++ b/docs/configuration/client-setup.md
@@ -105,7 +105,7 @@ metadata = client.server_metadata
 client.client_type = :confidential_asymmetric if metadata.supports_asymmetric_auth?
 ```
 
-For a decision guide on which client type to use, see [SMART on FHIR — Choosing a Client Type]({{ site.baseurl }}/smart-on-fhir/).
+For a decision guide on which workflow to use, see [SMART on FHIR — Choosing a Workflow]({{ site.baseurl }}/smart-on-fhir/).
 
 ---
 
@@ -122,7 +122,7 @@ The following attributes are validated:
 | Attribute | Validated when |
 |-----------|----------------|
 | `base_url` | Always |
-| `redirect_uri` | Always |
+| `redirect_uri` | When provided (required for App Launch; not used in Backend Services) |
 | `issuer` | When provided (defaults to `base_url`) |
 | `authorization_endpoint` | When provided |
 | `token_endpoint` | When provided |

--- a/docs/configuration/client-setup.md
+++ b/docs/configuration/client-setup.md
@@ -23,10 +23,12 @@ Pass configuration as a Hash — Safire wraps it in a `ClientConfig` automatical
 
 ```ruby
 client = Safire::Client.new(
-  base_url:     'https://fhir.example.com/r4',
-  client_id:    'my_client_id',
-  redirect_uri: 'https://myapp.com/callback',
-  scopes:       ['openid', 'profile', 'patient/*.read']
+  {
+    base_url:     'https://fhir.example.com/r4',
+    client_id:    'my_client_id',
+    redirect_uri: 'https://myapp.com/callback',
+    scopes:       ['openid', 'profile', 'patient/*.read']
+  }
 )
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ A lean Ruby gem implementing **[SMART on FHIR](https://hl7.org/fhir/smart-app-la
 |---------|-------------|
 | [Getting Started]({{ site.baseurl }}/installation/) | Install Safire and quick start guide |
 | [Configuration]({{ site.baseurl }}/configuration/) | All configuration options and parameters |
-| [SMART on FHIR]({{ site.baseurl }}/smart-on-fhir/) | Discovery, Public clients, Confidential clients |
+| [SMART on FHIR]({{ site.baseurl }}/smart-on-fhir/) | App Launch (Public, Confidential Symmetric, Confidential Asymmetric) and Backend Services |
 | [UDAP]({{ site.baseurl }}/udap/) | UDAP protocol overview and planned support |
 | [Security Guide]({{ site.baseurl }}/security/) | HTTPS, credential protection, token storage, key rotation |
 | [Advanced Examples]({{ site.baseurl }}/advanced/) | Caching, multi-server, token management, complete Rails integration |
@@ -35,6 +35,11 @@ A lean Ruby gem implementing **[SMART on FHIR](https://hl7.org/fhir/smart-app-la
 - Confidential Asymmetric Client (private_key_jwt with RS384/ES384)
 - POST-Based Authorization
 
+### SMART on FHIR Backend Services
+
+- System-to-system token requests (`client_credentials` grant)
+- JWT assertion authentication (RS384/ES384) — no user interaction, redirect, or PKCE
+
 ### UDAP
 
 > Planned. See [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md) for details (coming soon).
@@ -47,7 +52,7 @@ A Sinatra-based demo app is included to help you explore Safire's features:
 bin/demo
 ```
 
-Visit http://localhost:4567 to test SMART discovery, authorization flows, and token management.
+Visit http://localhost:4567 to test SMART discovery, authorization flows, token management, and backend services token requests.
 
 See [`examples/sinatra_app/README.md`](https://github.com/vanessuniq/safire/tree/main/examples/sinatra_app) for details.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,10 +71,12 @@ A quick smoke test to confirm the gem is installed and SMART discovery is workin
 require 'safire'
 
 client = Safire::Client.new(
-  base_url:     'https://launch.smarthealthit.org/v/r4/sim/eyJoIjoiMSJ9/fhir',
-  client_id:    'test',
-  redirect_uri: 'https://example.com/callback',
-  scopes:       ['openid', 'profile', 'patient/*.read']
+  {
+    base_url:     'https://launch.smarthealthit.org/v/r4/sim/eyJoIjoiMSJ9/fhir',
+    client_id:    'test',
+    redirect_uri: 'https://example.com/callback',
+    scopes:       ['openid', 'profile', 'patient/*.read']
+  }
 )
 
 metadata = client.server_metadata

--- a/docs/smart-on-fhir/backend-services/index.md
+++ b/docs/smart-on-fhir/backend-services/index.md
@@ -1,0 +1,92 @@
+---
+layout: default
+title: Backend Services Workflow
+parent: SMART on FHIR
+nav_order: 6
+has_children: true
+permalink: /smart-on-fhir/backend-services/
+---
+
+# Backend Services Workflow
+
+{: .no_toc }
+
+<div class="code-example" markdown="1">
+System-to-system access token requests using the OAuth 2.0 `client_credentials` grant and mandatory JWT assertion authentication — no user interaction, redirect URI, or PKCE required.
+</div>
+
+---
+
+## Overview
+
+SMART Backend Services enables autonomous server-to-server FHIR access without involving a user. It is defined in the [SMART App Launch Backend Services](https://hl7.org/fhir/smart-app-launch/backend-services.html) specification.
+
+Instead of a redirect flow, the client:
+
+1. Registers with the authorization server following the [confidential asymmetric registration steps](https://hl7.org/fhir/smart-app-launch/client-confidential-asymmetric.html#registering-a-client-communicating-public-keys) (required by the spec)
+2. Builds a signed JWT assertion using its registered private key
+3. Posts the assertion to the token endpoint with `grant_type=client_credentials`
+4. Receives an access token directly — no authorization code, no callback, no PKCE
+
+Suitable for:
+
+- Scheduled data pipelines and batch jobs
+- System integrations that run without a logged-in user
+- Clinical quality reporting and analytics platforms
+- Any server-to-server FHIR workflow
+
+---
+
+## Key Differences from App Launch
+
+| Aspect | App Launch | Backend Services |
+|--------|------------|-----------------|
+| **Grant type** | `authorization_code` | `client_credentials` |
+| **User interaction** | Required | None |
+| **Redirect URI** | Required | Not used |
+| **PKCE** | Required | Not used |
+| **Client auth** | Varies by `client_type:` | JWT assertion always |
+| **Scopes** | `patient/`, `user/`, `openid` | `system/` |
+| **Refresh token** | Usually issued | Not issued |
+| **`expires_in`** | Recommended | Required |
+
+---
+
+## Prerequisites: Registration, Keys, and JWKS
+
+### Client Registration
+
+Before making any token requests, the client **SHALL** register with the authorization server following the [confidential asymmetric client registration](https://hl7.org/fhir/smart-app-launch/client-confidential-asymmetric.html#registering-a-client-communicating-public-keys) steps defined in the SMART App Launch specification. Registration communicates the client's public key(s) to the server, either via a JWKS URI or by uploading the JWKS directly.
+
+### Key Pair and JWKS
+
+Backend services use the same RSA or EC key pair infrastructure as the confidential asymmetric app launch flow — key generation, JWKS publishing, and algorithm selection are identical. See the [Confidential Asymmetric Client — Prerequisites]({% link smart-on-fhir/confidential-asymmetric/index.md %}#prerequisites-keys-jwks-and-algorithm) guide for full details.
+
+---
+
+## Client Setup
+
+`redirect_uri` and `scopes` are optional for backend services clients. If `scopes` is omitted, Safire defaults to `["system/*.rs"]` when `request_backend_token` is called.
+
+```ruby
+config = Safire::ClientConfig.new(
+  base_url:    ENV['FHIR_BASE_URL'],
+  client_id:   ENV['SMART_CLIENT_ID'],
+  private_key: OpenSSL::PKey::RSA.new(ENV['SMART_PRIVATE_KEY_PEM']),
+  kid:         ENV['SMART_KEY_ID'],
+  scopes:      ['system/Patient.rs', 'system/Observation.rs']  # optional
+)
+
+client = Safire::Client.new(config)
+```
+
+{: .note }
+> `client_type:` is not used for backend services — `request_backend_token` always authenticates via JWT assertion regardless of `client_type`.
+
+---
+
+## What's Next
+
+- [Token Request]({% link smart-on-fhir/backend-services/token-request.md %}) — Requesting a token, scope/credential overrides, flow diagram, validation, error handling, and proactive renewal
+- [Security Guide]({{ site.baseurl }}/security/) — Private key management and rotation
+- [Confidential Asymmetric Client]({% link smart-on-fhir/confidential-asymmetric/index.md %}) — The app launch counterpart that shares the same key infrastructure

--- a/docs/smart-on-fhir/backend-services/token-request.md
+++ b/docs/smart-on-fhir/backend-services/token-request.md
@@ -1,0 +1,207 @@
+---
+layout: default
+title: Token Request
+parent: Backend Services Workflow
+grand_parent: SMART on FHIR
+nav_order: 1
+---
+
+# Token Request
+
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Requesting an Access Token
+
+```ruby
+token_data = client.request_backend_token
+# => {
+#      "access_token" => "eyJhbGci...",
+#      "token_type"   => "Bearer",
+#      "expires_in"   => 300,
+#      "scope"        => "system/Patient.rs system/Observation.rs"
+#    }
+```
+
+Safire posts to the token endpoint:
+
+```http
+POST /token HTTP/1.1
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=client_credentials&
+scope=system%2FPatient.rs+system%2FObservation.rs&
+client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&
+client_assertion=eyJhbGciOiJSUzM4NCIsImtpZCI6Im15LWtleS1pZCJ9...
+```
+
+The JWT assertion structure is identical to the one used in app launch. See [Confidential Asymmetric — Token Exchange]({% link smart-on-fhir/confidential-asymmetric/token-exchange.md %}#step-3-token-exchange) for the full claim breakdown.
+
+{: .important }
+> No `Authorization` header is sent and no `client_id` appears in the request body — the client identity is carried entirely within the signed JWT assertion.
+
+---
+
+## Scope and Credential Overrides
+
+`scopes`, `private_key`, and `kid` can all be overridden at call time without changing the client configuration:
+
+```ruby
+# Override scope only
+token_data = client.request_backend_token(scopes: ['system/Patient.rs'])
+
+# Override credentials (e.g. during key rotation)
+token_data = client.request_backend_token(
+  private_key: OpenSSL::PKey::RSA.new(ENV['NEW_PRIVATE_KEY_PEM']),
+  kid:         ENV['NEW_KEY_ID']
+)
+```
+
+---
+
+## Flow Diagram
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant Safire
+    participant FHIR as FHIR Server
+
+    App->>Safire: Client.new(config)
+    Note over Safire: No network call yet
+
+    App->>Safire: request_backend_token
+    Safire->>FHIR: GET /.well-known/smart-configuration
+    FHIR-->>Safire: SmartMetadata (token_endpoint, ...)
+    Note over Safire: Builds + signs JWT assertion
+
+    Safire->>FHIR: POST /token
+    Note over Safire,FHIR: grant_type=client_credentials<br/>client_assertion=[signed JWT]
+    FHIR-->>Safire: { access_token, token_type, expires_in, scope }
+    Safire-->>App: token response Hash
+```
+
+{: .note }
+> Discovery is lazy — the first call to `request_backend_token` fetches `/.well-known/smart-configuration` to resolve the token endpoint. Subsequent calls reuse the cached metadata. If `token_endpoint` is set directly in `ClientConfig`, discovery is skipped entirely.
+
+---
+
+## Validating the Token Response
+
+Use `token_response_valid?` with `flow: :backend_services` to apply Backend Services compliance checks. This additionally validates that `expires_in` is present, which is required by the Backend Services spec (only recommended for App Launch):
+
+```ruby
+token_data = client.request_backend_token
+
+if client.token_response_valid?(token_data, flow: :backend_services)
+  access_token = token_data['access_token']
+  expires_in   = token_data['expires_in']
+else
+  # Warnings already logged by Safire — inspect logs for details
+  raise 'Non-compliant token response from server'
+end
+```
+
+---
+
+## Error Handling
+
+```ruby
+begin
+  token_data = client.request_backend_token
+rescue Safire::Errors::ConfigurationError => e
+  # private_key or kid missing from config and not passed at call time
+  Rails.logger.error("Backend services misconfigured: #{e.message}")
+  raise
+rescue Safire::Errors::TokenError => e
+  case e.error_code
+  when 'invalid_client'
+    # JWT assertion rejected — wrong key, bad signature, or unrecognized client_id
+    Rails.logger.error("Backend services auth rejected: #{e.message}")
+  when 'invalid_scope'
+    # Server does not allow the requested scopes for this client
+    Rails.logger.error("Unauthorized scope: #{e.message}")
+  else
+    Rails.logger.error("Token request failed: #{e.message}")
+  end
+  raise
+rescue Safire::Errors::NetworkError => e
+  # Connection failure, timeout, or SSL error — raised by Safire::HTTPClient
+  Rails.logger.error("Network error: #{e.message}")
+  raise
+end
+```
+
+See [Troubleshooting — Confidential Client Errors]({% link troubleshooting/client-errors.md %}) for more detail on `invalid_client` and missing credential errors.
+
+---
+
+## Proactive Token Renewal
+
+Backend services tokens expire (typically in 5–15 minutes) and no refresh token is issued. Track expiry and renew proactively:
+
+```ruby
+class BackendTokenManager
+  EXPIRY_BUFFER = 60 # seconds
+
+  def initialize(client)
+    @client     = client
+    @token_data = nil
+    @expires_at = nil
+  end
+
+  def access_token
+    refresh! if needs_refresh?
+    @token_data['access_token']
+  end
+
+  private
+
+  def needs_refresh?
+    @token_data.nil? || Time.current >= (@expires_at - EXPIRY_BUFFER)
+  end
+
+  def refresh!
+    @token_data = @client.request_backend_token
+    @expires_at = Time.current + @token_data['expires_in'].to_i
+  end
+end
+
+# Usage
+manager = BackendTokenManager.new(client)
+token   = manager.access_token  # fetches on first call, renews when near expiry
+```
+
+For the app launch equivalent (proactive refresh using a refresh token), see [Advanced Examples — Token Management]({{ site.baseurl }}/advanced/#token-management).
+
+---
+
+## Live Testing
+
+Safire includes a live integration spec that exercises the full Backend Services flow against a real server. See `spec/integration/backend_services_live_spec.rb`. Required environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `SAFIRE_LIVE_BACKEND_BASE_URL` | FHIR server base URL |
+| `SAFIRE_LIVE_BACKEND_CLIENT_ID` | Registered backend client ID |
+| `SAFIRE_LIVE_BACKEND_KID` | Key ID matching the registered JWKS |
+| `SAFIRE_LIVE_BACKEND_PRIVATE_KEY_PEM` | PEM-encoded private key |
+| `SAFIRE_LIVE_BACKEND_SCOPES` | Space-separated scopes (optional; default: `system/*.rs`) |
+| `SAFIRE_LIVE_BACKEND_ALGORITHM` | JWT algorithm (optional; default: `RS384`) |
+
+```bash
+bundle exec rspec --tag live spec/integration/backend_services_live_spec.rb
+```
+
+The [SMART Health IT sandbox](https://launch.smarthealthit.org) supports backend services and can be used for testing without a dedicated FHIR server.
+
+---
+
+**See also:** [Backend Services Overview]({% link smart-on-fhir/backend-services/index.md %}) · [Confidential Asymmetric Client]({% link smart-on-fhir/confidential-asymmetric/index.md %}) · [Security Guide]({{ site.baseurl }}/security/) · [Troubleshooting]({% link troubleshooting/index.md %})

--- a/docs/smart-on-fhir/backend-services/token-request.md
+++ b/docs/smart-on-fhir/backend-services/token-request.md
@@ -165,12 +165,12 @@ class BackendTokenManager
   private
 
   def needs_refresh?
-    @token_data.nil? || Time.current >= (@expires_at - EXPIRY_BUFFER)
+    @token_data.nil? || Time.now >= (@expires_at - EXPIRY_BUFFER)
   end
 
   def refresh!
     @token_data = @client.request_backend_token
-    @expires_at = Time.current + @token_data['expires_in'].to_i
+    @expires_at = Time.now + @token_data['expires_in'].to_i
   end
 end
 

--- a/docs/smart-on-fhir/confidential-asymmetric/index.md
+++ b/docs/smart-on-fhir/confidential-asymmetric/index.md
@@ -24,9 +24,12 @@ Confidential asymmetric clients authenticate using **`private_key_jwt`** — a s
 Safire implements `private_key_jwt` per [SMART App Launch STU 2.2.0](https://hl7.org/fhir/smart-app-launch/client-confidential-asymmetric.html).
 
 Suitable for:
-- Backend services where sharing a secret out-of-band is impractical
+- Server-side apps authenticating in the authorization code flow without sharing a secret out-of-band
 - Multi-tenant platforms where independent key rotation per tenant is valuable
 - Deployments requiring the highest level of client authentication assurance
+
+{: .note }
+> The key pair setup and JWT assertion mechanism described here are also used by the **[Backend Services]({% link smart-on-fhir/backend-services/index.md %})** flow (`client_credentials` grant), which applies the same `private_key_jwt` authentication without a user-facing redirect.
 
 ---
 

--- a/docs/smart-on-fhir/discovery/capability-checks.md
+++ b/docs/smart-on-fhir/discovery/capability-checks.md
@@ -52,7 +52,16 @@ metadata.supports_openid_connect?
 # POST-based authorization
 metadata.supports_post_based_authorization?
 # => true if capabilities include "authorize-post"
+
+# Backend Services (client_credentials grant, no user interaction)
+metadata.supports_backend_services?
+# => true if:
+#    grant_types_supported includes "client_credentials"
+#    AND supports_asymmetric_auth? (private_key_jwt with RS384/ES384)
 ```
+
+{: .note }
+> `supports_backend_services?` checks `grant_types_supported` rather than a capability flag — it combines a grant type check with `supports_asymmetric_auth?` because the SMART Backend Services flow always authenticates via JWT assertion (`private_key_jwt`).
 
 ---
 
@@ -115,6 +124,21 @@ def configure_client_type(client)
   else
     raise 'Server does not support any known client types'
   end
+end
+```
+
+**Backend Services is a separate workflow** — it uses the `client_credentials` grant rather than `authorization_code`, so `client_type` is not relevant. Check `supports_backend_services?` independently:
+
+```ruby
+metadata = client.server_metadata
+
+if metadata.supports_backend_services?
+  token_data = client.request_backend_token(
+    private_key: private_key,
+    kid:         kid
+  )
+else
+  raise 'Server does not support the Backend Services (client_credentials) flow'
 end
 ```
 

--- a/docs/smart-on-fhir/index.md
+++ b/docs/smart-on-fhir/index.md
@@ -19,23 +19,31 @@ This section provides step-by-step guides for implementing SMART on FHIR authori
 | [Confidential Symmetric Client]({% link smart-on-fhir/confidential-symmetric/index.md %}) | Authorization flow for server-side applications with client secrets |
 | [Confidential Asymmetric Client]({% link smart-on-fhir/confidential-asymmetric/index.md %}) | Authorization flow using private_key_jwt (RSA/EC key pair) |
 | [POST-Based Authorization]({% link smart-on-fhir/post-based-authorization.md %}) | Sending the authorization request as a form POST (`authorize-post` capability) |
+| [Backend Services]({% link smart-on-fhir/backend-services/index.md %}) | System-to-system token requests using `client_credentials` grant; no user interaction |
 
-## Choosing a Client Type
+## Choosing a Workflow
 
 ```
-Is your application a server-side web application
-that can securely store credentials?
+Does your application require a logged-in user?
         │
-        ├── YES → Can you use asymmetric key pairs (RSA/EC)?
+        ├── YES → App Launch flow (authorization_code grant)
         │         │
-        │         ├── YES → Confidential Asymmetric Client
-        │         │         (Uses private_key_jwt with signed JWT assertions)
+        │         Is your application a server-side web app
+        │         that can securely store credentials?
         │         │
-        │         └── NO  → Confidential Symmetric Client
-        │                   (Uses client_secret with HTTP Basic auth)
+        │         ├── YES → Can you use asymmetric key pairs (RSA/EC)?
+        │         │         │
+        │         │         ├── YES → Confidential Asymmetric Client
+        │         │         │         (private_key_jwt with signed JWT assertions)
+        │         │         │
+        │         │         └── NO  → Confidential Symmetric Client
+        │         │                   (client_secret with HTTP Basic auth)
+        │         │
+        │         └── NO  → Public Client
+        │                   (PKCE only, no client secret)
         │
-        └── NO  → Public Client
-                  (Uses PKCE only, no client secret)
+        └── NO  → Backend Services (client_credentials grant)
+                  (JWT assertion, no redirect or PKCE)
 ```
 
 ## Common Flow

--- a/docs/troubleshooting/auth-errors.md
+++ b/docs/troubleshooting/auth-errors.md
@@ -96,6 +96,9 @@ auth_data = client.authorization_url(
 )
 ```
 
+{: .note }
+> **Backend Services:** `request_backend_token` does not raise this error — it defaults to `["system/*.rs"]` when no scopes are configured. Pass `scopes:` to override: `client.request_backend_token(scopes: ['system/Patient.rs'])`.
+
 ### State mismatch on callback
 
 **Symptom:** authorization callback fails or state validation raises an error.

--- a/docs/troubleshooting/client-errors.md
+++ b/docs/troubleshooting/client-errors.md
@@ -97,6 +97,36 @@ Verify the public key registered with the server matches the private key you are
 
 ---
 
+## Backend Services Errors
+
+### `ConfigurationError`: Missing `private_key` or `kid`
+
+```
+Safire::Errors::ConfigurationError: Configuration missing: private_key, kid
+```
+
+`request_backend_token` validates `private_key` and `kid` when building the JWT assertion. Ensure both are in config or passed as overrides:
+
+```ruby
+# In config (preferred)
+config = Safire::ClientConfig.new(
+  private_key: OpenSSL::PKey::RSA.new(File.read(ENV['SMART_PRIVATE_KEY_PATH'])),
+  kid:         ENV.fetch('SMART_KEY_ID'),
+  # ...
+)
+client = Safire::Client.new(config)
+
+# Or override per call
+client.request_backend_token(
+  private_key: OpenSSL::PKey::RSA.new(File.read(ENV['SMART_PRIVATE_KEY_PATH'])),
+  kid:         ENV.fetch('SMART_KEY_ID')
+)
+```
+
+See [Backend Services — Prerequisites]({% link smart-on-fhir/backend-services/index.md %}#prerequisites) for key generation steps.
+
+---
+
 ## Network Errors
 
 ### `NetworkError`: Connection refused or timeout

--- a/docs/troubleshooting/client-errors.md
+++ b/docs/troubleshooting/client-errors.md
@@ -123,7 +123,7 @@ client.request_backend_token(
 )
 ```
 
-See [Backend Services — Prerequisites]({% link smart-on-fhir/backend-services/index.md %}#prerequisites) for key generation steps.
+See [Backend Services — Prerequisites]({% link smart-on-fhir/backend-services/index.md %}#prerequisites-registration-keys-and-jwks) for key generation steps.
 
 ---
 

--- a/examples/sinatra_app/Gemfile.lock
+++ b/examples/sinatra_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    safire (0.0.1)
+    safire (0.1.0)
       activesupport (~> 8.0.0)
       addressable (~> 2.8)
       faraday (~> 2.14)

--- a/examples/sinatra_app/README.md
+++ b/examples/sinatra_app/README.md
@@ -16,8 +16,9 @@ A Sinatra-based web application that demonstrates the features of the Safire gem
   - Confidential Symmetric (client_secret with Basic Auth)
   - Confidential Asymmetric (private_key_jwt with JWT assertion)
 - **Token Management**: View obtained tokens and test token refresh functionality
+- **Backend Services**: Request system-to-system access tokens via the `client_credentials` grant (no user interaction) when the server advertises support
 - **Session Reset**: Clear all OAuth and token session data via the "Reset Session" button in the navigation bar
-- **JWKS Endpoint**: Serves the app's public key at `/.well-known/jwks.json` for asymmetric auth
+- **JWKS Endpoint**: Serves the app's public key at `/.well-known/jwks.json` for asymmetric auth and backend services
 
 ## Quick Start
 
@@ -126,6 +127,18 @@ To test EHR launch with the SMART sandbox:
 - `http://localhost:4567/launch?client_type=confidential_symmetric` - Confidential client with Basic Auth
 - `http://localhost:4567/launch?client_type=confidential_asymmetric` - Confidential client with JWT assertion
 
+### Backend Services Token Request
+
+If the server advertises `client_credentials` grant support, the "Backend Services" card appears on the server detail page:
+
+1. Navigate to a server detail page
+2. Click "Request Backend Token"
+3. Optionally enter custom scopes (defaults to `system/*.rs`)
+4. Click "Request Token"
+5. View the access token, expiry, granted scopes, and SMART compliance check result
+
+Requires `ASYMMETRIC_PRIVATE_KEY_PEM` and `ASYMMETRIC_KID` to be configured (same key pair used for confidential asymmetric App Launch).
+
 ### Token Refresh
 
 After completing an authorization flow, if the server issued a refresh token:
@@ -168,7 +181,8 @@ examples/sinatra_app/
         ├── discovery.erb
         ├── authorize.erb
         ├── tokens.erb
-        └── refresh.erb
+        ├── refresh.erb
+        └── backend_token.erb
 ```
 
 ## Endpoints
@@ -178,6 +192,8 @@ examples/sinatra_app/
 | `/.well-known/jwks.json` | JWKS endpoint serving the app's public key |
 | `/launch` | EHR/Portal launch endpoint |
 | `/callback` | OAuth2 callback handler |
+| `GET /demo/:id/backend-token` | Backend Services token request form |
+| `POST /demo/:id/backend-token` | Submits the backend services token request |
 | `POST /reset-session` | Clears all OAuth and token session data |
 
 ## License

--- a/examples/sinatra_app/app.rb
+++ b/examples/sinatra_app/app.rb
@@ -13,6 +13,14 @@ require_relative 'models/fhir_server'
 
 # Sinatra demo application for Safire gem
 class SafireDemo < Sinatra::Base
+  # In-memory metadata cache shared across requests (keyed by server base_url)
+  METADATA_CACHE_TTL = 300 # seconds
+
+  @metadata_cache = {}
+  class << self
+    attr_reader :metadata_cache
+  end
+
   configure :development do
     register Sinatra::Reloader
   end
@@ -122,6 +130,7 @@ class SafireDemo < Sinatra::Base
   get '/servers/:id' do
     @server = FhirServer.find(params[:id])
     halt 404, 'Server not found' unless @server
+    @metadata = cached_server_metadata(@server)
     erb :'servers/show'
   end
 
@@ -168,11 +177,11 @@ class SafireDemo < Sinatra::Base
     @server = FhirServer.find(params[:server_id])
     halt 404, 'Server not found' unless @server
 
-    begin
-      @safire_client = build_safire_client(@server)
-      @metadata = @safire_client.server_metadata
-    rescue Safire::Errors::Error => e
-      set_flash(:error, flash_error_message('Server connection failed', e))
+    @safire_client = build_safire_client(@server)
+    @metadata = cached_server_metadata(@server, client: @safire_client)
+
+    unless @metadata
+      set_flash(:error, 'Server discovery failed — check the server URL and try again.')
       redirect "/servers/#{@server.id}"
     end
   end
@@ -202,6 +211,34 @@ class SafireDemo < Sinatra::Base
     rescue Safire::Errors::Error => e
       set_flash(:error, flash_error_message('Authorization failed', e))
       redirect "/servers/#{@server.id}"
+    end
+  end
+
+  # Backend Services - request form
+  get '/demo/:server_id/backend-token' do
+    erb :'demo/backend_token'
+  end
+
+  # Backend Services - request token
+  post '/demo/:server_id/backend-token' do
+    unless asymmetric_credentials_configured?
+      set_flash(:error, 'Backend Services requires ASYMMETRIC_PRIVATE_KEY_PEM and ASYMMETRIC_KID to be set.')
+      redirect "/demo/#{@server.id}/backend-token"
+      return
+    end
+
+    begin
+      scopes = params[:scopes].to_s.strip.empty? ? ['system/*.rs'] : parse_scopes(params[:scopes])
+      @token_response = @safire_client.request_backend_token(
+        scopes: scopes,
+        private_key: asymmetric_private_key,
+        kid: ENV.fetch('ASYMMETRIC_KID', nil)
+      )
+      @valid = @safire_client.token_response_valid?(@token_response, flow: :backend_services)
+      erb :'demo/backend_token'
+    rescue Safire::Errors::Error => e
+      set_flash(:error, flash_error_message('Backend Services token request failed', e))
+      redirect "/demo/#{@server.id}/backend-token"
     end
   end
 
@@ -392,6 +429,26 @@ class SafireDemo < Sinatra::Base
 
     client_type = client_type_param.to_s.strip.to_sym
     %i[public confidential_symmetric confidential_asymmetric].include?(client_type) ? client_type : :public
+  end
+
+  def cached_server_metadata(server, client: nil)
+    entry = SafireDemo.metadata_cache[server.base_url]
+    return entry[:metadata] if fresh_cache?(entry)
+
+    fetch_and_cache_metadata(server, client)
+  end
+
+  def fresh_cache?(entry)
+    entry && Time.now.to_i - entry[:fetched_at] < METADATA_CACHE_TTL
+  end
+
+  def fetch_and_cache_metadata(server, client)
+    client ||= Safire::Client.new({ base_url: server.base_url, client_id: server.client_id })
+    metadata = client.server_metadata
+    SafireDemo.metadata_cache[server.base_url] = { metadata: metadata, fetched_at: Time.now.to_i }
+    metadata
+  rescue Safire::Errors::Error
+    nil
   end
 
   def build_safire_client(server, client_type: :public)

--- a/examples/sinatra_app/app.rb
+++ b/examples/sinatra_app/app.rb
@@ -216,6 +216,12 @@ class SafireDemo < Sinatra::Base
 
   # Backend Services - request form
   get '/demo/:server_id/backend-token' do
+    unless @metadata&.supports_backend_services?
+      set_flash(:error, 'This server does not advertise the client_credentials grant.')
+      redirect "/servers/#{@server.id}"
+      return
+    end
+
     erb :'demo/backend_token'
   end
 

--- a/examples/sinatra_app/public/css/style.css
+++ b/examples/sinatra_app/public/css/style.css
@@ -401,13 +401,16 @@ section {
 }
 
 .action-cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  display: flex;
   gap: 1rem;
   margin-top: 1rem;
+  align-items: stretch;
 }
 
 .action-card {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
   padding: 1.5rem;
   background-color: var(--bg-color);
   border: 1px solid var(--border-color);
@@ -425,7 +428,9 @@ section {
   font-size: 0.875rem;
 }
 
-.action-card .btn {
+.action-card .btn,
+.action-card .disabled-note {
+  margin-top: auto;
   width: 100%;
   text-align: center;
 }

--- a/examples/sinatra_app/views/demo/backend_token.erb
+++ b/examples/sinatra_app/views/demo/backend_token.erb
@@ -24,7 +24,7 @@
     <div class="token-section">
       <h3>Access Token</h3>
       <div class="token-display">
-        <code class="token-value"><%= @token_response['access_token'] %></code>
+        <code class="token-value"><%= h(@token_response['access_token']) %></code>
       </div>
     </div>
 
@@ -52,7 +52,7 @@
 
     <div class="token-section">
       <h3>Full Response</h3>
-      <pre class="json-display"><%= JSON.pretty_generate(@token_response) %></pre>
+      <pre class="json-display"><%= h(JSON.pretty_generate(@token_response)) %></pre>
     </div>
 
     <div class="form-actions">

--- a/examples/sinatra_app/views/demo/backend_token.erb
+++ b/examples/sinatra_app/views/demo/backend_token.erb
@@ -1,0 +1,93 @@
+<div class="page-header">
+  <h1>Backend Services Token Request</h1>
+</div>
+
+<section class="token-results">
+  <h2>Server: <%= h(@server.name) %></h2>
+  <p class="server-url"><code><%= h(@server.base_url) %></code></p>
+
+  <% unless asymmetric_credentials_configured? %>
+    <div class="error-box">
+      <strong>Credentials not configured.</strong> Set <code>ASYMMETRIC_PRIVATE_KEY_PEM</code> and
+      <code>ASYMMETRIC_KID</code> environment variables to enable Backend Services.
+      See the <a href="https://github.com/vanessuniq/safire/tree/main/examples/sinatra_app#setting-up-asymmetric-authentication">README</a>
+      for setup instructions.
+    </div>
+  <% end %>
+
+  <% if @token_response %>
+    <div class="<%= @valid ? 'success-box' : 'warning-box' %>">
+      Token obtained. SMART compliance check (<code>flow: :backend_services</code>):
+      <strong><%= @valid ? 'PASSED' : 'FAILED — see application logs for details' %></strong>
+    </div>
+
+    <div class="token-section">
+      <h3>Access Token</h3>
+      <div class="token-display">
+        <code class="token-value"><%= @token_response['access_token'] %></code>
+      </div>
+    </div>
+
+    <div class="token-section">
+      <h3>Token Details</h3>
+      <dl class="details-list">
+        <dt>Token Type</dt>
+        <dd><%= @token_response['token_type'] || 'Not specified' %></dd>
+
+        <dt>Expires In</dt>
+        <dd><%= @token_response['expires_in'] ? "#{@token_response['expires_in']} seconds" : 'Not specified' %></dd>
+
+        <dt>Scope</dt>
+        <dd>
+          <% if @token_response['scope'] %>
+            <% @token_response['scope'].split(' ').each do |scope| %>
+              <span class="badge badge-scope"><%= scope %></span>
+            <% end %>
+          <% else %>
+            <em>Not specified</em>
+          <% end %>
+        </dd>
+      </dl>
+    </div>
+
+    <div class="token-section">
+      <h3>Full Response</h3>
+      <pre class="json-display"><%= JSON.pretty_generate(@token_response) %></pre>
+    </div>
+
+    <div class="form-actions">
+      <form action="/demo/<%= @server.id %>/backend-token" method="post" style="display:inline;">
+        <button type="submit" class="btn btn-primary">Request New Token</button>
+      </form>
+      <a href="/servers/<%= @server.id %>" class="btn btn-secondary">Back to Server</a>
+    </div>
+
+  <% else %>
+    <p>
+      Request a backend services access token using the <code>client_credentials</code> grant.
+      No user interaction or redirect is required.
+    </p>
+
+    <form action="/demo/<%= @server.id %>/backend-token" method="post" class="demo-form">
+      <div class="form-group">
+        <label for="scopes">Scopes <span class="optional">(optional)</span></label>
+        <input type="text" id="scopes" name="scopes"
+               placeholder="system/Patient.rs system/Observation.rs"
+               class="form-input">
+        <p class="form-hint">Space or comma-separated. Defaults to <code>system/*.rs</code> when omitted.</p>
+      </div>
+
+      <div class="form-actions">
+        <button type="submit" class="btn btn-primary"
+                <%= 'disabled' unless asymmetric_credentials_configured? %>>
+          Request Token
+        </button>
+        <a href="/servers/<%= @server.id %>" class="btn btn-secondary">Cancel</a>
+      </div>
+    </form>
+  <% end %>
+</section>
+
+<div class="back-link">
+  <a href="/servers/<%= @server.id %>">&larr; Back to Server</a>
+</div>

--- a/examples/sinatra_app/views/demo/discovery.erb
+++ b/examples/sinatra_app/views/demo/discovery.erb
@@ -74,6 +74,7 @@
 
       <h4>Other Features</h4>
       <ul>
+        <li>Backend Services (<code>client_credentials</code>): <%= @metadata.supports_backend_services? ? 'Yes' : 'No' %></li>
         <li>OpenID Connect SSO: <%= @metadata.supports_openid_connect? ? 'Yes' : 'No' %></li>
         <li>POST-based Authorization: <%= @metadata.supports_post_based_authorization? ? 'Yes' : 'No' %></li>
       </ul>

--- a/examples/sinatra_app/views/servers/show.erb
+++ b/examples/sinatra_app/views/servers/show.erb
@@ -58,6 +58,18 @@
         <p class="disabled-note"><em>Complete authorization flow first to enable token refresh.</em></p>
       <% end %>
     </div>
+
+    <% if @metadata&.supports_backend_services? %>
+      <div class="action-card">
+        <h3>Backend Services</h3>
+        <p>Request an access token via the <code>client_credentials</code> grant — no user interaction or redirect required.</p>
+        <% if asymmetric_credentials_configured? %>
+          <a href="/demo/<%= @server.id %>/backend-token" class="btn btn-primary">Request Backend Token</a>
+        <% else %>
+          <p class="disabled-note"><em>Set <code>ASYMMETRIC_PRIVATE_KEY_PEM</code> and <code>ASYMMETRIC_KID</code> to enable.</em></p>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 </section>
 

--- a/lib/safire/protocols/smart_metadata.rb
+++ b/lib/safire/protocols/smart_metadata.rb
@@ -143,6 +143,13 @@ module Safire
            token_endpoint_auth_methods_supported.include?('client_secret_basic'))
       end
 
+      # Checks if the server supports the SMART Backend Services workflow.
+      # @return [Boolean] true if the server advertises the client_credentials grant type
+      #   and supports private_key_jwt authentication (via {#supports_asymmetric_auth?})
+      def supports_backend_services?
+        grant_types_supported&.include?('client_credentials') && supports_asymmetric_auth?
+      end
+
       # Checks if the server supports confidential asymmetric authentication.
       # @return [Boolean] true if server has capability, auth methods not advertised or includes private_key_jwt,
       #   and has supported algorithms

--- a/lib/safire/protocols/smart_metadata.rb
+++ b/lib/safire/protocols/smart_metadata.rb
@@ -147,7 +147,9 @@ module Safire
       # @return [Boolean] true if the server advertises the client_credentials grant type
       #   and supports private_key_jwt authentication (via {#supports_asymmetric_auth?})
       def supports_backend_services?
-        grant_types_supported&.include?('client_credentials') && supports_asymmetric_auth?
+        grant_types_supported.present? &&
+          grant_types_supported.include?('client_credentials') &&
+          supports_asymmetric_auth?
       end
 
       # Checks if the server supports confidential asymmetric authentication.

--- a/spec/safire/protocols/smart_metadata_spec.rb
+++ b/spec/safire/protocols/smart_metadata_spec.rb
@@ -207,6 +207,12 @@ RSpec.describe Safire::Protocols::SmartMetadata do
       expect(metadata.supports_backend_services?).to be(false)
     end
 
+    it 'returns false when grant_types_supported is nil' do
+      data = full_metadata.except('grant_types_supported')
+      metadata = described_class.new(data)
+      expect(metadata.supports_backend_services?).to be(false)
+    end
+
     it 'returns false when supports_asymmetric_auth? is false' do
       smart_metadata.capabilities.delete('client-confidential-asymmetric')
       expect(smart_metadata.supports_backend_services?).to be(false)

--- a/spec/safire/protocols/smart_metadata_spec.rb
+++ b/spec/safire/protocols/smart_metadata_spec.rb
@@ -196,6 +196,23 @@ RSpec.describe Safire::Protocols::SmartMetadata do
     end
   end
 
+  describe '#supports_backend_services?' do
+    it 'returns true when client_credentials grant and asymmetric auth are both supported' do
+      expect(smart_metadata.supports_backend_services?).to be(true)
+    end
+
+    it 'returns false when client_credentials is not in grant_types_supported' do
+      data = full_metadata.merge('grant_types_supported' => ['authorization_code'])
+      metadata = described_class.new(data)
+      expect(metadata.supports_backend_services?).to be(false)
+    end
+
+    it 'returns false when supports_asymmetric_auth? is false' do
+      smart_metadata.capabilities.delete('client-confidential-asymmetric')
+      expect(smart_metadata.supports_backend_services?).to be(false)
+    end
+  end
+
   describe '#asymmetric_signing_algorithms_supported' do
     it 'returns intersection of server and supported algorithms' do
       data = full_metadata.merge('token_endpoint_auth_signing_alg_values_supported' => %w[RS384 RS256 ES384])


### PR DESCRIPTION
## Summary

This PR completes the Backend Services series by adding everything a user needs to understand and explore the `client_credentials` flow introduced in BS-2.

- Added a two-page Backend Services guide under the SMART on FHIR docs section (overview/prerequisites and token request/validation/error handling), following the same structure as the other workflow guides. Updated the SMART index, confidential asymmetric page, docs home, ADR-008, configuration, and troubleshooting pages for accuracy.
- Added `supports_backend_services?` to `SmartMetadata` (with specs) so callers can check whether a server advertises the `client_credentials` grant before attempting the flow. Documented the method in the capability-checks guide alongside the other `supports_*?` methods.
- Extended the Sinatra demo app with a Backend Services token request route, a new result view, and an in-memory metadata cache (5-minute TTL) so the server detail page and demo routes share a single discovery call. The server detail page now shows the Backend Services card only when `supports_backend_services?` is true.
- Fixed all `Safire::Client.new(key: val)` inline-kwargs examples in docs and README to use explicit hash syntax (`{ key: val }`), which is required for correct positional argument passing in Ruby 3.

## Test plan

- [ ] `bundle exec rspec spec/safire/protocols/smart_metadata_spec.rb` — all examples pass including the three new `supports_backend_services?` cases
- [ ] Run `bin/demo`, add a SMART server that supports `client_credentials` (e.g. SMART Health IT sandbox), verify the Backend Services card appears on the server detail page and the token request completes
- [ ] Confirm the Backend Services card does not appear for servers that do not advertise `client_credentials` in `grant_types_supported`
- [ ] Run `bundle exec jekyll build` in `docs/` — clean build, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)