### PR TITLE
Correct SMART spec name throughout codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Corrected spec name throughout: "SMART on FHIR" → "SMART App Launch" per the
+  [SMART App Launch IG](https://hl7.org/fhir/smart-app-launch/); Backend Services is
+  presented as a feature within the spec, not a separate spec
+
 ### Added
 
 - SMART Backend Services Authorization flow (`client_credentials` grant) via
@@ -19,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   when `flow: :backend_services`, also validates `expires_in` presence (required per
   SMART Backend Services spec)
 - `token_response_valid?` accepts both `"Bearer"` (SMART App Launch spec) and `"bearer"`
-  (SMART Backend Services spec) as valid `token_type` values; the non-compliance warning
+  (SMART Backend Services) as valid `token_type` values; the non-compliance warning
   now references the expected value for the active flow
 - `SmartMetadata#supports_backend_services?` returns `true` when the server advertises the
   `client_credentials` grant type and supports `private_key_jwt` authentication
@@ -39,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Safire::Client` facade with `protocol:` (`:smart`) and `client_type:`
   (`:public`, `:confidential_symmetric`, `:confidential_asymmetric`) keywords
-- SMART on FHIR App Launch 2.2.0 support via `Safire::Protocols::Smart`:
+- SMART App Launch 2.2.0 support via `Safire::Protocols::Smart`:
   - Server metadata discovery from `/.well-known/smart-configuration`
   - Authorization URL builder for GET and POST-based authorization
     (`authorize-post` capability)

--- a/README.md
+++ b/README.md
@@ -5,25 +5,20 @@
 [![Coverage](https://codecov.io/gh/vanessuniq/safire/branch/main/graph/badge.svg)](https://codecov.io/gh/vanessuniq/safire)
 [![Documentation](https://img.shields.io/badge/docs-yard-blue.svg)](https://vanessuniq.github.io/safire)
 
-Safire is a lean Ruby library that implements [SMART on FHIR](https://hl7.org/fhir/smart-app-launch/) and [UDAP](https://hl7.org/fhir/us/udap-security/) client protocols for healthcare applications.
+Safire is a lean Ruby library that implements [SMART App Launch](https://hl7.org/fhir/smart-app-launch/) and [UDAP](https://hl7.org/fhir/us/udap-security/) client protocols for healthcare applications.
 
 ---
 
 ## Features
 
-### SMART on FHIR App Launch (v2.2.0)
+### SMART App Launch (v2.2.0)
 
 - Discovery (`/.well-known/smart-configuration`)
 - Public Client (PKCE)
 - Confidential Symmetric Client (`client_secret` + HTTP Basic Auth)
 - Confidential Asymmetric Client (`private_key_jwt` with RS384/ES384)
 - POST-Based Authorization
-
-### SMART on FHIR Backend Services
-
-- System-to-system access token request (`client_credentials` grant)
-- JWT assertion authentication (RS384/ES384) — no user interaction, redirect, or PKCE
-- Scope defaults to `system/*.rs` when not configured
+- Backend Services (`client_credentials` grant, JWT assertion, no user interaction or PKCE; scope defaults to `system/*.rs`)
 
 ### UDAP
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ Feedback, bug reports, and pull requests are welcome via the [issue tracker](htt
 
 ## Implemented Features
 
-### SMART on FHIR App Launch (v2.2.0)
+### SMART App Launch (v2.2.0)
 
 - **Discovery** — lazy fetch of `/.well-known/smart-configuration`; metadata cached per client instance
 - **Public Client** — PKCE-only authorization code flow (RS256/ES256)
@@ -19,16 +19,13 @@ Feedback, bug reports, and pull requests are welcome via the [issue tracker](htt
 - **POST-Based Authorization** — form-encoded authorization requests
 - **JWT Assertion Builder** — signed JWT assertions with configurable `kid` and expiry
 - **PKCE** — automatic code verifier and challenge generation
-
-### SMART on FHIR Backend Services
-
 - **Backend Services** — `client_credentials` grant for system-to-system flows; JWT assertion (RS384/ES384); no user interaction, redirect, or PKCE required; scope defaults to `system/*.rs` when not configured
 
 ---
 
 ## Planned Features
 
-### SMART on FHIR
+### SMART App Launch
 
 - **Dynamic Client Registration** — programmatic client registration per [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591)
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -19,7 +19,7 @@
 # in the templates via {{ site.myvariable }}.
 
 title: Safire Documentation
-description: SMART on FHIR and UDAP implementation library for Ruby
+description: SMART App Launch and UDAP implementation library for Ruby
 baseurl: /safire
 url: https://vanessuniq.github.io
 

--- a/docs/adr/ADR-002-facade-and-forwardable.md
+++ b/docs/adr/ADR-002-facade-and-forwardable.md
@@ -13,7 +13,7 @@ nav_order: 2
 
 ## Context
 
-Safire must support multiple authorization protocols (SMART on FHIR, UDAP) from a single public entry point. There are several ways to structure this:
+Safire must support multiple authorization protocols (SMART App Launch, UDAP) from a single public entry point. There are several ways to structure this:
 
 **Option A — Monolithic `Client`:** implement all protocol logic directly inside `Safire::Client`. Simple at first, but grows unbounded as each protocol adds methods, and makes it impossible to test protocol logic in isolation.
 

--- a/docs/adr/ADR-003-protocol-vs-client-type.md
+++ b/docs/adr/ADR-003-protocol-vs-client-type.md
@@ -13,7 +13,7 @@ nav_order: 3
 
 ## Context
 
-`Safire::Client` needs to support multiple healthcare authorization protocols (SMART on FHIR, UDAP) and, within SMART, multiple client authentication methods (public, confidential symmetric, confidential asymmetric). There are two ways to model this:
+`Safire::Client` needs to support multiple healthcare authorization protocols (SMART, UDAP) and, within SMART, multiple client authentication methods (public, confidential symmetric, confidential asymmetric). There are two ways to model this:
 
 **Option A — flat enum:** a single parameter enumerating every combination.
 

--- a/docs/adr/ADR-006-lazy-discovery.md
+++ b/docs/adr/ADR-006-lazy-discovery.md
@@ -13,7 +13,7 @@ nav_order: 6
 
 ## Context
 
-SMART on FHIR clients need the authorization server's endpoints (`authorization_endpoint`, `token_endpoint`) to build authorization URLs and request tokens. These are obtained by fetching `/.well-known/smart-configuration`. There are two approaches:
+SMART clients need the authorization server's endpoints (`authorization_endpoint`, `token_endpoint`) to build authorization URLs and request tokens. These are obtained by fetching `/.well-known/smart-configuration`. There are two approaches:
 
 **Option A — eager discovery:** fetch metadata in `Smart#initialize`.
 

--- a/docs/configuration/client-setup.md
+++ b/docs/configuration/client-setup.md
@@ -107,7 +107,7 @@ metadata = client.server_metadata
 client.client_type = :confidential_asymmetric if metadata.supports_asymmetric_auth?
 ```
 
-For a decision guide on which workflow to use, see [SMART on FHIR — Choosing a Workflow]({{ site.baseurl }}/smart-on-fhir/).
+For a decision guide on which workflow to use, see [SMART App Launch — Choosing a Workflow]({{ site.baseurl }}/smart-on-fhir/).
 
 ---
 
@@ -157,4 +157,4 @@ config.inspect
 ## Next Steps
 
 - [Logging]({{ site.baseurl }}/configuration/logging/) — configure Safire's logger and HTTP request logging
-- [SMART on FHIR Workflows]({{ site.baseurl }}/smart-on-fhir/) — step-by-step authorization flow guides
+- [SMART App Launch Workflows]({{ site.baseurl }}/smart-on-fhir/) — step-by-step authorization flow guides

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ permalink: /
 [![Gem Version](https://badge.fury.io/rb/safire.svg)](https://badge.fury.io/rb/safire)
 [![CI](https://github.com/vanessuniq/safire/workflows/CI/badge.svg)](https://github.com/vanessuniq/safire/actions)
 
-A lean Ruby gem implementing **[SMART on FHIR](https://hl7.org/fhir/smart-app-launch/)** and **[UDAP](https://hl7.org/fhir/us/udap-security/)** protocols for clients.
+A lean Ruby gem implementing **[SMART App Launch](https://hl7.org/fhir/smart-app-launch/)** and **[UDAP](https://hl7.org/fhir/us/udap-security/)** protocols for clients.
 
 ## Quick Navigation
 
@@ -18,7 +18,7 @@ A lean Ruby gem implementing **[SMART on FHIR](https://hl7.org/fhir/smart-app-la
 |---------|-------------|
 | [Getting Started]({{ site.baseurl }}/installation/) | Install Safire and quick start guide |
 | [Configuration]({{ site.baseurl }}/configuration/) | All configuration options and parameters |
-| [SMART on FHIR]({{ site.baseurl }}/smart-on-fhir/) | App Launch (Public, Confidential Symmetric, Confidential Asymmetric) and Backend Services |
+| [SMART]({{ site.baseurl }}/smart-on-fhir/) | App Launch (Public, Confidential Symmetric, Confidential Asymmetric) and Backend Services |
 | [UDAP]({{ site.baseurl }}/udap/) | UDAP protocol overview and planned support |
 | [Security Guide]({{ site.baseurl }}/security/) | HTTPS, credential protection, token storage, key rotation |
 | [Advanced Examples]({{ site.baseurl }}/advanced/) | Caching, multi-server, token management, complete Rails integration |
@@ -27,18 +27,14 @@ A lean Ruby gem implementing **[SMART on FHIR](https://hl7.org/fhir/smart-app-la
 
 ## Features
 
-### SMART on FHIR App Launch
+### SMART App Launch
 
 - Discovery (`/.well-known/smart-configuration`)
 - Public Client (PKCE)
 - Confidential Symmetric Client (client_secret + Basic Auth)
 - Confidential Asymmetric Client (private_key_jwt with RS384/ES384)
 - POST-Based Authorization
-
-### SMART on FHIR Backend Services
-
-- System-to-system token requests (`client_credentials` grant)
-- JWT assertion authentication (RS384/ES384) — no user interaction, redirect, or PKCE
+- Backend Services (client_credentials grant, JWT assertion, no user interaction or PKCE)
 
 ### UDAP
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -93,6 +93,6 @@ If you see an authorization endpoint URL, the gem is working. For troubleshootin
 | | |
 |-|-|
 | [Configuration]({{ site.baseurl }}/configuration/) | Client credentials, logging, and protocol selection |
-| [SMART on FHIR]({{ site.baseurl }}/smart-on-fhir/) | Authorization flows for public and confidential clients |
+| [SMART App Launch]({{ site.baseurl }}/smart-on-fhir/) | Authorization flows for public, confidential clients, and Backend Services |
 | [Security Guide]({{ site.baseurl }}/security/) | HTTPS requirements, credential protection, token storage |
 | [API Reference]({{ site.baseurl }}/api/){:target="_blank"} | Complete YARD documentation |

--- a/docs/smart-on-fhir/backend-services/index.md
+++ b/docs/smart-on-fhir/backend-services/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Backend Services Workflow
-parent: SMART on FHIR
+parent: SMART
 nav_order: 6
 has_children: true
 permalink: /smart-on-fhir/backend-services/

--- a/docs/smart-on-fhir/backend-services/token-request.md
+++ b/docs/smart-on-fhir/backend-services/token-request.md
@@ -2,7 +2,7 @@
 layout: default
 title: Token Request
 parent: Backend Services Workflow
-grand_parent: SMART on FHIR
+grand_parent: SMART
 nav_order: 1
 ---
 

--- a/docs/smart-on-fhir/confidential-asymmetric/authorization.md
+++ b/docs/smart-on-fhir/confidential-asymmetric/authorization.md
@@ -2,7 +2,7 @@
 layout: default
 title: Authorization
 parent: Confidential Asymmetric Client Workflow
-grand_parent: SMART on FHIR
+grand_parent: SMART
 nav_order: 1
 ---
 

--- a/docs/smart-on-fhir/confidential-asymmetric/index.md
+++ b/docs/smart-on-fhir/confidential-asymmetric/index.md
@@ -12,7 +12,7 @@ permalink: /smart-on-fhir/confidential-asymmetric/
 {: .no_toc }
 
 <div class="code-example" markdown="1">
-This guide demonstrates SMART on FHIR confidential asymmetric client integration in a **Rails application**. The patterns shown here can be adapted for Sinatra or other Ruby web frameworks.
+This guide demonstrates SMART App Launch confidential asymmetric client integration in a **Rails application**. The patterns shown here can be adapted for Sinatra or other Ruby web frameworks.
 </div>
 
 ---

--- a/docs/smart-on-fhir/confidential-asymmetric/index.md
+++ b/docs/smart-on-fhir/confidential-asymmetric/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Confidential Asymmetric Client Workflow
-parent: SMART on FHIR
+parent: SMART
 nav_order: 4
 has_children: true
 permalink: /smart-on-fhir/confidential-asymmetric/

--- a/docs/smart-on-fhir/confidential-asymmetric/token-exchange.md
+++ b/docs/smart-on-fhir/confidential-asymmetric/token-exchange.md
@@ -2,7 +2,7 @@
 layout: default
 title: Token Exchange & Refresh
 parent: Confidential Asymmetric Client Workflow
-grand_parent: SMART on FHIR
+grand_parent: SMART
 nav_order: 2
 ---
 

--- a/docs/smart-on-fhir/confidential-symmetric/authorization.md
+++ b/docs/smart-on-fhir/confidential-symmetric/authorization.md
@@ -2,7 +2,7 @@
 layout: default
 title: Authorization
 parent: Confidential Symmetric Client Workflow
-grand_parent: SMART on FHIR
+grand_parent: SMART
 nav_order: 1
 ---
 

--- a/docs/smart-on-fhir/confidential-symmetric/index.md
+++ b/docs/smart-on-fhir/confidential-symmetric/index.md
@@ -12,7 +12,7 @@ permalink: /smart-on-fhir/confidential-symmetric/
 {: .no_toc }
 
 <div class="code-example" markdown="1">
-This guide demonstrates SMART on FHIR confidential symmetric client integration in a **Rails application**. The patterns shown here can be adapted for Sinatra or other Ruby web frameworks.
+This guide demonstrates SMART App Launch confidential symmetric client integration in a **Rails application**. The patterns shown here can be adapted for Sinatra or other Ruby web frameworks.
 </div>
 
 ---

--- a/docs/smart-on-fhir/confidential-symmetric/index.md
+++ b/docs/smart-on-fhir/confidential-symmetric/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Confidential Symmetric Client Workflow
-parent: SMART on FHIR
+parent: SMART
 nav_order: 3
 has_children: true
 permalink: /smart-on-fhir/confidential-symmetric/

--- a/docs/smart-on-fhir/confidential-symmetric/token-exchange.md
+++ b/docs/smart-on-fhir/confidential-symmetric/token-exchange.md
@@ -2,7 +2,7 @@
 layout: default
 title: Token Exchange & Refresh
 parent: Confidential Symmetric Client Workflow
-grand_parent: SMART on FHIR
+grand_parent: SMART
 nav_order: 2
 ---
 

--- a/docs/smart-on-fhir/discovery/capability-checks.md
+++ b/docs/smart-on-fhir/discovery/capability-checks.md
@@ -2,7 +2,7 @@
 layout: default
 title: Capability Checks and Client Selection
 parent: SMART Discovery
-grand_parent: SMART on FHIR
+grand_parent: SMART
 nav_order: 2
 ---
 

--- a/docs/smart-on-fhir/discovery/index.md
+++ b/docs/smart-on-fhir/discovery/index.md
@@ -12,7 +12,7 @@ permalink: /smart-on-fhir/discovery/
 {: .no_toc }
 
 <div class="code-example" markdown="1">
-SMART on FHIR discovery allows clients to dynamically learn about a FHIR server's authorization capabilities before initiating the OAuth flow.
+SMART discovery allows clients to dynamically learn about a FHIR server's authorization capabilities before initiating the OAuth flow.
 </div>
 
 ---
@@ -54,7 +54,7 @@ begin
 rescue Safire::Errors::DiscoveryError => e
   case e.message
   when /404/
-    puts 'FHIR server does not support SMART on FHIR'
+    puts 'FHIR server does not support SMART App Launch'
   when /timeout/i
     puts 'Discovery request timed out'
   when /expected JSON object/

--- a/docs/smart-on-fhir/discovery/index.md
+++ b/docs/smart-on-fhir/discovery/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: SMART Discovery
-parent: SMART on FHIR
+parent: SMART
 nav_order: 1
 has_children: true
 permalink: /smart-on-fhir/discovery/

--- a/docs/smart-on-fhir/discovery/metadata.md
+++ b/docs/smart-on-fhir/discovery/metadata.md
@@ -2,7 +2,7 @@
 layout: default
 title: Metadata Fields and Validation
 parent: SMART Discovery
-grand_parent: SMART on FHIR
+grand_parent: SMART
 nav_order: 1
 ---
 

--- a/docs/smart-on-fhir/index.md
+++ b/docs/smart-on-fhir/index.md
@@ -1,14 +1,14 @@
 ---
 layout: default
-title: SMART on FHIR
+title: SMART
 nav_order: 4
 has_children: true
 permalink: /smart-on-fhir/
 ---
 
-# SMART on FHIR
+# SMART App Launch
 
-This section provides step-by-step guides for implementing SMART on FHIR authorization flows with Safire.
+This section provides step-by-step guides for implementing SMART authorization flows with Safire.
 
 ## Available Workflows
 

--- a/docs/smart-on-fhir/post-based-authorization.md
+++ b/docs/smart-on-fhir/post-based-authorization.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: POST-Based Authorization
-parent: SMART on FHIR
+parent: SMART
 nav_order: 5
 has_toc: true
 ---

--- a/docs/smart-on-fhir/public-client/authorization.md
+++ b/docs/smart-on-fhir/public-client/authorization.md
@@ -2,7 +2,7 @@
 layout: default
 title: Authorization
 parent: Public Client Workflow
-grand_parent: SMART on FHIR
+grand_parent: SMART
 nav_order: 1
 ---
 

--- a/docs/smart-on-fhir/public-client/index.md
+++ b/docs/smart-on-fhir/public-client/index.md
@@ -12,7 +12,7 @@ permalink: /smart-on-fhir/public-client/
 {: .no_toc }
 
 <div class="code-example" markdown="1">
-This guide demonstrates SMART on FHIR public client integration in a **Rails application**. The patterns shown here can be adapted for Sinatra or other Ruby web frameworks.
+This guide demonstrates SMART App Launch public client integration in a **Rails application**. The patterns shown here can be adapted for Sinatra or other Ruby web frameworks.
 </div>
 
 ---

--- a/docs/smart-on-fhir/public-client/index.md
+++ b/docs/smart-on-fhir/public-client/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Public Client Workflow
-parent: SMART on FHIR
+parent: SMART
 nav_order: 2
 has_children: true
 permalink: /smart-on-fhir/public-client/

--- a/docs/smart-on-fhir/public-client/token-exchange.md
+++ b/docs/smart-on-fhir/public-client/token-exchange.md
@@ -2,7 +2,7 @@
 layout: default
 title: Token Exchange & Refresh
 parent: Public Client Workflow
-grand_parent: SMART on FHIR
+grand_parent: SMART
 nav_order: 2
 ---
 

--- a/docs/troubleshooting/auth-errors.md
+++ b/docs/troubleshooting/auth-errors.md
@@ -26,7 +26,7 @@ Safire::Errors::DiscoveryError: Failed to discover SMART configuration from
 https://fhir.example.com/.well-known/smart-configuration (HTTP 404)
 ```
 
-**Causes:** the server does not support SMART on FHIR, `base_url` includes an extra path segment, or the server uses a non-standard discovery path.
+**Causes:** the server does not support SMART App Launch, `base_url` includes an extra path segment, or the server uses a non-standard discovery path.
 
 Verify the endpoint manually:
 

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -11,7 +11,7 @@ permalink: /troubleshooting/
 {: .no_toc }
 
 <div class="code-example" markdown="1">
-Common issues and solutions when integrating SMART on FHIR with Safire.
+Common issues and solutions when integrating with Safire.
 </div>
 
 ## Table of contents

--- a/docs/udap.md
+++ b/docs/udap.md
@@ -24,7 +24,7 @@ nav_order: 5
 
 UDAP (Unified Data Access Profiles) is a security framework for healthcare data exchange defined by the [UDAP Security Implementation Guide](https://hl7.org/fhir/us/udap-security/). It extends standard OAuth 2.0 with X.509 certificate-based identity, dynamic client registration, and trust community models — designed primarily for backend system-to-system integration and cross-organizational data access.
 
-UDAP is a separate protocol from SMART on FHIR. In Safire, it is selected via `protocol: :udap` rather than a `client_type:`. Watch the [GitHub repository](https://github.com/vanessuniq/safire) for release announcements.
+UDAP is a separate protocol from SMART. In Safire, it is selected via `protocol: :udap` rather than a `client_type:`. Watch the [GitHub repository](https://github.com/vanessuniq/safire) for release announcements.
 
 ---
 
@@ -59,9 +59,9 @@ UDAP is a separate protocol from SMART on FHIR. In Safire, it is selected via `p
 
 ---
 
-## Comparison with SMART on FHIR
+## Comparison with SMART
 
-| Feature | SMART on FHIR | UDAP |
+| Feature | SMART | UDAP |
 |---------|---------------|------|
 | Primary use case | User-facing apps, EHR launch | B2B, backend services, cross-org access |
 | Client registration | Pre-registered per server, optional DCR (recommended) | Dynamic (DCR) or pre-registered |

--- a/examples/sinatra_app/README.md
+++ b/examples/sinatra_app/README.md
@@ -1,6 +1,6 @@
 # Safire Demo Application
 
-A Sinatra-based web application that demonstrates the features of the Safire gem for SMART on FHIR authorization.
+A Sinatra-based web application that demonstrates the features of the Safire gem for SMART authorization.
 
 ## Features
 

--- a/examples/sinatra_app/views/index.erb
+++ b/examples/sinatra_app/views/index.erb
@@ -1,6 +1,6 @@
 <h1>Welcome to Safire Demo</h1>
 
-<p>This application demonstrates the features of the <strong>Safire</strong> gem - a SMART on FHIR & UDAP Ruby library.</p>
+<p>This application demonstrates the features of the <strong>Safire</strong> gem - a SMART & UDAP Ruby library.</p>
 
 <section class="info-box">
   <h2>Getting Started</h2>

--- a/examples/sinatra_app/views/layout.erb
+++ b/examples/sinatra_app/views/layout.erb
@@ -27,7 +27,7 @@
   </main>
 
   <footer>
-    <p>Powered by <a href="https://github.com/vanessuniq/safire" target="_blank">Safire</a> - SMART on FHIR Ruby Client</p>
+    <p>Powered by <a href="https://github.com/vanessuniq/safire" target="_blank">Safire</a> - SMART & UDAP Ruby Client</p>
   </footer>
 </body>
 </html>

--- a/examples/sinatra_app/views/servers/new.erb
+++ b/examples/sinatra_app/views/servers/new.erb
@@ -1,6 +1,6 @@
 <h1>Add New Server</h1>
 
-<p>Configure a new FHIR server for testing SMART on FHIR authorization flows.</p>
+<p>Configure a new FHIR server for testing SMART App Launch authorization flows.</p>
 
 <form action="/servers" method="post" class="server-form">
   <%= erb :'servers/_form' %>

--- a/examples/sinatra_app/views/servers/show.erb
+++ b/examples/sinatra_app/views/servers/show.erb
@@ -32,7 +32,7 @@
 
 <section class="demo-actions">
   <h2>Demo Actions</h2>
-  <p>Select an action to demonstrate Safire's SMART on FHIR capabilities:</p>
+  <p>Select an action to demonstrate Safire's SMART App Launch capabilities:</p>
 
   <div class="action-cards">
     <div class="action-card">

--- a/lib/safire/client.rb
+++ b/lib/safire/client.rb
@@ -1,7 +1,7 @@
 module Safire
-  # Unified facade client for SMART on FHIR and (future) UDAP authorization flows.
+  # Unified facade client for SMART and (future) UDAP authorization flows.
   #
-  # This class is the main entry point for integrating SMART on FHIR authorization via Safire.
+  # This class is the main entry point for integrating SMART authorization via Safire.
   # It supports discovery of server metadata and provides a unified interface for building
   # authorization URLs, exchanging authorization codes, refreshing tokens, and requesting
   # backend services access tokens (client_credentials grant).

--- a/lib/safire/client_config.rb
+++ b/lib/safire/client_config.rb
@@ -1,6 +1,6 @@
 module Safire
   # Client configuration entity providing necessary attributes to perform different
-  # auth flows such as SMART on FHIR puclic, confidential symmetric, confidential asymmetric
+  # auth flows such as SMART public, confidential symmetric, confidential asymmetric
   # clients, and backend services.
   # The ClientConfig instance is passed to Safire::Client upon initialization.
   #

--- a/lib/safire/jwt_assertion.rb
+++ b/lib/safire/jwt_assertion.rb
@@ -3,7 +3,7 @@ require 'openssl'
 require 'securerandom'
 
 module Safire
-  # Generates JWT client assertions for SMART on FHIR confidential asymmetric authentication.
+  # Generates JWT client assertions for SMART confidential asymmetric authentication.
   #
   # This class creates signed JWTs according to the SMART App Launch STU 2.2.0 specification
   # for private_key_jwt client authentication.

--- a/lib/safire/protocols/smart.rb
+++ b/lib/safire/protocols/smart.rb
@@ -324,7 +324,7 @@ module Safire
         return true if %w[Bearer bearer].include?(response['token_type'])
 
         expected = if flow == :backend_services
-                     "'bearer' (SMART Backend Services spec)"
+                     "'bearer' (SMART App Launch Backend Services)"
                    else
                      "'Bearer' (SMART App Launch spec)"
                    end

--- a/lib/safire/protocols/smart.rb
+++ b/lib/safire/protocols/smart.rb
@@ -1,6 +1,6 @@
 module Safire
   module Protocols
-    # SMART on FHIR OAuth2 implementation for app launch (authorization code, token exchange, refresh)
+    # SMART OAuth2 implementation for app launch (authorization code, token exchange, refresh)
     # and backend services (client credentials) flows.
     #
     # This is an internal class used exclusively by {Safire::Client}. Do not instantiate it directly —

--- a/lib/safire/protocols/smart_metadata.rb
+++ b/lib/safire/protocols/smart_metadata.rb
@@ -1,7 +1,7 @@
 module Safire
   module Protocols
-    # SMART Metadata obtained from SMART on FHIR discovery endpoint. Attributes are defined
-    # as per [SMART on FHIR specification](https://build.fhir.org/ig/HL7/smart-app-launch/conformance.html#using-well-known)
+    # SMART Metadata obtained from SMART discovery endpoint. Attributes are defined
+    # as per [SMART App Launch specification](https://build.fhir.org/ig/HL7/smart-app-launch/conformance.html#using-well-known)
     #
     # @!attribute [r] issuer
     #   @return [String] conveying this system’s OpenID Connect Issuer URL. Required if the server’s

--- a/safire.gemspec
+++ b/safire.gemspec
@@ -6,8 +6,8 @@ Gem::Specification.new do |spec|
   spec.version               = Safire::VERSION
   spec.authors               = ['Vanessa Fotso']
   spec.email                 = ['vanessuniq@gmail.com']
-  spec.summary               = 'SMART on FHIR and UDAP implementation for Ruby'
-  spec.description           = 'A Ruby gem implementing SMART on FHIR and UDAP protocols for clients.'
+  spec.summary               = 'SMART App Launch and UDAP implementation for Ruby'
+  spec.description           = 'A Ruby gem implementing SMART App Launch (v2.2.0) and UDAP protocols for clients.'
   spec.homepage              = 'https://github.com/vanessuniq/safire'
   spec.license               = 'Apache-2.0'
   spec.required_ruby_version = Gem::Requirement.new('>= 4.0.2')

--- a/spec/safire/protocols/smart_spec.rb
+++ b/spec/safire/protocols/smart_spec.rb
@@ -963,7 +963,7 @@ RSpec.describe Safire::Protocols::Smart do
           response = backend_response.merge('token_type' => 'BEARER')
           result = client.token_response_valid?(response, flow: :backend_services)
           expect(result).to be(false)
-          expect(Safire.logger).to have_received(:warn).with(/token_type.*SMART Backend Services spec/)
+          expect(Safire.logger).to have_received(:warn).with(/token_type.*SMART App Launch Backend Services/)
         end
       end
     end


### PR DESCRIPTION
## Summary

- Replaces incorrect "SMART on FHIR" spec name with "SMART App Launch" per the [HL7 Implementation Guide](https://hl7.org/fhir/smart-app-launch/index.html) across all user-facing content (README, docs, gemspec, demo app)
- Merges the "SMART on FHIR Backend Services" feature heading under the "SMART App Launch" section in README, ROADMAP, and docs — Backend Services is a workflow within SMART App Launch, not a separate spec
- Uses "SMART" as shorthand in source code YARD comments; uses "SMART App Launch" in user-facing prose and when hyperlinking the spec
- Updates one warning message string (`token_type` non-compliance) and its matching spec regex to remove the implication that Backend Services is a separate spec
- No API, logic, file path, or URL changes

## Test plan

- [x] `bundle exec rspec` — 338 examples, 0 failures
- [x] `bundle exec rubocop` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)