### PR TITLE
Make DiscoveryError protocol-neutral with a label kwarg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Safire::Errors::DiscoveryError` accepts a `label:` keyword argument (default: `'SMART configuration'`)
+  and exposes it as a readable attribute; consumers can inspect `error.label` to identify which
+  protocol's discovery failed
+
 ### Changed
 
 - Ruby requirement changed from >= 4.0.2 to >= 4.0.3.

--- a/lib/safire/errors.rb
+++ b/lib/safire/errors.rb
@@ -80,7 +80,7 @@ module Safire
       end
     end
 
-    # Raised when SMART configuration discovery fails.
+    # Raised when protocol discovery fails.
     #
     # @!attribute [r] endpoint
     #   @return [String] the discovery endpoint URL that was requested
@@ -88,20 +88,23 @@ module Safire
     #   @return [Integer, nil] HTTP status code returned by the server
     # @!attribute [r] error_description
     #   @return [String, nil] description of why discovery failed (e.g. unexpected response format)
+    # @!attribute [r] label
+    #   @return [String] protocol label used in the error message (e.g. 'SMART configuration', 'UDAP metadata')
     class DiscoveryError < Error
-      attr_reader :endpoint, :status, :error_description
+      attr_reader :endpoint, :status, :error_description, :label
 
-      def initialize(endpoint:, status: nil, error_description: nil)
+      def initialize(endpoint:, status: nil, error_description: nil, label: 'SMART configuration')
         @endpoint          = endpoint
         @status            = status
         @error_description = error_description
+        @label             = label
         super(build_message)
       end
 
       private
 
       def build_message
-        msg = "Failed to discover SMART configuration from #{@endpoint}"
+        msg = "Failed to discover #{@label} from #{@endpoint}"
         msg += " (HTTP #{@status})" if @status
         msg += ": #{@error_description}" if @error_description
         msg

--- a/spec/safire/errors_spec.rb
+++ b/spec/safire/errors_spec.rb
@@ -116,6 +116,39 @@ RSpec.describe Safire::Errors do
         expect(error.message).to match(/response is not a JSON object/)
       end
     end
+
+    context 'with default label' do
+      subject(:error) { described_class.new(endpoint: 'https://fhir.example.com/.well-known/smart-configuration') }
+
+      it 'defaults label to SMART configuration' do
+        expect(error.label).to eq('SMART configuration')
+      end
+
+      it 'uses the default label in the message' do
+        expect(error.message).to match(/SMART configuration/)
+      end
+    end
+
+    context 'with a custom label' do
+      subject(:error) do
+        described_class.new(
+          endpoint: 'https://fhir.example.com/.well-known/udap',
+          label: 'UDAP metadata'
+        )
+      end
+
+      it 'exposes the custom label' do
+        expect(error.label).to eq('UDAP metadata')
+      end
+
+      it 'uses the custom label in the message' do
+        expect(error.message).to match(/UDAP metadata/)
+      end
+
+      it 'does not include the default label in the message' do
+        expect(error.message).not_to match(/SMART configuration/)
+      end
+    end
   end
 
   describe Safire::Errors::OAuthError do


### PR DESCRIPTION
## Summary

`DiscoveryError` previously hardcoded `"SMART configuration"` in its message, which would have produced misleading error output for UDAP discovery failures. This PR adds a `label:` keyword argument (defaulting to `'SMART configuration'`) so each protocol can identify itself in the error message without any change to existing SMART callers.

## Test plan

- [x] `bundle exec rspec spec/safire/errors_spec.rb` — all 62 examples pass, including the new `with default label` and `with a custom label` contexts
- [x] `bundle exec rspec` — full suite green (393 examples)
- [x] `bundle exec rubocop lib/safire/errors.rb spec/safire/errors_spec.rb` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)