### PR TITLE
Make client_id optional at initialization, validated per flow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,45 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Please review this pull request for the Safire Ruby gem — an OAuth 2.0 client
+            library implementing SMART App Launch 2.2.0 and UDAP Security for healthcare
+            FHIR applications.
+
+            Focus on:
+            - Correctness and protocol compliance (OAuth 2.0, SMART App Launch, RFC 7591)
+            - Security: credential handling, token exposure, input validation at trust boundaries
+            - Ruby quality and elegance — flag anything that could be simpler or cleaner
+            - Rubocop patterns: guard clause spacing, single quotes, `described_class` in specs,
+              `receive_messages` for multiple stubs, `instance_double` over `double`
+            - Test coverage: edge cases, error paths, and correct layer (do not test ClientConfig
+              behaviour from Smart specs, and vice versa)
+            - YARD docs: accuracy and completeness for any public API changes
+            - CHANGELOG: does the PR update `[Unreleased]` for any user-facing change?
+
+            Use `gh pr comment` for overall feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`)
+            for specific line-level issues.
+            Only post GitHub comments — do not reply as messages.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `client_id` is now optional at `ClientConfig` and `Protocols::Smart` initialization;
+  all authorization flows (`authorization_url`, `request_access_token`, `refresh_token`,
+  `request_backend_token`) validate its presence at call time and raise
+  `Safire::Errors::ConfigurationError` if it is absent
+- `Protocols::Smart#token_endpoint` now raises `Safire::Errors::DiscoveryError` when
+  the discovery response does not include a `token_endpoint` field, rather than silently
+  passing `nil` to the HTTP client
+
 ## [0.2.0] - 2026-04-04
 
 ### Added

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -32,14 +32,7 @@ class SmartMetadataService
 
   def self.fetch(base_url)
     Rails.cache.fetch("smart_metadata:#{base_url}", expires_in: CACHE_TTL) do
-      config = Safire::ClientConfig.new(
-        base_url:     base_url,
-        client_id:    'discovery_only',
-        redirect_uri: 'https://example.com',
-        scopes:       []
-      )
-      client = Safire::Client.new(config)
-      client.server_metadata.to_hash
+      Safire::Client.new({ base_url: base_url }).server_metadata.to_hash
     end
   end
 

