### PR TITLE
Clean up protocol construction before UDAP lands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `Safire::Client` now raises `ConfigurationError` when `client_type:` is passed explicitly for
+  `protocol: :udap`, both at construction and via `client_type=`; previously the value was
+  ignored silently
+
 ## [0.3.0] - 2026-04-15
 
 ### Added

--- a/docs/adr/ADR-002-facade-and-forwardable.md
+++ b/docs/adr/ADR-002-facade-and-forwardable.md
@@ -42,22 +42,30 @@ class Client
   def_delegators :protocol_client,
                  :server_metadata, :authorization_url,
                  :request_access_token, :refresh_token,
+                 :request_backend_token,
                  :token_response_valid?, :register_client
 
   private
 
   def protocol_client
-    @protocol_client ||= PROTOCOL_CLASSES.fetch(@protocol).new(config, client_type:)
+    @protocol_client ||= build_protocol_client
+  end
+
+  def build_protocol_client
+    case @protocol
+    when :smart then Protocols::Smart.new(config, client_type:)
+    when :udap  then raise NotImplementedError, 'UDAP protocol client is not yet implemented'
+    end
   end
 end
 ```
 
-Protocol implementations (`Protocols::Smart`, future `Protocols::Udap`) include `Protocols::Behaviours` to declare the required interface. Adding a new protocol requires:
+Protocol implementations (`Protocols::Smart`, `Protocols::Udap`) include `Protocols::Behaviours` to declare the required interface. Adding a new protocol requires:
 1. Implementing the `Behaviours` interface in a new class
-2. Adding the class to `PROTOCOL_CLASSES`
+2. Adding a `when` branch to `build_protocol_client` in `Client`
 3. Adding its valid client types to `PROTOCOL_CLIENT_TYPES`
 
-No changes to `Client` itself.
+The original design aimed for "no changes to `Client` itself" when adding a protocol. That invariant was intentionally relaxed: protocols have different constructor signatures (`Smart` takes `client_type:`, `Udap` does not), and a small explicit `case` in `build_protocol_client` is preferable to forcing every protocol into a uniform constructor it does not need.
 
 **Why `Forwardable` over `method_missing`:** `Forwardable` is explicit — the delegated method list is visible in the class body, easy to grep, and YARD-documented. `method_missing` is implicit, difficult to introspect, and catches typos silently.
 
@@ -77,3 +85,4 @@ No changes to `Client` itself.
 **Trade-offs:**
 - `Client` itself has no runtime behaviour — all logic lives in protocol classes; contributors must know to look in `Protocols::Smart` for SMART logic, not in `Client`
 - `def_delegators` does not forward keyword arguments transparently in all Ruby versions — method signatures in `Behaviours` must be compatible with delegation
+- Adding a new protocol requires a one-line change to `build_protocol_client` in `Client`; this is a small, contained cost that buys protocol-specific constructor freedom

--- a/docs/adr/ADR-002-facade-and-forwardable.md
+++ b/docs/adr/ADR-002-facade-and-forwardable.md
@@ -60,7 +60,7 @@ class Client
 end
 ```
 
-Protocol implementations (`Protocols::Smart`, `Protocols::Udap`) include `Protocols::Behaviours` to declare the required interface. Adding a new protocol requires:
+`Protocols::Smart` includes `Protocols::Behaviours` to declare the required interface. Future protocol implementations (e.g. `Protocols::Udap`, once it exists) will do the same. Adding a new protocol requires:
 1. Implementing the `Behaviours` interface in a new class
 2. Adding a `when` branch to `build_protocol_client` in `Client`
 3. Adding its valid client types to `PROTOCOL_CLIENT_TYPES`

