### PR TITLE
Fix broken Getting Started and UDAP links in docs nav

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,6 +2,7 @@
 layout: default
 title: Installation
 nav_order: 2
+permalink: /installation/
 description: "How to install the Safire Ruby gem and get started with SMART App Launch and UDAP authorization in your healthcare application."
 ---
 

--- a/docs/udap.md
+++ b/docs/udap.md
@@ -2,6 +2,7 @@
 layout: default
 title: UDAP
 nav_order: 5
+permalink: /udap/
 description: "Overview of planned UDAP Security protocol support in Safire, including UDAP discovery, dynamic client registration, JWT client authentication, and tiered OAuth for healthcare data exchange."
 ---
 


### PR DESCRIPTION
The Getting Started and UDAP links in the Quick Navigation table on the docs index page were returning 404. Both `installation.md` and `udap.md` were missing explicit `permalink` declarations in their front matter, so Jekyll was not serving them at the `/installation/` and `/udap/` paths the index links expected. This PR adds the missing permalinks to match the pattern already used by the other standalone doc pages.