### PR TITLE
Fix broken YARD API docs nav links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Corrected spec name throughout: "SMART on FHIR" → "SMART App Launch" per the
-  [SMART App Launch IG](https://hl7.org/fhir/smart-app-launch/); Backend Services is
-  presented as a feature within the spec, not a separate spec
-
 ### Added
 
 - SMART Backend Services Authorization flow (`client_credentials` grant) via
@@ -34,10 +28,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Corrected spec name throughout: "SMART on FHIR" → "SMART App Launch" per the
+  [SMART App Launch IG](https://hl7.org/fhir/smart-app-launch/); Backend Services is
+  presented as a feature within the spec, not a separate spec
 - `redirect_uri` and `authorization_endpoint` are now optional in `Safire::Protocols::Smart`;
   both are validated only when `authorization_url` is called (app launch flow)
 - `redirect_uri` is now optional in `Safire::ClientConfig` to support backend services
   clients that operate without a redirect URI; the field is still validated when provided
+
+### Fixed
+
+- YARD API docs nav links broken after in-page navigation: relative hrefs from the nav
+  iframe were resolved against the parent window URL (which changes on each navigation)
+  instead of the iframe base; `bin/docs` now patches the generated `full_list.js` to
+  resolve links to absolute URLs before messaging the parent
 
 ## [0.1.0] - 2026-03-25
 

--- a/bin/docs
+++ b/bin/docs
@@ -1,2 +1,15 @@
 #!/bin/sh
 bundle exec yard doc --no-private --output-dir docs/api -m markdown
+
+# Fix YARD navigation bug: nav iframe links are relative to the iframe base URL,
+# but app.js resolves them against the parent window URL (which changes on navigation).
+# Convert them to absolute URLs in the iframe before posting the navigate message.
+ruby -e '
+  file = "docs/api/js/full_list.js"
+  content = File.read(file)
+  content.sub!(
+    "url: \$clicked.find(\x27.object_link a\x27).attr(\x27href\x27),",
+    "url: new URL(\$clicked.find(\x27.object_link a\x27).attr(\x27href\x27), window.location.href).href,"
+  )
+  File.write(file, content)
+'

--- a/lib/safire/client_config.rb
+++ b/lib/safire/client_config.rb
@@ -18,10 +18,10 @@ module Safire
   #     Optionally provided.
   # @!attribute [r] authorization_endpoint
   #   @return [String] URL of the server’s OAuth2 Authorization Endpoint.
-  # =>  Optional, will be retrieved from the well-known smart-configuration if not provided
+  #   =>  Optional, will be retrieved from the well-known smart-configuration if not provided
   # @!attribute [r] token_endpoint
   #   @return [String] URL of the server's OAuth2 Token Endpoint.
-  # =>  Optional, will be retrieved from the well-known smart-configuration if not provided
+  #   =>  Optional, will be retrieved from the well-known smart-configuration if not provided
   # @!attribute [r] private_key
   #   @return [OpenSSL::PKey::RSA, OpenSSL::PKey::EC, String, nil] the private key for signing
   #     JWT assertions in confidential asymmetric auth. Can be an OpenSSL key object or PEM string.


### PR DESCRIPTION
## Summary

The links in the YARD API docs sidebar navigation were broken after any in-page navigation. Clicking a nav item would construct an incorrect URL by resolving the relative href against the current parent page URL instead of the nav iframe's base URL, sending the browser to a nonexistent path.

The fix patches `bin/docs` to update the generated `full_list.js` after each YARD run, converting relative hrefs to absolute URLs before they are posted to the parent window. This ensures navigation always resolves from the correct base regardless of where the parent page currently is.

## Test plan

- [x] Run `bin/docs` and confirm it completes without error
- [x] Serve the docs (`cd docs && bundle exec jekyll serve`) and open the API docs
- [x] Navigate to any class page from the sidebar
- [x] Continue clicking other sidebar items and confirm each loads the correct page with no 404 errors in the server log
- [x] Run `bin/docs` a second time and confirm the fix is still applied afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)