### PR TITLE
Skip Claude review for bot-opened PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.user.type != 'Bot'
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- Adds an `if:` condition to the `review` job so the workflow skips PRs opened by bot accounts (dependabot, renovate, etc.)
- `workflow_dispatch` runs are always allowed regardless of this condition