--- a/docs/configuration/client-setup.md
+++ b/docs/configuration/client-setup.md
@@ -45,6 +45,9 @@ config = Safire::ClientConfig.new(
 client = Safire::Client.new(config)
 ```
 
+{: .note }
+> `client_id` is the only authorization parameter validated at call time rather than at construction. `authorization_url`, `request_access_token`, `refresh_token`, and `request_backend_token` each raise `Safire::Errors::ConfigurationError` if `client_id` is absent when called. This means you can build a `ClientConfig` before a `client_id` has been issued — for example, when registering with a new server before any flow begins.
+
 ---
 
 ## Protocol and Client Type

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -41,12 +41,12 @@ flowchart TD
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `base_url` | String | Yes | — | FHIR server base URL |
-| `client_id` | String | Yes | — | OAuth2 client identifier |
-| `redirect_uri` | String | Yes | — | Registered callback URL |
+| `client_id` | String | No | — | OAuth2 client identifier — required by all authorization flows; validated at call time, not at construction |
+| `redirect_uri` | String | No | — | Registered callback URL — required for App Launch flows; not used in Backend Services |
 | `protocol:` | Symbol | No | `:smart` | Authorization protocol — `:smart` or `:udap` |
 | `client_type:` | Symbol | No | `:public` | SMART client type — `:public`, `:confidential_symmetric`, or `:confidential_asymmetric` |
 | `client_secret` | String | No | — | Required for `:confidential_symmetric` |
-| `private_key` | OpenSSL::PKey / String | No | — | RSA/EC private key; required for `:confidential_asymmetric` |
+| `private_key` | OpenSSL::PKey / String | No | — | RSA/EC private key; required for `:confidential_asymmetric` and Backend Services |
 | `kid` | String | No | — | Key ID matching the public key registered with the server |
 | `jwt_algorithm` | String | No | auto | `RS384` or `ES384`; auto-detected from key type |
 | `jwks_uri` | String | No | — | URL to client's public JWKS, included as `jku` in JWT header |

--- a/docs/smart-on-fhir/backend-services/token-request.md
+++ b/docs/smart-on-fhir/backend-services/token-request.md
@@ -117,7 +117,7 @@ end
 begin
   token_data = client.request_backend_token
 rescue Safire::Errors::ConfigurationError => e
-  # private_key or kid missing from config and not passed at call time
+  # client_id, private_key, or kid missing — only private_key and kid can be overridden at call time
   Rails.logger.error("Backend services misconfigured: #{e.message}")
   raise
 rescue Safire::Errors::TokenError => e

--- a/docs/troubleshooting/auth-errors.md
+++ b/docs/troubleshooting/auth-errors.md
@@ -75,6 +75,26 @@ The response must be a JSON object (`{...}`) with at least `authorization_endpoi
 
 ## Authorization Errors
 
+### `ConfigurationError`: Missing `client_id`
+
+```
+Safire::Errors::ConfigurationError: Configuration missing: client_id
+```
+
+`client_id` is optional at construction but required by every authorization method. It is validated at call time, not when the client is created. Ensure `client_id` is set in `ClientConfig` before calling any flow method:
+
+```ruby
+config = Safire::ClientConfig.new(
+  base_url:  'https://fhir.example.com',
+  client_id: ENV.fetch('SMART_CLIENT_ID'),
+  # ...
+)
+```
+
+This error is raised by `authorization_url`, `request_access_token`, `refresh_token`, and `request_backend_token`.
+
+---
+
 ### `ConfigurationError`: Missing scopes
 
 ```

--- a/lib/safire/client.rb
+++ b/lib/safire/client.rb
@@ -9,7 +9,8 @@ module Safire
   # Configuration is provided via {Safire::ClientConfig} or a Hash. Key attributes:
   #
   # * :base_url [String] FHIR base URL used for SMART discovery
-  # * :client_id [String] OAuth2 client identifier
+  # * :client_id [String, nil] OAuth2 client identifier — optional at initialization;
+  #     required by all authorization flows and validated at call time
   # * :redirect_uri [String] redirect URI registered with the authorization server;
   #     required for app launch, not required for backend services
   # * :scopes [Array<String>] default scopes; falls back to +["system/*.rs"]+ for

--- a/lib/safire/client_config.rb
+++ b/lib/safire/client_config.rb
@@ -10,7 +10,10 @@ module Safire
   #   @return [String] the URL of the FHIR service from which the app wishes to retrieve FHIR data.
   #     Optionally provided. Will default to `base_url` if not provided.
   # @!attribute [r] client_id
-  #   @return [String] the client identifier issued to the app by the authorization server
+  #   @return [String, nil] the client identifier issued to the app by the authorization server.
+  #     Optional at initialization — required by all authorization flows. Omit only when
+  #     performing Dynamic Client Registration (RFC 7591) to obtain a +client_id+ before
+  #     any flow begins.
   # @!attribute [r] redirect_uri
   #   @return [String] the redirect URI registered by the app with the authorization server
   # @!attribute [r] scopes
@@ -155,15 +158,9 @@ module Safire
     end
 
     def validate!
-      required_attrs = %i[base_url client_id]
-      nil_vars = required_attrs.select { |attr| send(attr).nil? }
+      raise Errors::ConfigurationError.new(missing_attributes: [:base_url]) if base_url.nil?
 
-      if nil_vars.empty?
-        validate_uris!
-        return
-      end
-
-      raise Errors::ConfigurationError.new(missing_attributes: nil_vars)
+      validate_uris!
     end
   end
 end

--- a/lib/safire/protocols/smart.rb
+++ b/lib/safire/protocols/smart.rb
@@ -13,9 +13,6 @@ module Safire
     #
     # @note For internal use by {Safire::Client} only.
     # @api private
-    #
-    # @raise [Safire::Errors::ConfigurationError]
-    #   if required configuration attributes are missing or invalid
     class Smart
       include Behaviours
 
@@ -25,9 +22,9 @@ module Safire
         private_key kid jwt_algorithm jwks_uri
       ].freeze
 
-      # Attributes that are not required during validation
+      # Attributes that are not required during initialization; validated per-flow when needed
       OPTIONAL_ATTRIBUTES = %i[
-        redirect_uri authorization_endpoint scopes client_secret private_key kid jwt_algorithm jwks_uri
+        client_id redirect_uri authorization_endpoint scopes client_secret private_key kid jwt_algorithm jwks_uri
       ].freeze
 
       WELL_KNOWN_PATH = '/.well-known/smart-configuration'.freeze
@@ -42,8 +39,6 @@ module Safire
         @client_type = client_type.to_sym
         @http_client = Safire::HTTPClient.new
         @issuer ||= base_url
-
-        validate!
       end
 
       def authorization_endpoint
@@ -51,10 +46,10 @@ module Safire
       end
 
       def token_endpoint
-        @token_endpoint ||= server_metadata.token_endpoint
+        @token_endpoint ||= discovered_token_endpoint
       end
 
-      # Retrieves and parses SMART on FHIR configuration metadata from the FHIR server.
+      # Retrieves and parses SMART configuration metadata from the FHIR server.
       #
       # This method sends a GET request to the server's
       # +/.well-known/smart-configuration+ endpoint, validates the response format,
@@ -93,12 +88,13 @@ module Safire
       #   * :state [String] state parameter for CSRF protection; store and verify on callback
       #   * :code_verifier [String] PKCE code verifier for the token exchange
       #   * :params [Hash] (POST only) authorization parameters to submit as the request body
-      # @raise [Errors::ConfigurationError] if method is invalid, scopes are missing,
+      # @raise [Errors::ConfigurationError] if method is invalid, +client_id+/scopes are missing,
       #   or +redirect_uri+ / +authorization_endpoint+ are not configured or resolvable via discovery
       def authorization_url(launch: nil, custom_scopes: nil, method: :get)
         method = method.to_sym
         custom_scopes ||= scopes
         validate_authorization_method(method)
+        validate_client_id!
         validate_presence_of_scopes(custom_scopes)
         validate_app_launch_attrs!
 
@@ -125,10 +121,13 @@ module Safire
       #   * "refresh_token"           [String] refresh token, if issued (optional)
       #   * "authorization_details"   [Hash] additional authorization details, if provided (optional)
       #   * Context parameters such as "patient" or "encounter" MAY be present, depending on server behavior.
+      # @raise [Safire::Errors::ConfigurationError] if +client_id+ is missing,
+      #   or if +private_key+/+kid+ are absent for +:confidential_asymmetric+
       # @raise [Safire::Errors::TokenError] if the request fails or response is invalid.
       # @raise [Safire::Errors::NetworkError] on connection failure, timeout, or SSL error.
       def request_access_token(code:, code_verifier:, client_secret: self.client_secret,
                                private_key: self.private_key, kid: self.kid)
+        validate_client_id!
         Safire.logger.info('Requesting access token using authorization code...')
 
         response = @http_client.post(
@@ -152,10 +151,13 @@ module Safire
       # @param kid [String, nil] optional; key ID for asymmetric auth (overrides configured)
       # @return [Hash] token response parsed from the authorization server.
       #   See {#request_access_token} for token response format.
+      # @raise [Safire::Errors::ConfigurationError] if +client_id+ is missing,
+      #   or if +private_key+/+kid+ are absent for +:confidential_asymmetric+
       # @raise [Safire::Errors::TokenError] if the refresh request fails or the response is invalid.
       # @raise [Safire::Errors::NetworkError] on connection failure, timeout, or SSL error.
       def refresh_token(refresh_token:, scopes: nil, client_secret: self.client_secret,
                         private_key: self.private_key, kid: self.kid)
+        validate_client_id!
         Safire.logger.info('Refreshing access token...')
 
         response = @http_client.post(
@@ -188,11 +190,12 @@ module Safire
       #   * "token_type"  [String] token type, value +"Bearer"+ (required)
       #   * "expires_in"  [Integer] lifetime of the access token in seconds (required per Backend Services spec)
       #   * "scope"       [String] authorized scopes (required)
-      # @raise [Safire::Errors::ConfigurationError] if private_key or kid are missing
+      # @raise [Safire::Errors::ConfigurationError] if +client_id+, +private_key+, or +kid+ are missing
       # @raise [Safire::Errors::TokenError] if the server returns an error or invalid response
       # @raise [Safire::Errors::NetworkError] on connection failure, timeout, or SSL error
       def request_backend_token(scopes: nil, private_key: self.private_key, kid: self.kid)
         scopes ||= self.scopes.presence || ['system/*.rs']
+        validate_client_id!
 
         Safire.logger.info('Requesting backend services access token (client_credentials grant)...')
 
@@ -246,13 +249,6 @@ module Safire
 
       private
 
-      def validate!
-        missing = (ATTRIBUTES - OPTIONAL_ATTRIBUTES).select { |attr| send(attr).blank? }
-        return if missing.empty?
-
-        raise Errors::ConfigurationError.new(missing_attributes: missing)
-      end
-
       def validate_authorization_method(method)
         return if %i[get post].include?(method)
 
@@ -280,6 +276,12 @@ module Safire
         return if missing.empty?
 
         raise Errors::ConfigurationError.new(missing_attributes: missing)
+      end
+
+      def validate_client_id!
+        return if client_id.present?
+
+        raise Errors::ConfigurationError.new(missing_attributes: [:client_id])
       end
 
       def validate_presence_of_scopes(scopes_value)
@@ -380,7 +382,7 @@ module Safire
       def client_auth_params(private_key:, kid:)
         case client_type
         when :public
-          { client_id: client_id }
+          { client_id: }
         when :confidential_asymmetric
           jwt_assertion_params(private_key:, kid:)
         else
@@ -408,10 +410,10 @@ module Safire
         validate_asymmetric_credentials!(private_key, kid)
 
         assertion = Safire::JWTAssertion.new(
-          client_id: client_id,
-          token_endpoint: token_endpoint,
-          private_key: private_key,
-          kid: kid,
+          client_id:,
+          token_endpoint:,
+          private_key:,
+          kid:,
           algorithm: jwt_algorithm,
           jku: jwks_uri
         )
@@ -443,6 +445,16 @@ module Safire
         )
       rescue JSON::ParserError
         Errors::TokenError.new(status:)
+      end
+
+      def discovered_token_endpoint
+        endpoint = server_metadata.token_endpoint
+        return endpoint if endpoint.present?
+
+        raise Errors::DiscoveryError.new(
+          endpoint: well_known_endpoint,
+          error_description: "response missing required field 'token_endpoint'"
+        )
       end
 
       def well_known_endpoint

--- a/spec/safire/client_config_spec.rb
+++ b/spec/safire/client_config_spec.rb
@@ -20,11 +20,13 @@ RSpec.describe Safire::ClientConfig do
       expect { described_class.new(valid_attrs.except(:redirect_uri)) }.not_to raise_error
     end
 
-    %i[base_url client_id].each do |attr|
-      it "raises ConfigurationError when #{attr} is missing" do
-        expect { described_class.new(valid_attrs.except(attr)) }
-          .to raise_error(Safire::Errors::ConfigurationError, /#{attr}/)
-      end
+    it 'initializes successfully without client_id' do
+      expect { described_class.new(valid_attrs.except(:client_id)) }.not_to raise_error
+    end
+
+    it 'raises ConfigurationError when base_url is missing' do
+      expect { described_class.new(valid_attrs.except(:base_url)) }
+        .to raise_error(Safire::Errors::ConfigurationError, /base_url/)
     end
   end
 

--- a/spec/safire/protocols/smart_spec.rb
+++ b/spec/safire/protocols/smart_spec.rb
@@ -207,16 +207,9 @@ RSpec.describe Safire::Protocols::Smart do
       expect(client.client_secret).to be_nil
     end
 
-    it 'raises ConfigurationError when a required attribute is missing' do
-      %i[client_id base_url].each do |attr|
-        expect { described_class.new(Safire::ClientConfig.new(config_attrs.except(attr))) }
-          .to raise_error(Safire::Errors::ConfigurationError, /#{attr}/)
-      end
-    end
-
-    it 'initializes successfully without redirect_uri and authorization_endpoint' do
-      cfg = Safire::ClientConfig.new(config_attrs.except(:redirect_uri, :authorization_endpoint))
-      expect { described_class.new(cfg) }.not_to raise_error
+    it 'allows client_id to be omitted on initialization' do
+      client = described_class.new(Safire::ClientConfig.new(config_attrs.except(:client_id)))
+      expect(client.client_id).to be_nil
     end
 
     it 'gives each instance its own distinct HTTPClient' do
@@ -225,14 +218,6 @@ RSpec.describe Safire::Protocols::Smart do
 
       expect(client1.instance_variable_get(:@http_client))
         .not_to be(client2.instance_variable_get(:@http_client))
-    end
-
-    it 'fetches endpoints from well-known when not provided' do
-      stub_well_known
-      cfg = Safire::ClientConfig.new(config_attrs.except(:authorization_endpoint, :token_endpoint))
-      client = described_class.new(cfg)
-      expect(client.authorization_endpoint).to eq(smart_metadata_body['authorization_endpoint'])
-      expect(client.token_endpoint).to eq(smart_metadata_body['token_endpoint'])
     end
   end
 
@@ -289,6 +274,29 @@ RSpec.describe Safire::Protocols::Smart do
 
       stub_well_known(base_url: 'https://fhir.example.com')
       expect { described_class.new(config).server_metadata }.not_to raise_error
+    end
+  end
+
+  # ---------- Endpoint Resolution ----------
+
+  describe 'endpoint resolution' do
+    context 'when endpoints are absent from config' do
+      it 'resolves both from well-known discovery' do
+        stub_well_known
+        cfg = Safire::ClientConfig.new(config_attrs.except(:authorization_endpoint, :token_endpoint))
+        client = described_class.new(cfg)
+        expect(client.authorization_endpoint).to eq(smart_metadata_body['authorization_endpoint'])
+        expect(client.token_endpoint).to eq(smart_metadata_body['token_endpoint'])
+      end
+    end
+
+    context 'when token_endpoint is absent from the discovery response' do
+      it 'raises DiscoveryError with a descriptive message' do
+        cfg = Safire::ClientConfig.new(config_attrs.except(:token_endpoint))
+        stub_well_known(body: smart_metadata_body.except('token_endpoint'))
+        expect { described_class.new(cfg).token_endpoint }
+          .to raise_error(Safire::Errors::DiscoveryError, /token_endpoint/)
+      end
     end
   end
 
@@ -421,6 +429,14 @@ RSpec.describe Safire::Protocols::Smart do
       end
     end
 
+    context 'when client_id is not configured' do
+      it 'raises ConfigurationError' do
+        cfg = Safire::ClientConfig.new(config_attrs.except(:client_id))
+        expect { described_class.new(cfg).authorization_url }
+          .to raise_error(Safire::Errors::ConfigurationError, /client_id/)
+      end
+    end
+
     context 'when authorization_endpoint cannot be resolved' do
       it 'raises ConfigurationError' do
         cfg = Safire::ClientConfig.new(config_attrs.except(:authorization_endpoint))
@@ -538,6 +554,15 @@ RSpec.describe Safire::Protocols::Smart do
         token_response
         expect(WebMock).to(have_requested(:post, config_attrs[:token_endpoint])
           .with { |req| !req.headers.key?('Authorization') })
+      end
+    end
+
+    context 'when client_id is not configured' do
+      it 'raises ConfigurationError' do
+        cfg = Safire::ClientConfig.new(config_attrs.except(:client_id))
+        expect do
+          described_class.new(cfg).request_access_token(code: 'code', code_verifier: 'verifier')
+        end.to raise_error(Safire::Errors::ConfigurationError, /client_id/)
       end
     end
 
@@ -691,6 +716,14 @@ RSpec.describe Safire::Protocols::Smart do
       end
     end
 
+    context 'when client_id is not configured' do
+      it 'raises ConfigurationError' do
+        cfg = Safire::ClientConfig.new(config_attrs.except(:client_id))
+        expect { described_class.new(cfg).refresh_token(refresh_token: 'token') }
+          .to raise_error(Safire::Errors::ConfigurationError, /client_id/)
+      end
+    end
+
     it 'raises TokenError on invalid refresh token' do
       stub_token_post(
         body_matcher: {
@@ -832,6 +865,14 @@ RSpec.describe Safire::Protocols::Smart do
 
         expect(WebMock).to have_requested(:post, config_attrs[:token_endpoint])
           .with(body: hash_including('scope' => 'system/*.rs'))
+      end
+    end
+
+    context 'when client_id is not configured' do
+      it 'raises ConfigurationError — client_id is required for JWT assertion claims' do
+        cfg = Safire::ClientConfig.new(backend_config_attrs.except(:client_id))
+        expect { described_class.new(cfg).request_backend_token }
+          .to raise_error(Safire::Errors::ConfigurationError, /client_id/)
       end
     end
 


### PR DESCRIPTION
`client_id` is now optional when creating a `ClientConfig` or `Client`. Previously the gem rejected configurations without a `client_id` at construction time, which made it impossible to set up a client before a `client_id` had been issued. Now each authorization method — `authorization_url`, `request_access_token`, `refresh_token`, and `request_backend_token` — validates that `client_id` is present when called and raises a clear `ConfigurationError` if it is not.

This change also fixes a silent failure where a non-conformant discovery response missing `token_endpoint` would pass a `nil` URL to the HTTP client. The gem now raises a descriptive `DiscoveryError` in that case.

This is the first step toward Dynamic Client Registration (RFC 7591) support, which requires building a client configuration before a `client_id` has been obtained from the authorization server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)