### PR TITLE
Make Safire easier to find when searching for SMART and UDAP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Coverage](https://codecov.io/gh/vanessuniq/safire/branch/main/graph/badge.svg)](https://codecov.io/gh/vanessuniq/safire)
 [![Documentation](https://img.shields.io/badge/docs-yard-blue.svg)](https://vanessuniq.github.io/safire)
 
-Safire is a lean Ruby library that implements [SMART App Launch](https://hl7.org/fhir/smart-app-launch/) and [UDAP](https://hl7.org/fhir/us/udap-security/) client protocols for healthcare applications.
+Safire is a Ruby gem implementing the [SMART App Launch 2.2.0](https://hl7.org/fhir/smart-app-launch/) specification and the [UDAP Security](https://hl7.org/fhir/us/udap-security/) protocol for healthcare client applications. It handles OAuth 2.0 authorization against HL7 FHIR servers, covering PKCE, private key JWT assertions, and the Backend Services system-to-system flow, so you can focus on your application rather than protocol plumbing.
 
 ---
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -19,7 +19,10 @@
 # in the templates via {{ site.myvariable }}.
 
 title: Safire Documentation
+tagline: Ruby gem for SMART App Launch and UDAP protocols
 description: SMART App Launch and UDAP implementation library for Ruby
+author: Vanessa Fotso
+lang: en-US
 baseurl: /safire
 url: https://vanessuniq.github.io
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,7 @@ layout: default
 title: Home
 nav_order: 1
 permalink: /
+description: "Safire is a Ruby gem implementing SMART App Launch 2.2.0 and UDAP Security protocols for healthcare client applications, with full support for OAuth 2.0 authorization against HL7 FHIR servers."
 ---
 
 # Safire Documentation

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,6 +2,7 @@
 layout: default
 title: Installation
 nav_order: 2
+description: "How to install the Safire Ruby gem and get started with SMART App Launch and UDAP authorization in your healthcare application."
 ---
 
 # Installation

--- a/docs/smart-on-fhir/index.md
+++ b/docs/smart-on-fhir/index.md
@@ -4,6 +4,7 @@ title: SMART
 nav_order: 4
 has_children: true
 permalink: /smart-on-fhir/
+description: "Step-by-step guides for SMART App Launch OAuth 2.0 flows in Ruby, covering public client (PKCE), confidential symmetric, confidential asymmetric (private_key_jwt), and Backend Services (system-to-system)."
 ---
 
 # SMART App Launch

--- a/docs/udap.md
+++ b/docs/udap.md
@@ -2,6 +2,7 @@
 layout: default
 title: UDAP
 nav_order: 5
+description: "Overview of planned UDAP Security protocol support in Safire, including UDAP discovery, dynamic client registration, JWT client authentication, and tiered OAuth for healthcare data exchange."
 ---
 
 # UDAP

--- a/safire.gemspec
+++ b/safire.gemspec
@@ -7,7 +7,11 @@ Gem::Specification.new do |spec|
   spec.authors               = ['Vanessa Fotso']
   spec.email                 = ['vanessuniq@gmail.com']
   spec.summary               = 'SMART App Launch and UDAP implementation for Ruby'
-  spec.description           = 'A Ruby gem implementing SMART App Launch (v2.2.0) and UDAP protocols for clients.'
+  spec.description           = 'A Ruby gem implementing the SMART App Launch 2.2.0 specification and UDAP Security ' \
+                               'protocol for healthcare client applications. It supports OAuth 2.0 authorization ' \
+                               'against HL7 FHIR servers, including PKCE, private_key_jwt assertions (RS384 and ' \
+                               'ES384), confidential client flows, and the Backend Services system-to-system ' \
+                               '(client_credentials) grant.'
   spec.homepage              = 'https://github.com/vanessuniq/safire'
   spec.license               = 'Apache-2.0'
   spec.required_ruby_version = Gem::Requirement.new('>= 4.0.2')


### PR DESCRIPTION
When developers search for Ruby tools to work with SMART or UDAP, Safire should show up. This PR improves the gem listing on RubyGems.org, the documentation site metadata, and the README introduction so that search engines and developer platforms surface Safire for the right queries. No code was changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)