--- a/docs/adr/ADR-003-protocol-vs-client-type.md
+++ b/docs/adr/ADR-003-protocol-vs-client-type.md
@@ -49,7 +49,7 @@ PROTOCOL_CLIENT_TYPES = {
 ```
 
 - `protocol:` is validated against `VALID_PROTOCOLS`; an unknown protocol raises `ConfigurationError`
-- `client_type:` is validated against `PROTOCOL_CLIENT_TYPES[@protocol]`; if `nil` (UDAP), validation is skipped and the setter logs a warning and no-ops rather than raising
+- `client_type:` defaults to `nil`. For `:smart`, `nil` resolves to `:public` before validation. For `:udap`, `nil` is the only accepted value — passing any explicit `client_type:` at construction or via `client_type=` raises `ConfigurationError`
 - Changing `client_type=` on a SMART client updates the underlying protocol client in place — already-fetched server metadata is preserved and no re-discovery occurs
 
 ---
@@ -60,8 +60,8 @@ PROTOCOL_CLIENT_TYPES = {
 - No invalid combinations — UDAP has no client type choices at all; this is enforced at the type level, not with runtime checks
 - `client_type=` mutation is clean and natural for the "discover first, then select client type" pattern
 - Adding a new SMART client type requires only adding a symbol to `PROTOCOL_CLIENT_TYPES[:smart]`
-- Adding a new protocol requires adding a class to `PROTOCOL_CLASSES` and an entry to `PROTOCOL_CLIENT_TYPES`
+- Adding a new protocol requires adding an entry to `PROTOCOL_CLIENT_TYPES` and a branch to `build_protocol_client` (see [ADR-002]({% link adr/ADR-002-facade-and-forwardable.md %}))
 
 **Trade-offs:**
 - Two keyword args instead of one — a caller needs to know which dimension belongs to which kwarg; mitigated by clear documentation and validation errors that name the invalid parameter
-- `client_type:` defaults to `:public` even when `protocol: :udap` — the value is ignored for UDAP, but setting it is technically a no-op with a warning rather than an error; this is intentional for resilience in generic caller code
+- `client_type:` defaults to `nil` — for SMART callers who previously relied on the `:public` default, behavior is unchanged; for UDAP callers, passing an explicit value now raises rather than silently no-oping, which is stricter but prevents misconfiguration

--- a/docs/configuration/client-setup.md
+++ b/docs/configuration/client-setup.md
@@ -67,7 +67,7 @@ Selects the authorization protocol. Defaults to `:smart`.
 | `:smart` | Implemented | SMART App Launch 2.2.0 |
 | `:udap` | Planned | UDAP Security 1.0 — accepted by the validator, raises `NotImplementedError` until implemented |
 
-For UDAP, `client_type:` is ignored — UDAP clients always authenticate with a JWT signed by their private key.
+For UDAP, `client_type:` is not applicable. Passing any explicit value raises `ConfigurationError`. UDAP clients always authenticate via a JWT signed by their private key.
 
 ### Client Type
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -44,7 +44,7 @@ flowchart TD
 | `client_id` | String | No | — | OAuth2 client identifier — required by all authorization flows; validated at call time, not at construction |
 | `redirect_uri` | String | No | — | Registered callback URL — required for App Launch flows; not used in Backend Services |
 | `protocol:` | Symbol | No | `:smart` | Authorization protocol — `:smart` or `:udap` |
-| `client_type:` | Symbol | No | `:public` | SMART client type — `:public`, `:confidential_symmetric`, or `:confidential_asymmetric` |
+| `client_type:` | Symbol | No | `nil` (→ `:public` for SMART) | SMART client type — `:public`, `:confidential_symmetric`, or `:confidential_asymmetric`; not applicable for `:udap` (any explicit value raises `ConfigurationError`) |
 | `client_secret` | String | No | — | Required for `:confidential_symmetric` |
 | `private_key` | OpenSSL::PKey / String | No | — | RSA/EC private key; required for `:confidential_asymmetric` and Backend Services |
 | `kid` | String | No | — | Key ID matching the public key registered with the server |

--- a/lib/safire/client.rb
+++ b/lib/safire/client.rb
@@ -26,18 +26,20 @@ module Safire
   # * :smart (default) — SMART App Launch 2.2.0
   # * :udap             — UDAP Security (future; not yet implemented)
   #
-  # The +client_type:+ keyword controls how the SMART client authenticates at the token endpoint:
+  # The +client_type:+ keyword controls how the SMART client authenticates at the token endpoint.
+  # Defaults to +nil+, which resolves to +:public+ for SMART. For UDAP, +client_type:+ is not
+  # applicable — passing any explicit value raises +ConfigurationError+.
   #
-  # * :public (default)             — no client authentication; client_id sent in request body
+  # * :public             — no client authentication; client_id sent in request body (SMART default)
   # * :confidential_symmetric       — HTTP Basic auth using client_secret
   # * :confidential_asymmetric      — private_key_jwt assertion (JWT signed with private key)
   #
-  # client_type is validated for :smart and ignored for :udap. UDAP clients authenticate via
-  # signed JWT assertions (Authentication Token / AnT) with an X.509 certificate chain in the
-  # x5c JOSE header; the authentication method is not user-configurable for UDAP. DCR is
-  # typically performed once to obtain a client_id, which is then reused as iss/sub in every
-  # subsequent AnT. The unregistered client flow (§8.1) allows client_credentials grant without
-  # prior DCR when identity can be fully determined from certificate attributes alone.
+  # UDAP clients authenticate via signed JWT assertions (Authentication Token / AnT) with an
+  # X.509 certificate chain in the x5c JOSE header; the authentication method is not
+  # user-configurable for UDAP. DCR is typically performed once to obtain a client_id, which is
+  # then reused as iss/sub in every subsequent AnT. The unregistered client flow (§8.1) allows
+  # client_credentials grant without prior DCR when identity can be fully determined from
+  # certificate attributes alone.
   #
   # @note Future kwargs (not yet implemented):
   #
@@ -45,9 +47,6 @@ module Safire
   #     :b2b          — client_credentials grant, server-to-server
   #     :b2c          — authorization_code grant, user-facing
   #     :tiered_oauth — authorization_code + IdP identity delegation
-  #
-  #   When protocol: :udap is fully implemented, client_type: will default to nil
-  #   (not applicable) and the flow: kwarg will drive B2B vs B2C selection.
   #
   # @!attribute [r] config
   #   @return [Safire::ClientConfig] the resolved client configuration
@@ -136,15 +135,8 @@ module Safire
 
     VALID_PROTOCOLS = %i[smart udap].freeze
 
-    PROTOCOL_CLASSES = {
-      smart: Protocols::Smart
-      # udap: Protocols::Udap  # future
-    }.freeze
-
     # Valid client_type values per protocol.
-    # nil means the protocol does not use client_type (e.g. UDAP authenticates via signed
-    # JWT assertions with an X.509 certificate chain; the authentication method is not
-    # user-configurable for UDAP).
+    # nil means client_type is not applicable for that protocol; any explicit value raises ConfigurationError.
     PROTOCOL_CLIENT_TYPES = {
       smart: %i[public confidential_symmetric confidential_asymmetric],
       udap: nil # UDAP authenticates via signed JWT assertions (AnT) with X.509 certificate chain
@@ -158,12 +150,13 @@ module Safire
 
     attr_reader :config, :protocol, :client_type
 
-    def initialize(config, protocol: :smart, client_type: :public)
+    def initialize(config, protocol: :smart, client_type: nil)
       @protocol    = protocol.to_sym
-      @client_type = client_type.to_sym
+      @client_type = client_type&.to_sym
       @config      = build_config(config)
 
       validate_protocol!
+      resolve_client_type!
       validate_client_type!
     end
 
@@ -184,13 +177,7 @@ module Safire
     #     client.client_type = :confidential_symmetric
     #   end
     def client_type=(new_client_type)
-      if PROTOCOL_CLIENT_TYPES[@protocol].nil?
-        Safire.logger.warn(
-          "client_type is not configurable for protocol: :#{@protocol}; " \
-          'UDAP clients authenticate via signed JWT assertions — ignoring'
-        )
-        return
-      end
+      raise_client_type_not_applicable!(new_client_type) if PROTOCOL_CLIENT_TYPES[@protocol].nil?
 
       @client_type = new_client_type.to_sym
       validate_client_type!
@@ -200,7 +187,14 @@ module Safire
     private
 
     def protocol_client
-      @protocol_client ||= PROTOCOL_CLASSES.fetch(@protocol).new(config, client_type:)
+      @protocol_client ||= build_protocol_client
+    end
+
+    def build_protocol_client
+      case @protocol
+      when :smart then Protocols::Smart.new(config, client_type:)
+      when :udap  then raise NotImplementedError, 'UDAP protocol client is not yet implemented'
+      end
     end
 
     def build_config(config)
@@ -219,14 +213,31 @@ module Safire
       )
     end
 
+    def resolve_client_type!
+      @client_type = :public if @protocol == :smart && @client_type.nil?
+    end
+
     def validate_client_type!
       valid_types = PROTOCOL_CLIENT_TYPES[@protocol]
-      return if valid_types.nil? || valid_types.include?(@client_type)
+      if valid_types.nil?
+        return if @client_type.nil?
+
+        raise_client_type_not_applicable!(@client_type)
+      end
+      return if valid_types.include?(@client_type)
 
       raise Errors::ConfigurationError.new(
         invalid_attribute: :client_type,
         invalid_value: @client_type,
         valid_values: valid_types
+      )
+    end
+
+    def raise_client_type_not_applicable!(value)
+      raise Errors::ConfigurationError.new(
+        invalid_attribute: :client_type,
+        invalid_value: value,
+        valid_values: ["N/A (client_type is not applicable for protocol :#{@protocol})"]
       )
     end
   end

--- a/lib/safire/client.rb
+++ b/lib/safire/client.rb
@@ -55,8 +55,9 @@ module Safire
   #   @return [Symbol] the selected protocol (:smart or :udap)
   #
   # @!attribute [r] client_type
-  #   @return [Symbol] the client authentication method
-  #     (:public, :confidential_symmetric, or :confidential_asymmetric)
+  #   @return [Symbol, nil] the SMART client authentication method
+  #     (:public, :confidential_symmetric, or :confidential_asymmetric);
+  #     nil for protocol: :udap where client authentication is not user-configurable
   #
   # @see Safire::ClientConfig
   # @see Safire::Protocols::Smart
@@ -152,7 +153,7 @@ module Safire
 
     def initialize(config, protocol: :smart, client_type: nil)
       @protocol    = protocol.to_sym
-      @client_type = client_type&.to_sym
+      @client_type = normalize_client_type(client_type)
       @config      = build_config(config)
 
       validate_protocol!
@@ -179,7 +180,7 @@ module Safire
     def client_type=(new_client_type)
       raise_client_type_not_applicable!(new_client_type) if PROTOCOL_CLIENT_TYPES[@protocol].nil?
 
-      @client_type = new_client_type.to_sym
+      @client_type = normalize_client_type(new_client_type)
       validate_client_type!
       @protocol_client&.client_type = @client_type
     end
@@ -238,6 +239,17 @@ module Safire
         invalid_attribute: :client_type,
         invalid_value: value,
         valid_values: ["N/A (client_type is not applicable for protocol :#{@protocol})"]
+      )
+    end
+
+    def normalize_client_type(value)
+      return nil if value.nil?
+      return value.to_sym if value.is_a?(Symbol) || value.is_a?(String)
+
+      raise Errors::ConfigurationError.new(
+        invalid_attribute: :client_type,
+        invalid_value: value,
+        valid_values: PROTOCOL_CLIENT_TYPES[:smart]
       )
     end
   end

--- a/spec/safire/client_spec.rb
+++ b/spec/safire/client_spec.rb
@@ -57,8 +57,17 @@ RSpec.describe Safire::Client do
       expect(described_class.new(config).protocol).to eq(:smart)
     end
 
-    it 'defaults to client_type: :public' do
+    it 'resolves client_type to :public by default for SMART' do
       expect(described_class.new(config).client_type).to eq(:public)
+    end
+
+    it 'defaults client_type to nil for UDAP' do
+      expect(described_class.new(config, protocol: :udap).client_type).to be_nil
+    end
+
+    it 'raises ConfigurationError when an explicit client_type is passed for UDAP' do
+      expect { described_class.new(config, protocol: :udap, client_type: :public) }
+        .to raise_error(Safire::Errors::ConfigurationError, /client_type/)
     end
 
     it 'raises ConfigurationError for unknown protocol' do
@@ -111,15 +120,12 @@ RSpec.describe Safire::Client do
         .with(headers: { 'Authorization' => /^Basic / })
     end
 
-    context 'when protocol does not support client_type (e.g. :udap)' do
-      it 'logs a warning and returns without changing client_type' do
+    context 'when protocol does not support client_type (UDAP)' do
+      it 'raises ConfigurationError' do
         client = described_class.new(config, protocol: :udap)
 
-        allow(Safire.logger).to receive(:warn)
-        client.client_type = :confidential_symmetric
-
-        expect(Safire.logger).to have_received(:warn).with(/not configurable.*:udap/i)
-        expect(client.client_type).to eq(:public)
+        expect { client.client_type = :confidential_symmetric }
+          .to raise_error(Safire::Errors::ConfigurationError, /client_type/)
       end
     end
 

--- a/spec/safire/client_spec.rb
+++ b/spec/safire/client_spec.rb
@@ -153,6 +153,17 @@ RSpec.describe Safire::Client do
     end
   end
 
+  # ---------- UDAP (not yet implemented) ----------
+
+  describe 'UDAP delegation' do
+    it 'raises NotImplementedError when a delegated method is called' do
+      client = described_class.new(config, protocol: :udap)
+
+      expect { client.server_metadata }
+        .to raise_error(NotImplementedError, /UDAP protocol client is not yet implemented/)
+    end
+  end
+
   # ---------- Authorization URL ----------
 
   describe '#authorization_url' do


### PR DESCRIPTION
This PR tidies up how `Safire::Client` constructs its protocol implementations, removing a design inconsistency before UDAP support is added. Previously, all protocol classes were required to accept a `client_type:` keyword argument even though it is meaningless for UDAP. The client type parameter now defaults to `nil` and resolves to `:public` automatically for SMART, while any explicit value passed for a UDAP client raises a `ConfigurationError` immediately — at construction and via the setter — rather than silently doing nothing. The internal wiring is replaced by a small protocol-aware factory method that gives each protocol the exact constructor call it needs. Two architecture decision records are updated to reflect these changes accurately.

## Test plan
- [ ] CI passes
- [ ] SMART callers with no `client_type:` still get `:public` (no behavioral change)
- [ ] `Safire::Client.new(config, protocol: :udap)` initializes with `client_type` nil
- [ ] `Safire::Client.new(config, protocol: :udap, client_type: :public)` raises `ConfigurationError`
- [ ] `client.client_type = :anything` on a UDAP client raises `ConfigurationError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)