### PR TITLE
Add UdapMetadata entity with STU2 structural validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `Safire::Protocols::UdapMetadata` for HL7 UDAP Security STU2 discovery metadata,
+  including structural `valid?` checks and helper methods for advertised UDAP profiles and capabilities.
+
 - `Safire::Errors::DiscoveryError` accepts a `label:` keyword argument (default: `'SMART configuration'`)
   and exposes it as a readable attribute; consumers can inspect `error.label` to identify which
   protocol's discovery failed

--- a/docs/adr/ADR-011-udap-stu2-discovery-conformance.md
+++ b/docs/adr/ADR-011-udap-stu2-discovery-conformance.md
@@ -60,12 +60,14 @@ semantics.
 - `udap_profiles_supported` must include `"udap_dcr"` and `"udap_authn"` (both required by STU2)
 - `token_endpoint_auth_methods_supported` must equal `["private_key_jwt"]` exactly (STU2 fixed value)
 - `scopes_supported`, `grant_types_supported`, and both JWT signing algorithm arrays must each have at least one element
-- `signed_metadata` must be a compact-JWS string (three dot-separated segments); JWT header
+- `signed_metadata` must be a compact-JWS string: exactly three dot-separated segments where
+  every segment contains only base64url characters (`[A-Za-z0-9\-_]`, no padding); JWT header
   algorithm (`alg`), required claim presence, and signature are not validated here — these are
   deferred to the cryptographic validator (future PR)
 - endpoint URL fields (`token_endpoint`, `registration_endpoint`, conditionally
-  `authorization_endpoint`) must be absolute HTTPS URLs; `localhost` HTTP is accepted to support
-  development and testing without TLS — this exception does not apply in production
+  `authorization_endpoint`) must be absolute HTTPS URLs; plain HTTP is accepted only for
+  `localhost` and `127.0.0.1` to support development without TLS — any other scheme on
+  those hosts (e.g. `ftp://localhost`) is rejected; this exception does not apply in production
 - `authorization_endpoint` is conditionally required when `grant_types_supported` includes
   `"authorization_code"`
 - `"udap_authz"` is conditionally required in `udap_profiles_supported` when `grant_types_supported`
@@ -84,8 +86,11 @@ semantics.
   only whether the server advertises the profile string in `udap_profiles_supported`; they do
   not check whether all required supporting fields are present.
 - *Capability checks* (`supports_dynamic_registration?`, `supports_jwt_client_auth?`, etc.)
-  combine profile advertisement with any additional preconditions (e.g.,
-  `supports_dynamic_registration?` also requires `registration_endpoint` to be present).
+  combine profile advertisement with the minimum preconditions needed to start that flow:
+  - `supports_dynamic_registration?` requires `udap_dcr` profile and a valid `registration_endpoint`
+  - `supports_jwt_client_auth?` requires `udap_authn` profile and a valid `token_endpoint`
+  - `supports_client_authorization?` requires `udap_authz` profile, `client_credentials` in
+    `grant_types_supported`, and a valid `token_endpoint`
 
 ---
 

--- a/docs/adr/ADR-011-udap-stu2-discovery-conformance.md
+++ b/docs/adr/ADR-011-udap-stu2-discovery-conformance.md
@@ -48,17 +48,20 @@ dedicated cryptographic validator to be introduced in a future PR.
 response. Using `blank?` would flag `[]` as absent; using `nil?` preserves the distinction
 between "field not present in the JSON response" and "field present but empty".
 
-**Array type validation is explicit:** Discovery metadata is untrusted JSON. `UdapMetadata#valid?`
-verifies every array-valued field is actually an Array before it performs profile, grant,
-non-empty, or subset checks. Public helper methods also treat malformed scalar metadata as
-unsupported instead of using Ruby string `include?` semantics.
+**Array type and element validation is explicit:** Discovery metadata is untrusted JSON.
+`UdapMetadata#valid?` verifies every array-valued field is an `Array` whose elements are all
+`String`s before performing profile, grant, non-empty, or subset checks. Public helper methods
+also treat malformed scalar metadata as unsupported instead of using Ruby string `include?`
+semantics.
 
 **Value-level constraints in `valid?`:**
 
 - `udap_versions_supported` must equal `["1"]` exactly (STU2 fixed value)
 - `udap_profiles_supported` must include `"udap_dcr"` and `"udap_authn"` (both required by STU2)
 - `token_endpoint_auth_methods_supported` must equal `["private_key_jwt"]` exactly (STU2 fixed value)
-- `scopes_supported` and `grant_types_supported` must each have at least one element
+- `scopes_supported`, `grant_types_supported`, and both JWT signing algorithm arrays must each have at least one element
+- `signed_metadata` must be a compact-JWS string (three dot-separated segments); signature
+  verification is deferred to the cryptographic validator (future PR)
 - `authorization_endpoint` is conditionally required when `grant_types_supported` includes
   `"authorization_code"`
 - `"udap_authz"` is conditionally required in `udap_profiles_supported` when `grant_types_supported`

--- a/docs/adr/ADR-011-udap-stu2-discovery-conformance.md
+++ b/docs/adr/ADR-011-udap-stu2-discovery-conformance.md
@@ -1,0 +1,94 @@
+---
+layout: default
+title: "ADR-011: UdapMetadata entity — structural validation separate from cryptographic validation"
+parent: Architecture Decision Records
+nav_order: 11
+---
+
+# ADR-011: `UdapMetadata` entity — structural validation separate from cryptographic validation
+
+**Status:** Accepted
+
+---
+
+## Context
+
+UDAP Security STU2 discovery returns a JSON object from `/.well-known/udap`. That object must be
+parsed into a typed entity and validated before any downstream flow (Dynamic Client Registration,
+JWT client authentication, etc.) can proceed. Two distinct validation concerns arise:
+
+1. **Structural validation** — are all required fields present? Do they satisfy the fixed-value
+   and conditional constraints specified in STU2?
+2. **Cryptographic validation** — is the `signed_metadata` JWT signature valid, and does the
+   embedded X.509 chain chain to a trusted anchor?
+
+These concerns operate at different layers: structural checks need only the parsed JSON object,
+while cryptographic checks require a trusted certificate store and key material. Mixing them
+inside the same class would make the entity difficult to test (crypto requires real certs) and
+would couple two unrelated failure modes.
+
+---
+
+## Decision
+
+`UdapMetadata` handles structural parsing and validation only. It inherits from `Safire::Entity`
+(the same base used by `SmartMetadata`) and follows the same warn-and-return-false convention
+for `valid?`.
+
+**Conformance target:** HL7 UDAP Security STU2 / v2.0.0
+([discovery section](https://hl7.org/fhir/us/udap-security/STU2/discovery.html)).
+
+**Signed metadata:** STU2 uses `signed_metadata` (not the deprecated `signed_endpoints` from
+earlier drafts). `signed_metadata` is treated as a required field by `UdapMetadata#valid?` and
+as an opaque string. Cryptographic validation of the JWT is intentionally deferred to a
+dedicated validator (see ADR-012).
+
+**Presence check uses `nil?`, not `blank?`:** Several required array fields — for example,
+`udap_authorization_extensions_supported` — may legitimately be empty arrays in a conformant
+response. Using `blank?` would flag `[]` as absent; using `nil?` preserves the distinction
+between "field not present in the JSON response" and "field present but empty".
+
+**Value-level constraints in `valid?`:**
+
+- `udap_versions_supported` must equal `["1"]` exactly (STU2 fixed value)
+- `udap_profiles_supported` must include `"udap_dcr"` and `"udap_authn"` (both required by STU2)
+- `token_endpoint_auth_methods_supported` must equal `["private_key_jwt"]` exactly (STU2 fixed value)
+- `scopes_supported` and `grant_types_supported` must each have at least one element
+- `authorization_endpoint` is conditionally required when `grant_types_supported` includes
+  `"authorization_code"`
+- `"udap_authz"` is conditionally required in `udap_profiles_supported` when `grant_types_supported`
+  includes `"client_credentials"`
+- `"authorization_code"` is conditionally required in `grant_types_supported` when `"refresh_token"`
+  is also present
+- `udap_authorization_extensions_required` is conditionally required when
+  `udap_authorization_extensions_supported` is non-empty; its values must be a subset of
+  `udap_authorization_extensions_supported`
+- `udap_certifications_required` is conditionally required when `udap_certifications_supported`
+  is non-empty; its values must be a subset of `udap_certifications_supported`
+
+**Public helpers follow a two-tier naming convention:**
+
+- *Profile checks* (`dynamic_registration_profile?`, `jwt_client_auth_profile?`, etc.) test
+  only whether the server advertises the profile string in `udap_profiles_supported`; they do
+  not check whether all required supporting fields are present.
+- *Capability checks* (`supports_dynamic_registration?`, `supports_jwt_client_auth?`, etc.)
+  combine profile advertisement with any additional preconditions (e.g.,
+  `supports_dynamic_registration?` also requires `registration_endpoint` to be present).
+
+---
+
+## Consequences
+
+**Benefits:**
+
+- Structural conformance is independently testable without any certificate infrastructure
+- `valid?` follows the same warn-and-return-false contract as `SmartMetadata#valid?`, giving
+  callers a consistent API across protocols
+- `signed_metadata` cryptographic validation can be added (or skipped in dev/test) without
+  touching the entity
+
+**Trade-offs:**
+
+- A structurally valid `UdapMetadata` object is not automatically cryptographically validated;
+  callers that require full STU2 conformance must also invoke `signed_metadata_valid?`
+  (introduced in ADR-012) after structural validation passes

--- a/docs/adr/ADR-011-udap-stu2-discovery-conformance.md
+++ b/docs/adr/ADR-011-udap-stu2-discovery-conformance.md
@@ -48,6 +48,11 @@ dedicated validator (see ADR-012).
 response. Using `blank?` would flag `[]` as absent; using `nil?` preserves the distinction
 between "field not present in the JSON response" and "field present but empty".
 
+**Array type validation is explicit:** Discovery metadata is untrusted JSON. `UdapMetadata#valid?`
+verifies every array-valued field is actually an Array before it performs profile, grant,
+non-empty, or subset checks. Public helper methods also treat malformed scalar metadata as
+unsupported instead of using Ruby string `include?` semantics.
+
 **Value-level constraints in `valid?`:**
 
 - `udap_versions_supported` must equal `["1"]` exactly (STU2 fixed value)

--- a/docs/adr/ADR-011-udap-stu2-discovery-conformance.md
+++ b/docs/adr/ADR-011-udap-stu2-discovery-conformance.md
@@ -41,7 +41,7 @@ for `valid?`.
 **Signed metadata:** STU2 uses `signed_metadata` (not the deprecated `signed_endpoints` from
 earlier drafts). `signed_metadata` is treated as a required field by `UdapMetadata#valid?` and
 as an opaque string. Cryptographic validation of the JWT is intentionally deferred to a
-dedicated validator (see ADR-012).
+dedicated cryptographic validator to be introduced in a future PR.
 
 **Presence check uses `nil?`, not `blank?`:** Several required array fields — for example,
 `udap_authorization_extensions_supported` — may legitimately be empty arrays in a conformant
@@ -95,5 +95,6 @@ unsupported instead of using Ruby string `include?` semantics.
 **Trade-offs:**
 
 - A structurally valid `UdapMetadata` object is not automatically cryptographically validated;
-  callers that require full STU2 conformance must also invoke `signed_metadata_valid?`
-  (introduced in ADR-012) after structural validation passes
+  callers that require full STU2 conformance must also perform cryptographic validation of the
+  `signed_metadata` JWT after structural validation passes; a dedicated validator will be
+  introduced in a future PR

--- a/docs/adr/ADR-011-udap-stu2-discovery-conformance.md
+++ b/docs/adr/ADR-011-udap-stu2-discovery-conformance.md
@@ -60,8 +60,12 @@ semantics.
 - `udap_profiles_supported` must include `"udap_dcr"` and `"udap_authn"` (both required by STU2)
 - `token_endpoint_auth_methods_supported` must equal `["private_key_jwt"]` exactly (STU2 fixed value)
 - `scopes_supported`, `grant_types_supported`, and both JWT signing algorithm arrays must each have at least one element
-- `signed_metadata` must be a compact-JWS string (three dot-separated segments); signature
-  verification is deferred to the cryptographic validator (future PR)
+- `signed_metadata` must be a compact-JWS string (three dot-separated segments); JWT header
+  algorithm (`alg`), required claim presence, and signature are not validated here — these are
+  deferred to the cryptographic validator (future PR)
+- endpoint URL fields (`token_endpoint`, `registration_endpoint`, conditionally
+  `authorization_endpoint`) must be absolute HTTPS URLs; `localhost` HTTP is accepted to support
+  development and testing without TLS — this exception does not apply in production
 - `authorization_endpoint` is conditionally required when `grant_types_supported` includes
   `"authorization_code"`
 - `"udap_authz"` is conditionally required in `udap_profiles_supported` when `grant_types_supported`

--- a/lib/safire/protocols/udap_metadata.rb
+++ b/lib/safire/protocols/udap_metadata.rb
@@ -45,6 +45,8 @@ module Safire
     #   @return [String, nil] URL of the server's Authorization Endpoint; conditionally required
     #     when {#grant_types_supported} includes +"authorization_code"+
     class UdapMetadata < Safire::Entity
+      include URIValidation
+
       REQUIRED_ATTRIBUTES = %i[
         udap_versions_supported
         udap_profiles_supported
@@ -67,6 +69,7 @@ module Safire
       ].freeze
 
       ATTRIBUTES = (REQUIRED_ATTRIBUTES | OPTIONAL_ATTRIBUTES).freeze
+      STRING_URL_ATTRIBUTES = %i[token_endpoint registration_endpoint].freeze
       ARRAY_ATTRIBUTES = %i[
         udap_versions_supported
         udap_profiles_supported
@@ -99,7 +102,10 @@ module Safire
       # - +udap_versions_supported+ must equal <tt>["1"]</tt> exactly (STU2 fixed value)
       # - +udap_profiles_supported+ includes +"udap_dcr"+ and +"udap_authn"+
       # - +token_endpoint_auth_methods_supported+ must equal <tt>["private_key_jwt"]</tt> exactly (STU2 fixed value)
-      # - +scopes_supported+ and +grant_types_supported+ each have at least one element
+      # - +scopes_supported+, +grant_types_supported+, and both signing algorithm arrays each have at least one element
+      # - +token_endpoint+ and +registration_endpoint+ are absolute HTTPS URLs;
+      #   +authorization_endpoint+ is also validated when present
+      # - +signed_metadata+ is a non-empty string
       # - +authorization_endpoint+ present when +authorization_code+ is in +grant_types_supported+
       # - +udap_authz+ present in +udap_profiles_supported+ when +client_credentials+ is in +grant_types_supported+
       # - +authorization_code+ present in +grant_types_supported+ when +refresh_token+ is also present
@@ -121,6 +127,7 @@ module Safire
           required_profiles_valid?,
           auth_methods_valid?,
           non_empty_arrays_valid?,
+          string_values_valid?,
           conditional_presence_valid?,
           required_subset_valid?
         ].all?
@@ -244,13 +251,41 @@ module Safire
 
       def non_empty_arrays_valid?
         valid = true
-        %i[scopes_supported grant_types_supported].each do |attr|
+        %i[
+          scopes_supported
+          grant_types_supported
+          token_endpoint_auth_signing_alg_values_supported
+          registration_endpoint_jwt_signing_alg_values_supported
+        ].each do |attr|
           next if array_any?(attr)
 
           warn_noncompliance("#{attr} must be a non-empty array (required by UDAP Security STU2)")
           valid = false
         end
         valid
+      end
+
+      def string_values_valid?
+        [url_fields_valid?, signed_metadata_format_valid?].all?
+      end
+
+      def url_fields_valid?
+        attrs = STRING_URL_ATTRIBUTES.dup
+        attrs << :authorization_endpoint unless authorization_endpoint.nil?
+        invalid = attrs.reject { |attr| valid_https_url?(public_send(attr)) }
+        invalid.each { |attr| warn_noncompliance("#{attr} must be an absolute HTTPS URL") }
+        invalid.empty?
+      end
+
+      def signed_metadata_format_valid?
+        return true if signed_metadata.is_a?(String) && signed_metadata.present?
+
+        warn_noncompliance('signed_metadata must be a non-empty string')
+        false
+      end
+
+      def valid_https_url?(value)
+        value.is_a?(String) && classify_uri(value).nil?
       end
 
       def conditional_presence_valid?

--- a/lib/safire/protocols/udap_metadata.rb
+++ b/lib/safire/protocols/udap_metadata.rb
@@ -105,7 +105,10 @@ module Safire
       # - +scopes_supported+, +grant_types_supported+, and both signing algorithm arrays each have at least one element
       # - +token_endpoint+ and +registration_endpoint+ are absolute HTTPS URLs;
       #   +authorization_endpoint+ is also validated when present
-      # - +signed_metadata+ is a compact-JWS string (three dot-separated segments)
+      # - +signed_metadata+ is a compact-JWS string (three dot-separated segments); JWT header
+      #   algorithm (+alg+), required claim presence, and signature are not validated here —
+      #   these are deferred to the cryptographic validator (future PR)
+      # - endpoint URL checks accept localhost HTTP to support development without TLS
       # - +authorization_endpoint+ present when +authorization_code+ is in +grant_types_supported+
       # - +udap_authz+ present in +udap_profiles_supported+ when +client_credentials+ is in +grant_types_supported+
       # - +authorization_code+ present in +grant_types_supported+ when +refresh_token+ is also present
@@ -150,9 +153,9 @@ module Safire
       # Capability checks — combine profile advertisement with any additional preconditions.
 
       # @return [Boolean] true when the server supports UDAP Dynamic Client Registration
-      #   (advertises +udap_dcr+ profile and provides a +registration_endpoint+)
+      #   (advertises +udap_dcr+ profile and provides a valid +registration_endpoint+)
       def supports_dynamic_registration?
-        dynamic_registration_profile? && registration_endpoint.present?
+        dynamic_registration_profile? && valid_https_url?(registration_endpoint)
       end
 
       # @return [Boolean] true when the server supports JWT client authentication (+udap_authn+ profile)
@@ -174,8 +177,10 @@ module Safire
       # @return [Boolean] true when the server supports Tiered OAuth (+udap_to+ profile)
       def supports_tiered_oauth? = tiered_oauth_profile?
 
-      # @return [Boolean] true when the server provides a signed_metadata JWT
-      def supports_signed_metadata? = signed_metadata.present?
+      # @return [Boolean] true when the server provides a signed_metadata value in compact-JWS format
+      def supports_signed_metadata?
+        signed_metadata.is_a?(String) && compact_jws_format?(signed_metadata)
+      end
 
       private
 
@@ -273,7 +278,9 @@ module Safire
         attrs = STRING_URL_ATTRIBUTES.dup
         attrs << :authorization_endpoint unless authorization_endpoint.nil?
         invalid = attrs.reject { |attr| valid_https_url?(public_send(attr)) }
-        invalid.each { |attr| warn_noncompliance("#{attr} must be an absolute HTTPS URL") }
+        invalid.each do |attr|
+          warn_noncompliance("#{attr} must be an absolute HTTPS URL (localhost HTTP is accepted for development)")
+        end
         invalid.empty?
       end
 

--- a/lib/safire/protocols/udap_metadata.rb
+++ b/lib/safire/protocols/udap_metadata.rb
@@ -67,6 +67,19 @@ module Safire
       ].freeze
 
       ATTRIBUTES = (REQUIRED_ATTRIBUTES | OPTIONAL_ATTRIBUTES).freeze
+      ARRAY_ATTRIBUTES = %i[
+        udap_versions_supported
+        udap_profiles_supported
+        udap_authorization_extensions_supported
+        udap_certifications_supported
+        grant_types_supported
+        scopes_supported
+        token_endpoint_auth_methods_supported
+        token_endpoint_auth_signing_alg_values_supported
+        registration_endpoint_jwt_signing_alg_values_supported
+        udap_authorization_extensions_required
+        udap_certifications_required
+      ].freeze
 
       attr_reader(*ATTRIBUTES)
 
@@ -82,6 +95,7 @@ module Safire
       #
       # Checks performed:
       # - All required fields are present (nil? check; empty arrays are valid required values)
+      # - All array-valued fields are arrays before any profile/grant/subset checks are performed
       # - +udap_versions_supported+ must equal <tt>["1"]</tt> exactly (STU2 fixed value)
       # - +udap_profiles_supported+ includes +"udap_dcr"+ and +"udap_authn"+
       # - +token_endpoint_auth_methods_supported+ must equal <tt>["private_key_jwt"]</tt> exactly (STU2 fixed value)
@@ -98,8 +112,11 @@ module Safire
       #
       # @return [Boolean] true if all checks pass, false if any violation is found
       def valid?
+        fields_present = required_fields_present?
+        arrays_valid = array_fields_valid?
+        return false unless fields_present && arrays_valid
+
         [
-          required_fields_present?,
           version_valid?,
           required_profiles_valid?,
           auth_methods_valid?,
@@ -139,12 +156,12 @@ module Safire
 
       # @return [Boolean] true when the server supports the authorization_code grant type
       def supports_authorization_code?
-        grant_types_supported&.include?('authorization_code') || false
+        grant_type?('authorization_code')
       end
 
       # @return [Boolean] true when the server supports the refresh_token grant type
       def supports_refresh_token?
-        grant_types_supported&.include?('refresh_token') || false
+        grant_type?('refresh_token')
       end
 
       # @return [Boolean] true when the server supports Tiered OAuth (+udap_to+ profile)
@@ -156,7 +173,26 @@ module Safire
       private
 
       def profile?(name)
-        udap_profiles_supported&.include?(name)
+        array_includes?(:udap_profiles_supported, name)
+      end
+
+      def grant_type?(name)
+        array_includes?(:grant_types_supported, name)
+      end
+
+      def array_includes?(attr, value)
+        values = public_send(attr)
+        values.is_a?(Array) && values.include?(value)
+      end
+
+      def array_any?(attr)
+        values = public_send(attr)
+        values.is_a?(Array) && values.any?
+      end
+
+      def array_or_empty(attr)
+        values = public_send(attr)
+        values.is_a?(Array) ? values : []
       end
 
       def warn_noncompliance(message)
@@ -169,6 +205,15 @@ module Safire
         missing.empty?
       end
 
+      def array_fields_valid?
+        invalid = ARRAY_ATTRIBUTES.reject do |attr|
+          value = public_send(attr)
+          value.nil? || value.is_a?(Array)
+        end
+        invalid.each { |attr| warn_noncompliance("field '#{attr}' must be an array") }
+        invalid.empty?
+      end
+
       def version_valid?
         return true if udap_versions_supported == ['1']
 
@@ -179,7 +224,7 @@ module Safire
       def required_profiles_valid?
         valid = true
         %w[udap_dcr udap_authn].each do |profile|
-          next if udap_profiles_supported&.include?(profile)
+          next if profile?(profile)
 
           warn_noncompliance("'#{profile}' is missing from udap_profiles_supported (required by UDAP Security STU2)")
           valid = false
@@ -200,8 +245,7 @@ module Safire
       def non_empty_arrays_valid?
         valid = true
         %i[scopes_supported grant_types_supported].each do |attr|
-          value = public_send(attr)
-          next if value&.any?
+          next if array_any?(attr)
 
           warn_noncompliance("#{attr} must be a non-empty array (required by UDAP Security STU2)")
           valid = false
@@ -220,7 +264,7 @@ module Safire
       end
 
       def authorization_endpoint_conditionally_present?
-        return true unless grant_types_supported&.include?('authorization_code')
+        return true unless grant_type?('authorization_code')
         return true unless authorization_endpoint.nil?
 
         warn_noncompliance('authorization_endpoint is required when authorization_code grant type is supported')
@@ -228,7 +272,7 @@ module Safire
       end
 
       def extensions_required_conditionally_present?
-        return true unless udap_authorization_extensions_supported&.any?
+        return true unless array_any?(:udap_authorization_extensions_supported)
         return true unless udap_authorization_extensions_required.nil?
 
         warn_noncompliance(
@@ -239,7 +283,7 @@ module Safire
       end
 
       def certifications_required_conditionally_present?
-        return true unless udap_certifications_supported&.any?
+        return true unless array_any?(:udap_certifications_supported)
         return true unless udap_certifications_required.nil?
 
         warn_noncompliance(
@@ -249,8 +293,8 @@ module Safire
       end
 
       def authz_profile_conditionally_present?
-        return true unless grant_types_supported&.include?('client_credentials')
-        return true if udap_profiles_supported&.include?('udap_authz')
+        return true unless grant_type?('client_credentials')
+        return true if profile?('udap_authz')
 
         warn_noncompliance(
           "'udap_authz' is required in udap_profiles_supported when client_credentials grant type is supported"
@@ -259,8 +303,8 @@ module Safire
       end
 
       def refresh_token_requires_authorization_code?
-        return true unless grant_types_supported&.include?('refresh_token')
-        return true if grant_types_supported&.include?('authorization_code')
+        return true unless grant_type?('refresh_token')
+        return true if grant_type?('authorization_code')
 
         warn_noncompliance(
           "'refresh_token' grant type requires 'authorization_code' to also be in grant_types_supported"
@@ -276,10 +320,10 @@ module Safire
       end
 
       def extensions_required_subset_valid?
-        return true unless udap_authorization_extensions_required&.any?
+        return true unless array_any?(:udap_authorization_extensions_required)
 
-        supported = udap_authorization_extensions_supported || []
-        unsupported = udap_authorization_extensions_required - supported
+        unsupported = array_or_empty(:udap_authorization_extensions_required) -
+                      array_or_empty(:udap_authorization_extensions_supported)
         return true unless unsupported.any?
 
         warn_noncompliance(
@@ -290,10 +334,10 @@ module Safire
       end
 
       def certifications_required_subset_valid?
-        return true unless udap_certifications_required&.any?
+        return true unless array_any?(:udap_certifications_required)
 
-        supported = udap_certifications_supported || []
-        unsupported = udap_certifications_required - supported
+        unsupported = array_or_empty(:udap_certifications_required) -
+                      array_or_empty(:udap_certifications_supported)
         return true unless unsupported.any?
 
         warn_noncompliance(

--- a/lib/safire/protocols/udap_metadata.rb
+++ b/lib/safire/protocols/udap_metadata.rb
@@ -1,0 +1,307 @@
+module Safire
+  module Protocols
+    # UDAP Metadata obtained from the UDAP well-known discovery endpoint.
+    # Attributes are defined as per
+    # [UDAP Security STU2](https://hl7.org/fhir/us/udap-security/STU2/discovery.html).
+    #
+    # All twelve required attributes must be present and non-nil in a conformant
+    # discovery response. {#valid?} checks both field presence and the value-level
+    # constraints mandated by STU2.
+    #
+    # @!attribute [r] udap_versions_supported
+    #   @return [Array<String>, nil] UDAP versions supported; must contain +"1"+ per STU2
+    # @!attribute [r] udap_profiles_supported
+    #   @return [Array<String>, nil] UDAP profiles advertised; must include +"udap_dcr"+ and +"udap_authn"+
+    # @!attribute [r] udap_authorization_extensions_supported
+    #   @return [Array<String>, nil] UDAP authorization extensions the server supports
+    # @!attribute [r] udap_certifications_supported
+    #   @return [Array<String>, nil] UDAP certifications the server supports
+    # @!attribute [r] grant_types_supported
+    #   @return [Array<String>, nil] OAuth2 grant types supported at the token endpoint
+    # @!attribute [r] scopes_supported
+    #   @return [Array<String>, nil] scopes a client may request
+    # @!attribute [r] token_endpoint
+    #   @return [String, nil] URL of the server's OAuth2 Token Endpoint
+    # @!attribute [r] token_endpoint_auth_methods_supported
+    #   @return [Array<String>, nil] client authentication methods at the token endpoint;
+    #     must include +"private_key_jwt"+ per STU2
+    # @!attribute [r] token_endpoint_auth_signing_alg_values_supported
+    #   @return [Array<String>, nil] JWT signing algorithms supported for client authentication
+    # @!attribute [r] registration_endpoint
+    #   @return [String, nil] URL of the server's UDAP Dynamic Client Registration Endpoint
+    # @!attribute [r] registration_endpoint_jwt_signing_alg_values_supported
+    #   @return [Array<String>, nil] JWT signing algorithms supported for registration requests
+    # @!attribute [r] signed_metadata
+    #   @return [String, nil] a signed JWT containing a subset of the server's metadata claims
+    # @!attribute [r] udap_authorization_extensions_required
+    #   @return [Array<String>, nil] extensions the server requires; values must be a subset of
+    #     {#udap_authorization_extensions_supported}; conditionally required when
+    #     {#udap_authorization_extensions_supported} is non-empty
+    # @!attribute [r] udap_certifications_required
+    #   @return [Array<String>, nil] certifications the server requires; values must be a subset of
+    #     {#udap_certifications_supported}; conditionally required when {#udap_certifications_supported}
+    #     is non-empty
+    # @!attribute [r] authorization_endpoint
+    #   @return [String, nil] URL of the server's Authorization Endpoint; conditionally required
+    #     when {#grant_types_supported} includes +"authorization_code"+
+    class UdapMetadata < Safire::Entity
+      REQUIRED_ATTRIBUTES = %i[
+        udap_versions_supported
+        udap_profiles_supported
+        udap_authorization_extensions_supported
+        udap_certifications_supported
+        grant_types_supported
+        scopes_supported
+        token_endpoint
+        token_endpoint_auth_methods_supported
+        token_endpoint_auth_signing_alg_values_supported
+        registration_endpoint
+        registration_endpoint_jwt_signing_alg_values_supported
+        signed_metadata
+      ].freeze
+
+      OPTIONAL_ATTRIBUTES = %i[
+        udap_authorization_extensions_required
+        udap_certifications_required
+        authorization_endpoint
+      ].freeze
+
+      ATTRIBUTES = (REQUIRED_ATTRIBUTES | OPTIONAL_ATTRIBUTES).freeze
+
+      attr_reader(*ATTRIBUTES)
+
+      def initialize(metadata)
+        super(metadata, ATTRIBUTES)
+      end
+
+      # Checks whether the server's UDAP metadata is valid according to UDAP Security STU2.
+      #
+      # This is a user-callable helper. Safire performs discovery without automatically
+      # asserting server compliance — it is the caller's responsibility to invoke this
+      # method when they wish to verify conformance.
+      #
+      # Checks performed:
+      # - All required fields are present (nil? check; empty arrays are valid required values)
+      # - +udap_versions_supported+ must equal <tt>["1"]</tt> exactly (STU2 fixed value)
+      # - +udap_profiles_supported+ includes +"udap_dcr"+ and +"udap_authn"+
+      # - +token_endpoint_auth_methods_supported+ must equal <tt>["private_key_jwt"]</tt> exactly (STU2 fixed value)
+      # - +scopes_supported+ and +grant_types_supported+ each have at least one element
+      # - +authorization_endpoint+ present when +authorization_code+ is in +grant_types_supported+
+      # - +udap_authz+ present in +udap_profiles_supported+ when +client_credentials+ is in +grant_types_supported+
+      # - +authorization_code+ present in +grant_types_supported+ when +refresh_token+ is also present
+      # - +udap_authorization_extensions_required+ present when +udap_authorization_extensions_supported+
+      #   is non-empty, and its values are a subset of the supported list
+      # - +udap_certifications_required+ present when +udap_certifications_supported+ is non-empty,
+      #   and its values are a subset of the supported list
+      #
+      # A warning is logged for each STU2 violation detected.
+      #
+      # @return [Boolean] true if all checks pass, false if any violation is found
+      def valid?
+        [
+          required_fields_present?,
+          version_valid?,
+          required_profiles_valid?,
+          auth_methods_valid?,
+          non_empty_arrays_valid?,
+          conditional_presence_valid?,
+          required_subset_valid?
+        ].all?
+      end
+
+      # Profile checks — test profile advertisement only, not whether required fields are present.
+
+      # @return [Boolean] true when the server advertises the +udap_dcr+ profile
+      def dynamic_registration_profile? = profile?('udap_dcr')
+
+      # @return [Boolean] true when the server advertises the +udap_authn+ profile
+      def jwt_client_auth_profile? = profile?('udap_authn')
+
+      # @return [Boolean] true when the server advertises the +udap_authz+ profile
+      def client_authorization_profile? = profile?('udap_authz')
+
+      # @return [Boolean] true when the server advertises the +udap_to+ (Tiered OAuth) profile
+      def tiered_oauth_profile? = profile?('udap_to')
+
+      # Capability checks — combine profile advertisement with any additional preconditions.
+
+      # @return [Boolean] true when the server supports UDAP Dynamic Client Registration
+      #   (advertises +udap_dcr+ profile and provides a +registration_endpoint+)
+      def supports_dynamic_registration?
+        dynamic_registration_profile? && registration_endpoint.present?
+      end
+
+      # @return [Boolean] true when the server supports JWT client authentication (+udap_authn+ profile)
+      def supports_jwt_client_auth? = jwt_client_auth_profile?
+
+      # @return [Boolean] true when the server supports the UDAP client authorization profile (+udap_authz+)
+      def supports_client_authorization? = client_authorization_profile?
+
+      # @return [Boolean] true when the server supports the authorization_code grant type
+      def supports_authorization_code?
+        grant_types_supported&.include?('authorization_code') || false
+      end
+
+      # @return [Boolean] true when the server supports the refresh_token grant type
+      def supports_refresh_token?
+        grant_types_supported&.include?('refresh_token') || false
+      end
+
+      # @return [Boolean] true when the server supports Tiered OAuth (+udap_to+ profile)
+      def supports_tiered_oauth? = tiered_oauth_profile?
+
+      # @return [Boolean] true when the server provides a signed_metadata JWT
+      def supports_signed_metadata? = signed_metadata.present?
+
+      private
+
+      def profile?(name)
+        udap_profiles_supported&.include?(name)
+      end
+
+      def warn_noncompliance(message)
+        Safire.logger.warn("UDAP metadata non-compliance: #{message}")
+      end
+
+      def required_fields_present?
+        missing = REQUIRED_ATTRIBUTES.select { |attr| public_send(attr).nil? }
+        missing.each { |attr| warn_noncompliance("required field '#{attr}' is missing") }
+        missing.empty?
+      end
+
+      def version_valid?
+        return true if udap_versions_supported == ['1']
+
+        warn_noncompliance("udap_versions_supported must be the fixed array ['1'] (UDAP Security STU2 fixed value)")
+        false
+      end
+
+      def required_profiles_valid?
+        valid = true
+        %w[udap_dcr udap_authn].each do |profile|
+          next if udap_profiles_supported&.include?(profile)
+
+          warn_noncompliance("'#{profile}' is missing from udap_profiles_supported (required by UDAP Security STU2)")
+          valid = false
+        end
+        valid
+      end
+
+      def auth_methods_valid?
+        return true if token_endpoint_auth_methods_supported == ['private_key_jwt']
+
+        warn_noncompliance(
+          "token_endpoint_auth_methods_supported must be the fixed array ['private_key_jwt'] " \
+          '(required by UDAP Security STU2)'
+        )
+        false
+      end
+
+      def non_empty_arrays_valid?
+        valid = true
+        %i[scopes_supported grant_types_supported].each do |attr|
+          value = public_send(attr)
+          next if value&.any?
+
+          warn_noncompliance("#{attr} must be a non-empty array (required by UDAP Security STU2)")
+          valid = false
+        end
+        valid
+      end
+
+      def conditional_presence_valid?
+        [
+          authorization_endpoint_conditionally_present?,
+          extensions_required_conditionally_present?,
+          certifications_required_conditionally_present?,
+          authz_profile_conditionally_present?,
+          refresh_token_requires_authorization_code?
+        ].all?
+      end
+
+      def authorization_endpoint_conditionally_present?
+        return true unless grant_types_supported&.include?('authorization_code')
+        return true unless authorization_endpoint.nil?
+
+        warn_noncompliance('authorization_endpoint is required when authorization_code grant type is supported')
+        false
+      end
+
+      def extensions_required_conditionally_present?
+        return true unless udap_authorization_extensions_supported&.any?
+        return true unless udap_authorization_extensions_required.nil?
+
+        warn_noncompliance(
+          'udap_authorization_extensions_required must be present ' \
+          'when udap_authorization_extensions_supported is non-empty'
+        )
+        false
+      end
+
+      def certifications_required_conditionally_present?
+        return true unless udap_certifications_supported&.any?
+        return true unless udap_certifications_required.nil?
+
+        warn_noncompliance(
+          'udap_certifications_required must be present when udap_certifications_supported is non-empty'
+        )
+        false
+      end
+
+      def authz_profile_conditionally_present?
+        return true unless grant_types_supported&.include?('client_credentials')
+        return true if udap_profiles_supported&.include?('udap_authz')
+
+        warn_noncompliance(
+          "'udap_authz' is required in udap_profiles_supported when client_credentials grant type is supported"
+        )
+        false
+      end
+
+      def refresh_token_requires_authorization_code?
+        return true unless grant_types_supported&.include?('refresh_token')
+        return true if grant_types_supported&.include?('authorization_code')
+
+        warn_noncompliance(
+          "'refresh_token' grant type requires 'authorization_code' to also be in grant_types_supported"
+        )
+        false
+      end
+
+      def required_subset_valid?
+        [
+          extensions_required_subset_valid?,
+          certifications_required_subset_valid?
+        ].all?
+      end
+
+      def extensions_required_subset_valid?
+        return true unless udap_authorization_extensions_required&.any?
+
+        supported = udap_authorization_extensions_supported || []
+        unsupported = udap_authorization_extensions_required - supported
+        return true unless unsupported.any?
+
+        warn_noncompliance(
+          'udap_authorization_extensions_required contains values not in ' \
+          "udap_authorization_extensions_supported: #{unsupported.join(', ')}"
+        )
+        false
+      end
+
+      def certifications_required_subset_valid?
+        return true unless udap_certifications_required&.any?
+
+        supported = udap_certifications_supported || []
+        unsupported = udap_certifications_required - supported
+        return true unless unsupported.any?
+
+        warn_noncompliance(
+          'udap_certifications_required contains values not in ' \
+          "udap_certifications_supported: #{unsupported.join(', ')}"
+        )
+        false
+      end
+    end
+  end
+end

--- a/lib/safire/protocols/udap_metadata.rb
+++ b/lib/safire/protocols/udap_metadata.rb
@@ -98,14 +98,14 @@ module Safire
       #
       # Checks performed:
       # - All required fields are present (nil? check; empty arrays are valid required values)
-      # - All array-valued fields are arrays before any profile/grant/subset checks are performed
+      # - All array-valued fields are arrays of strings before any profile/grant/subset checks are performed
       # - +udap_versions_supported+ must equal <tt>["1"]</tt> exactly (STU2 fixed value)
       # - +udap_profiles_supported+ includes +"udap_dcr"+ and +"udap_authn"+
       # - +token_endpoint_auth_methods_supported+ must equal <tt>["private_key_jwt"]</tt> exactly (STU2 fixed value)
       # - +scopes_supported+, +grant_types_supported+, and both signing algorithm arrays each have at least one element
       # - +token_endpoint+ and +registration_endpoint+ are absolute HTTPS URLs;
       #   +authorization_endpoint+ is also validated when present
-      # - +signed_metadata+ is a non-empty string
+      # - +signed_metadata+ is a compact-JWS string (three dot-separated segments)
       # - +authorization_endpoint+ present when +authorization_code+ is in +grant_types_supported+
       # - +udap_authz+ present in +udap_profiles_supported+ when +client_credentials+ is in +grant_types_supported+
       # - +authorization_code+ present in +grant_types_supported+ when +refresh_token+ is also present
@@ -215,9 +215,9 @@ module Safire
       def array_fields_valid?
         invalid = ARRAY_ATTRIBUTES.reject do |attr|
           value = public_send(attr)
-          value.nil? || value.is_a?(Array)
+          value.nil? || (value.is_a?(Array) && value.all?(String))
         end
-        invalid.each { |attr| warn_noncompliance("field '#{attr}' must be an array") }
+        invalid.each { |attr| warn_noncompliance("field '#{attr}' must be an array of strings") }
         invalid.empty?
       end
 
@@ -278,10 +278,15 @@ module Safire
       end
 
       def signed_metadata_format_valid?
-        return true if signed_metadata.is_a?(String) && signed_metadata.present?
+        return true if signed_metadata.is_a?(String) && compact_jws_format?(signed_metadata)
 
-        warn_noncompliance('signed_metadata must be a non-empty string')
+        warn_noncompliance('signed_metadata must be a compact-JWS string (header.payload.signature)')
         false
+      end
+
+      def compact_jws_format?(value)
+        parts = value.split('.', -1)
+        parts.length == 3 && parts.all?(&:present?)
       end
 
       def valid_https_url?(value)

--- a/lib/safire/protocols/udap_metadata.rb
+++ b/lib/safire/protocols/udap_metadata.rb
@@ -70,6 +70,7 @@ module Safire
 
       ATTRIBUTES = (REQUIRED_ATTRIBUTES | OPTIONAL_ATTRIBUTES).freeze
       STRING_URL_ATTRIBUTES = %i[token_endpoint registration_endpoint].freeze
+      BASE64URL_SEGMENT = /\A[A-Za-z0-9\-_]+\z/
       ARRAY_ATTRIBUTES = %i[
         udap_versions_supported
         udap_profiles_supported
@@ -105,8 +106,8 @@ module Safire
       # - +scopes_supported+, +grant_types_supported+, and both signing algorithm arrays each have at least one element
       # - +token_endpoint+ and +registration_endpoint+ are absolute HTTPS URLs;
       #   +authorization_endpoint+ is also validated when present
-      # - +signed_metadata+ is a compact-JWS string (three dot-separated segments); JWT header
-      #   algorithm (+alg+), required claim presence, and signature are not validated here —
+      # - +signed_metadata+ is a compact-JWS string (three base64url-encoded dot-separated segments);
+      #   JWT header algorithm (+alg+), required claim presence, and signature are not validated here —
       #   these are deferred to the cryptographic validator (future PR)
       # - endpoint URL checks accept localhost HTTP to support development without TLS
       # - +authorization_endpoint+ present when +authorization_code+ is in +grant_types_supported+
@@ -158,11 +159,18 @@ module Safire
         dynamic_registration_profile? && valid_https_url?(registration_endpoint)
       end
 
-      # @return [Boolean] true when the server supports JWT client authentication (+udap_authn+ profile)
-      def supports_jwt_client_auth? = jwt_client_auth_profile?
+      # @return [Boolean] true when the server supports JWT client authentication
+      #   (advertises +udap_authn+ profile and provides a valid +token_endpoint+)
+      def supports_jwt_client_auth?
+        jwt_client_auth_profile? && valid_https_url?(token_endpoint)
+      end
 
-      # @return [Boolean] true when the server supports the UDAP client authorization profile (+udap_authz+)
-      def supports_client_authorization? = client_authorization_profile?
+      # @return [Boolean] true when the server supports the UDAP client authorization profile
+      #   (advertises +udap_authz+ profile, supports the +client_credentials+ grant, and provides
+      #   a valid +token_endpoint+)
+      def supports_client_authorization?
+        client_authorization_profile? && grant_type?('client_credentials') && valid_https_url?(token_endpoint)
+      end
 
       # @return [Boolean] true when the server supports the authorization_code grant type
       def supports_authorization_code?
@@ -293,7 +301,7 @@ module Safire
 
       def compact_jws_format?(value)
         parts = value.split('.', -1)
-        parts.length == 3 && parts.all?(&:present?)
+        parts.length == 3 && parts.all? { |p| BASE64URL_SEGMENT.match?(p) }
       end
 
       def valid_https_url?(value)
@@ -319,23 +327,24 @@ module Safire
       end
 
       def extensions_required_conditionally_present?
-        return true unless array_any?(:udap_authorization_extensions_supported)
-        return true unless udap_authorization_extensions_required.nil?
-
-        warn_noncompliance(
-          'udap_authorization_extensions_required must be present ' \
-          'when udap_authorization_extensions_supported is non-empty'
+        required_conditionally_present?(
+          :udap_authorization_extensions_required,
+          :udap_authorization_extensions_supported
         )
-        false
       end
 
       def certifications_required_conditionally_present?
-        return true unless array_any?(:udap_certifications_supported)
-        return true unless udap_certifications_required.nil?
-
-        warn_noncompliance(
-          'udap_certifications_required must be present when udap_certifications_supported is non-empty'
+        required_conditionally_present?(
+          :udap_certifications_required,
+          :udap_certifications_supported
         )
+      end
+
+      def required_conditionally_present?(required_attr, supported_attr)
+        return true unless array_any?(supported_attr)
+        return true unless public_send(required_attr).nil?
+
+        warn_noncompliance("#{required_attr} must be present when #{supported_attr} is non-empty")
         false
       end
 
@@ -367,30 +376,26 @@ module Safire
       end
 
       def extensions_required_subset_valid?
-        return true unless array_any?(:udap_authorization_extensions_required)
-
-        unsupported = array_or_empty(:udap_authorization_extensions_required) -
-                      array_or_empty(:udap_authorization_extensions_supported)
-        return true unless unsupported.any?
-
-        warn_noncompliance(
-          'udap_authorization_extensions_required contains values not in ' \
-          "udap_authorization_extensions_supported: #{unsupported.join(', ')}"
+        required_subset_valid_for?(
+          :udap_authorization_extensions_required,
+          :udap_authorization_extensions_supported
         )
-        false
       end
 
       def certifications_required_subset_valid?
-        return true unless array_any?(:udap_certifications_required)
+        required_subset_valid_for?(
+          :udap_certifications_required,
+          :udap_certifications_supported
+        )
+      end
 
-        unsupported = array_or_empty(:udap_certifications_required) -
-                      array_or_empty(:udap_certifications_supported)
+      def required_subset_valid_for?(required_attr, supported_attr)
+        return true unless array_any?(required_attr)
+
+        unsupported = array_or_empty(required_attr) - array_or_empty(supported_attr)
         return true unless unsupported.any?
 
-        warn_noncompliance(
-          'udap_certifications_required contains values not in ' \
-          "udap_certifications_supported: #{unsupported.join(', ')}"
-        )
+        warn_noncompliance("#{required_attr} contains values not in #{supported_attr}: #{unsupported.join(', ')}")
         false
       end
     end

--- a/lib/safire/uri_validation.rb
+++ b/lib/safire/uri_validation.rb
@@ -11,19 +11,24 @@ module Safire
 
     # Classifies a URI value as +:invalid+, +:non_https+, or +nil+ (acceptable).
     #
+    # HTTPS is accepted for all hosts. Plain HTTP is accepted only for localhost
+    # and 127.0.0.1 to support development without TLS. Any other scheme
+    # (including non-HTTP schemes on localhost) returns +:non_https+.
+    #
     # @param value [String, nil] the URI string to classify
     # @return [:invalid, :non_https, nil]
     def classify_uri(value)
       uri = Addressable::URI.parse(value)
       return :invalid unless uri.scheme && uri.host
+      return if uri.scheme == 'https'
+      return if uri.scheme == 'http' && localhost_host?(uri.host)
 
-      :non_https if uri.scheme != 'https' && !localhost_host?(uri.host)
+      :non_https
     rescue Addressable::URI::InvalidURIError
       :invalid
     end
 
     # Returns +true+ when the host is a local loopback address.
-    # HTTP is permitted for localhost to support development without TLS.
     #
     # @param host [String] the URI host
     # @return [Boolean]

--- a/spec/safire/protocols/udap_metadata_spec.rb
+++ b/spec/safire/protocols/udap_metadata_spec.rb
@@ -42,6 +42,19 @@ RSpec.describe Safire::Protocols::UdapMetadata do
       end
     end
 
+    context 'when an array-valued field has a malformed type' do
+      described_class::ARRAY_ATTRIBUTES.each do |attr|
+        it "returns false and logs a warning when #{attr} is not an array" do
+          m = described_class.new(full_metadata.merge(attr.to_s => attr.to_s))
+          result = nil
+
+          expect { result = m.valid? }.not_to raise_error
+          expect(result).to be(false)
+          expect(Safire.logger).to have_received(:warn).with(/field '#{attr}' must be an array/)
+        end
+      end
+    end
+
     context "when udap_versions_supported is not the fixed array ['1']" do
       it "returns false and logs a warning when '1' is absent" do
         m = described_class.new(full_metadata.merge('udap_versions_supported' => ['2']))
@@ -245,6 +258,12 @@ RSpec.describe Safire::Protocols::UdapMetadata do
 
         expect(m.dynamic_registration_profile?).to be(false)
       end
+
+      it 'does not substring-match malformed scalar metadata' do
+        m = described_class.new(full_metadata.merge('udap_profiles_supported' => 'udap_dcr'))
+
+        expect(m.dynamic_registration_profile?).to be(false)
+      end
     end
 
     describe '#jwt_client_auth_profile?' do
@@ -254,6 +273,12 @@ RSpec.describe Safire::Protocols::UdapMetadata do
 
       it "returns false when 'udap_authn' is absent" do
         m = described_class.new(full_metadata.merge('udap_profiles_supported' => ['udap_dcr']))
+
+        expect(m.jwt_client_auth_profile?).to be(false)
+      end
+
+      it 'does not substring-match malformed scalar metadata' do
+        m = described_class.new(full_metadata.merge('udap_profiles_supported' => 'udap_authn'))
 
         expect(m.jwt_client_auth_profile?).to be(false)
       end
@@ -269,6 +294,12 @@ RSpec.describe Safire::Protocols::UdapMetadata do
 
         expect(m.client_authorization_profile?).to be(false)
       end
+
+      it 'does not substring-match malformed scalar metadata' do
+        m = described_class.new(full_metadata.merge('udap_profiles_supported' => 'udap_authz'))
+
+        expect(m.client_authorization_profile?).to be(false)
+      end
     end
 
     describe '#tiered_oauth_profile?' do
@@ -280,6 +311,12 @@ RSpec.describe Safire::Protocols::UdapMetadata do
 
       it "returns false when 'udap_to' is absent" do
         expect(metadata.tiered_oauth_profile?).to be(false)
+      end
+
+      it 'does not substring-match malformed scalar metadata' do
+        m = described_class.new(full_metadata.merge('udap_profiles_supported' => 'udap_to'))
+
+        expect(m.tiered_oauth_profile?).to be(false)
       end
     end
   end
@@ -343,6 +380,12 @@ RSpec.describe Safire::Protocols::UdapMetadata do
 
         expect(m.supports_authorization_code?).to be(false)
       end
+
+      it 'does not substring-match malformed scalar metadata' do
+        m = described_class.new(full_metadata.merge('grant_types_supported' => 'authorization_code'))
+
+        expect(m.supports_authorization_code?).to be(false)
+      end
     end
 
     describe '#supports_refresh_token?' do
@@ -358,6 +401,12 @@ RSpec.describe Safire::Protocols::UdapMetadata do
 
       it 'returns false when grant_types_supported is nil' do
         m = described_class.new(full_metadata.except('grant_types_supported'))
+
+        expect(m.supports_refresh_token?).to be(false)
+      end
+
+      it 'does not substring-match malformed scalar metadata' do
+        m = described_class.new(full_metadata.merge('grant_types_supported' => 'refresh_token'))
 
         expect(m.supports_refresh_token?).to be(false)
       end

--- a/spec/safire/protocols/udap_metadata_spec.rb
+++ b/spec/safire/protocols/udap_metadata_spec.rb
@@ -1,0 +1,390 @@
+require 'spec_helper'
+
+RSpec.describe Safire::Protocols::UdapMetadata do
+  let(:full_metadata) do
+    {
+      'udap_versions_supported' => ['1'],
+      'udap_profiles_supported' => %w[udap_dcr udap_authn udap_authz],
+      'udap_authorization_extensions_supported' => %w[hl7-b2b hl7-b2b-user],
+      'udap_certifications_supported' => ['https://www.example.com/udap/profile/1'],
+      'grant_types_supported' => %w[authorization_code client_credentials],
+      'scopes_supported' => %w[openid profile launch user/*.rs],
+      'token_endpoint' => 'https://fhir.example.com/token',
+      'token_endpoint_auth_methods_supported' => ['private_key_jwt'],
+      'token_endpoint_auth_signing_alg_values_supported' => ['RS256'],
+      'registration_endpoint' => 'https://fhir.example.com/register',
+      'registration_endpoint_jwt_signing_alg_values_supported' => ['RS256'],
+      'signed_metadata' => 'eyJhbGci...',
+      'authorization_endpoint' => 'https://fhir.example.com/authorize',
+      'udap_authorization_extensions_required' => ['hl7-b2b'],
+      'udap_certifications_required' => ['https://www.example.com/udap/profile/1']
+    }
+  end
+
+  let(:metadata) { described_class.new(full_metadata) }
+
+  describe '#valid?' do
+    before { allow(Safire.logger).to receive(:warn) }
+
+    it 'returns true when all required fields are present and all constraints pass' do
+      expect(metadata.valid?).to be(true)
+      expect(Safire.logger).not_to have_received(:warn)
+    end
+
+    context 'when a required field is missing' do
+      described_class::REQUIRED_ATTRIBUTES.each do |attr|
+        it "returns false and logs a warning when #{attr} is absent" do
+          m = described_class.new(full_metadata.except(attr.to_s))
+
+          expect(m.valid?).to be(false)
+          expect(Safire.logger).to have_received(:warn).with(/required field '#{attr}' is missing/)
+        end
+      end
+    end
+
+    context "when udap_versions_supported is not the fixed array ['1']" do
+      it "returns false and logs a warning when '1' is absent" do
+        m = described_class.new(full_metadata.merge('udap_versions_supported' => ['2']))
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn).with(/udap_versions_supported must be the fixed array/)
+      end
+
+      it 'returns false and logs a warning when extra values are present alongside "1"' do
+        m = described_class.new(full_metadata.merge('udap_versions_supported' => %w[1 2]))
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn).with(/udap_versions_supported must be the fixed array/)
+      end
+    end
+
+    context 'when udap_profiles_supported is missing required profiles' do
+      it "returns false and logs a warning when 'udap_dcr' is absent" do
+        m = described_class.new(full_metadata.merge('udap_profiles_supported' => ['udap_authn']))
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn).with(/'udap_dcr' is missing from udap_profiles_supported/)
+      end
+
+      it "returns false and logs a warning when 'udap_authn' is absent" do
+        m = described_class.new(full_metadata.merge('udap_profiles_supported' => ['udap_dcr']))
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn).with(/'udap_authn' is missing from udap_profiles_supported/)
+      end
+    end
+
+    context "when token_endpoint_auth_methods_supported is not the fixed array ['private_key_jwt']" do
+      it "returns false and logs a warning when 'private_key_jwt' is absent" do
+        m = described_class.new(full_metadata.merge('token_endpoint_auth_methods_supported' => ['client_secret_basic']))
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn)
+          .with(/token_endpoint_auth_methods_supported must be the fixed array/)
+      end
+
+      it 'returns false and logs a warning when extra methods are present alongside private_key_jwt' do
+        data = full_metadata.merge('token_endpoint_auth_methods_supported' => %w[private_key_jwt client_secret_basic])
+        m = described_class.new(data)
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn)
+          .with(/token_endpoint_auth_methods_supported must be the fixed array/)
+      end
+    end
+
+    context 'when scopes_supported is empty' do
+      it 'returns false and logs a warning' do
+        m = described_class.new(full_metadata.merge('scopes_supported' => []))
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn).with(/scopes_supported must be a non-empty array/)
+      end
+    end
+
+    context 'when grant_types_supported is empty' do
+      it 'returns false and logs a warning' do
+        m = described_class.new(full_metadata.merge('grant_types_supported' => []))
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn).with(/grant_types_supported must be a non-empty array/)
+      end
+    end
+
+    context 'when authorization_code is in grant_types_supported' do
+      it 'returns false and logs a warning when authorization_endpoint is absent' do
+        m = described_class.new(full_metadata.except('authorization_endpoint'))
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn)
+          .with(/authorization_endpoint is required when authorization_code grant type is supported/)
+      end
+    end
+
+    context 'when authorization_code is not in grant_types_supported' do
+      it 'does not require authorization_endpoint' do
+        data = full_metadata.merge('grant_types_supported' => ['client_credentials']).except('authorization_endpoint')
+        m = described_class.new(data)
+
+        expect(m.valid?).to be(true)
+        expect(Safire.logger).not_to have_received(:warn)
+      end
+    end
+
+    context 'when udap_authorization_extensions_supported is non-empty' do
+      it 'returns false and logs a warning when udap_authorization_extensions_required is absent' do
+        m = described_class.new(full_metadata.except('udap_authorization_extensions_required'))
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn)
+          .with(/udap_authorization_extensions_required must be present/)
+      end
+
+      it 'returns false and logs a warning when a required extension is not in supported' do
+        data = full_metadata.merge('udap_authorization_extensions_required' => %w[hl7-b2b custom-ext])
+        m = described_class.new(data)
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn)
+          .with(/udap_authorization_extensions_required.*not in udap_authorization_extensions_supported.*custom-ext/)
+      end
+    end
+
+    context 'when udap_authorization_extensions_supported is empty' do
+      it 'does not require udap_authorization_extensions_required' do
+        data = full_metadata
+               .merge('udap_authorization_extensions_supported' => [])
+               .except('udap_authorization_extensions_required')
+        m = described_class.new(data)
+
+        expect(m.valid?).to be(true)
+        expect(Safire.logger).not_to have_received(:warn)
+      end
+    end
+
+    context 'when udap_certifications_supported is non-empty' do
+      it 'returns false and logs a warning when udap_certifications_required is absent' do
+        m = described_class.new(full_metadata.except('udap_certifications_required'))
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn)
+          .with(/udap_certifications_required must be present/)
+      end
+
+      it 'returns false and logs a warning when a required certification is not in supported' do
+        data = full_metadata.merge('udap_certifications_required' => ['https://other.example.com/cert'])
+        m = described_class.new(data)
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn)
+          .with(/udap_certifications_required contains values not in udap_certifications_supported/)
+      end
+    end
+
+    context 'when udap_certifications_supported is empty' do
+      it 'does not require udap_certifications_required' do
+        data = full_metadata
+               .merge('udap_certifications_supported' => [])
+               .except('udap_certifications_required')
+        m = described_class.new(data)
+
+        expect(m.valid?).to be(true)
+        expect(Safire.logger).not_to have_received(:warn)
+      end
+    end
+
+    context "when grant_types_supported includes 'client_credentials'" do
+      it "returns false and logs a warning when 'udap_authz' is absent from udap_profiles_supported" do
+        data = full_metadata.merge('udap_profiles_supported' => %w[udap_dcr udap_authn])
+        m = described_class.new(data)
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn)
+          .with(/'udap_authz'.*required.*udap_profiles_supported.*client_credentials/)
+      end
+
+      it "does not require 'udap_authz' when 'client_credentials' is absent" do
+        data = full_metadata
+               .merge('grant_types_supported' => ['authorization_code'])
+               .merge('udap_profiles_supported' => %w[udap_dcr udap_authn])
+        m = described_class.new(data)
+
+        expect(m.valid?).to be(true)
+        expect(Safire.logger).not_to have_received(:warn)
+      end
+    end
+
+    context "when grant_types_supported includes 'refresh_token'" do
+      it "returns false and logs a warning when 'authorization_code' is absent" do
+        data = full_metadata.merge('grant_types_supported' => %w[refresh_token client_credentials])
+        m = described_class.new(data)
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn)
+          .with(/'refresh_token'.*requires.*'authorization_code'/)
+      end
+
+      it "passes when 'authorization_code' is also present" do
+        data = full_metadata.merge('grant_types_supported' => %w[authorization_code refresh_token client_credentials])
+        m = described_class.new(data)
+
+        expect(m.valid?).to be(true)
+        expect(Safire.logger).not_to have_received(:warn)
+      end
+    end
+  end
+
+  describe 'profile checks' do
+    describe '#dynamic_registration_profile?' do
+      it "returns true when 'udap_dcr' is in udap_profiles_supported" do
+        expect(metadata.dynamic_registration_profile?).to be(true)
+      end
+
+      it "returns false when 'udap_dcr' is absent" do
+        m = described_class.new(full_metadata.merge('udap_profiles_supported' => ['udap_authn']))
+
+        expect(m.dynamic_registration_profile?).to be(false)
+      end
+    end
+
+    describe '#jwt_client_auth_profile?' do
+      it "returns true when 'udap_authn' is in udap_profiles_supported" do
+        expect(metadata.jwt_client_auth_profile?).to be(true)
+      end
+
+      it "returns false when 'udap_authn' is absent" do
+        m = described_class.new(full_metadata.merge('udap_profiles_supported' => ['udap_dcr']))
+
+        expect(m.jwt_client_auth_profile?).to be(false)
+      end
+    end
+
+    describe '#client_authorization_profile?' do
+      it "returns true when 'udap_authz' is in udap_profiles_supported" do
+        expect(metadata.client_authorization_profile?).to be(true)
+      end
+
+      it "returns false when 'udap_authz' is absent" do
+        m = described_class.new(full_metadata.merge('udap_profiles_supported' => %w[udap_dcr udap_authn]))
+
+        expect(m.client_authorization_profile?).to be(false)
+      end
+    end
+
+    describe '#tiered_oauth_profile?' do
+      it "returns true when 'udap_to' is in udap_profiles_supported" do
+        m = described_class.new(full_metadata.merge('udap_profiles_supported' => %w[udap_dcr udap_authn udap_to]))
+
+        expect(m.tiered_oauth_profile?).to be(true)
+      end
+
+      it "returns false when 'udap_to' is absent" do
+        expect(metadata.tiered_oauth_profile?).to be(false)
+      end
+    end
+  end
+
+  describe 'capability checks' do
+    describe '#supports_dynamic_registration?' do
+      it "returns true when 'udap_dcr' profile and registration_endpoint are both present" do
+        expect(metadata.supports_dynamic_registration?).to be(true)
+      end
+
+      it "returns false when 'udap_dcr' profile is absent" do
+        m = described_class.new(full_metadata.merge('udap_profiles_supported' => ['udap_authn']))
+
+        expect(m.supports_dynamic_registration?).to be(false)
+      end
+
+      it 'returns false when registration_endpoint is absent' do
+        m = described_class.new(full_metadata.except('registration_endpoint'))
+
+        expect(m.supports_dynamic_registration?).to be(false)
+      end
+    end
+
+    describe '#supports_jwt_client_auth?' do
+      it "returns true when 'udap_authn' is in udap_profiles_supported" do
+        expect(metadata.supports_jwt_client_auth?).to be(true)
+      end
+
+      it "returns false when 'udap_authn' is absent" do
+        m = described_class.new(full_metadata.merge('udap_profiles_supported' => ['udap_dcr']))
+
+        expect(m.supports_jwt_client_auth?).to be(false)
+      end
+    end
+
+    describe '#supports_client_authorization?' do
+      it "returns true when 'udap_authz' is in udap_profiles_supported" do
+        expect(metadata.supports_client_authorization?).to be(true)
+      end
+
+      it "returns false when 'udap_authz' is absent" do
+        m = described_class.new(full_metadata.merge('udap_profiles_supported' => %w[udap_dcr udap_authn]))
+
+        expect(m.supports_client_authorization?).to be(false)
+      end
+    end
+
+    describe '#supports_authorization_code?' do
+      it "returns true when 'authorization_code' is in grant_types_supported" do
+        expect(metadata.supports_authorization_code?).to be(true)
+      end
+
+      it "returns false when 'authorization_code' is absent" do
+        m = described_class.new(full_metadata.merge('grant_types_supported' => ['client_credentials']))
+
+        expect(m.supports_authorization_code?).to be(false)
+      end
+
+      it 'returns false when grant_types_supported is nil' do
+        m = described_class.new(full_metadata.except('grant_types_supported'))
+
+        expect(m.supports_authorization_code?).to be(false)
+      end
+    end
+
+    describe '#supports_refresh_token?' do
+      it "returns true when 'refresh_token' is in grant_types_supported" do
+        m = described_class.new(full_metadata.merge('grant_types_supported' => %w[authorization_code refresh_token]))
+
+        expect(m.supports_refresh_token?).to be(true)
+      end
+
+      it "returns false when 'refresh_token' is absent" do
+        expect(metadata.supports_refresh_token?).to be(false)
+      end
+
+      it 'returns false when grant_types_supported is nil' do
+        m = described_class.new(full_metadata.except('grant_types_supported'))
+
+        expect(m.supports_refresh_token?).to be(false)
+      end
+    end
+
+    describe '#supports_tiered_oauth?' do
+      it "returns true when 'udap_to' is in udap_profiles_supported" do
+        m = described_class.new(full_metadata.merge('udap_profiles_supported' => %w[udap_dcr udap_authn udap_to]))
+
+        expect(m.supports_tiered_oauth?).to be(true)
+      end
+
+      it "returns false when 'udap_to' is absent" do
+        expect(metadata.supports_tiered_oauth?).to be(false)
+      end
+    end
+
+    describe '#supports_signed_metadata?' do
+      it 'returns true when signed_metadata is present' do
+        expect(metadata.supports_signed_metadata?).to be(true)
+      end
+
+      it 'returns false when signed_metadata is absent' do
+        m = described_class.new(full_metadata.except('signed_metadata'))
+
+        expect(m.supports_signed_metadata?).to be(false)
+      end
+    end
+  end
+end

--- a/spec/safire/protocols/udap_metadata_spec.rb
+++ b/spec/safire/protocols/udap_metadata_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Safire::Protocols::UdapMetadata do
       'token_endpoint_auth_signing_alg_values_supported' => ['RS256'],
       'registration_endpoint' => 'https://fhir.example.com/register',
       'registration_endpoint_jwt_signing_alg_values_supported' => ['RS256'],
-      'signed_metadata' => 'eyJhbGci...',
+      'signed_metadata' => 'eyJhbGci.eyJpc3M.c2ln',
       'authorization_endpoint' => 'https://fhir.example.com/authorize',
       'udap_authorization_extensions_required' => ['hl7-b2b'],
       'udap_certifications_required' => ['https://www.example.com/udap/profile/1']
@@ -51,6 +51,19 @@ RSpec.describe Safire::Protocols::UdapMetadata do
           expect { result = m.valid? }.not_to raise_error
           expect(result).to be(false)
           expect(Safire.logger).to have_received(:warn).with(/field '#{attr}' must be an array/)
+        end
+      end
+    end
+
+    context 'when an array-valued field contains non-string elements' do
+      described_class::ARRAY_ATTRIBUTES.each do |attr|
+        it "returns false and logs a warning when #{attr} contains a non-string element" do
+          m = described_class.new(full_metadata.merge(attr.to_s => ['valid', 123]))
+          result = nil
+
+          expect { result = m.valid? }.not_to raise_error
+          expect(result).to be(false)
+          expect(Safire.logger).to have_received(:warn).with(/field '#{attr}' must be an array of strings/)
         end
       end
     end
@@ -176,7 +189,23 @@ RSpec.describe Safire::Protocols::UdapMetadata do
         m = described_class.new(full_metadata.merge('signed_metadata' => ''))
 
         expect(m.valid?).to be(false)
-        expect(Safire.logger).to have_received(:warn).with(/signed_metadata must be a non-empty string/)
+        expect(Safire.logger).to have_received(:warn).with(/signed_metadata must be a compact-JWS string/)
+      end
+    end
+
+    context 'when signed_metadata is not compact-JWS format' do
+      it 'returns false and logs a warning for a plain string with no dots' do
+        m = described_class.new(full_metadata.merge('signed_metadata' => 'not-a-jwt'))
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn).with(/signed_metadata must be a compact-JWS string/)
+      end
+
+      it 'returns false and logs a warning for a two-part string' do
+        m = described_class.new(full_metadata.merge('signed_metadata' => 'header.payload'))
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn).with(/signed_metadata must be a compact-JWS string/)
       end
     end
 

--- a/spec/safire/protocols/udap_metadata_spec.rb
+++ b/spec/safire/protocols/udap_metadata_spec.rb
@@ -124,6 +124,62 @@ RSpec.describe Safire::Protocols::UdapMetadata do
       end
     end
 
+    context 'when token_endpoint_auth_signing_alg_values_supported is empty' do
+      it 'returns false and logs a warning' do
+        m = described_class.new(full_metadata.merge('token_endpoint_auth_signing_alg_values_supported' => []))
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn)
+          .with(/token_endpoint_auth_signing_alg_values_supported must be a non-empty array/)
+      end
+    end
+
+    context 'when registration_endpoint_jwt_signing_alg_values_supported is empty' do
+      it 'returns false and logs a warning' do
+        m = described_class.new(full_metadata.merge('registration_endpoint_jwt_signing_alg_values_supported' => []))
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn)
+          .with(/registration_endpoint_jwt_signing_alg_values_supported must be a non-empty array/)
+      end
+    end
+
+    context 'when a required endpoint URL is not an absolute HTTPS URL' do
+      %w[token_endpoint registration_endpoint].each do |field|
+        it "returns false and logs a warning when #{field} is an HTTP URL" do
+          m = described_class.new(full_metadata.merge(field => 'http://fhir.example.com/endpoint'))
+
+          expect(m.valid?).to be(false)
+          expect(Safire.logger).to have_received(:warn).with(/#{field} must be an absolute HTTPS URL/)
+        end
+
+        it "returns false and logs a warning when #{field} is a blank string" do
+          m = described_class.new(full_metadata.merge(field => ''))
+
+          expect(m.valid?).to be(false)
+          expect(Safire.logger).to have_received(:warn).with(/#{field} must be an absolute HTTPS URL/)
+        end
+      end
+    end
+
+    context 'when authorization_endpoint is present but not an absolute HTTPS URL' do
+      it 'returns false and logs a warning' do
+        m = described_class.new(full_metadata.merge('authorization_endpoint' => 'http://fhir.example.com/auth'))
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn).with(/authorization_endpoint must be an absolute HTTPS URL/)
+      end
+    end
+
+    context 'when signed_metadata is a blank string' do
+      it 'returns false and logs a warning' do
+        m = described_class.new(full_metadata.merge('signed_metadata' => ''))
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn).with(/signed_metadata must be a non-empty string/)
+      end
+    end
+
     context 'when authorization_code is in grant_types_supported' do
       it 'returns false and logs a warning when authorization_endpoint is absent' do
         m = described_class.new(full_metadata.except('authorization_endpoint'))

--- a/spec/safire/protocols/udap_metadata_spec.rb
+++ b/spec/safire/protocols/udap_metadata_spec.rb
@@ -207,6 +207,13 @@ RSpec.describe Safire::Protocols::UdapMetadata do
         expect(m.valid?).to be(false)
         expect(Safire.logger).to have_received(:warn).with(/signed_metadata must be a compact-JWS string/)
       end
+
+      it 'returns false and logs a warning when a segment contains non-base64url characters' do
+        m = described_class.new(full_metadata.merge('signed_metadata' => 'not a.jwt.!!!'))
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn).with(/signed_metadata must be a compact-JWS string/)
+      end
     end
 
     context 'when authorization_code is in grant_types_supported' do
@@ -432,7 +439,7 @@ RSpec.describe Safire::Protocols::UdapMetadata do
     end
 
     describe '#supports_jwt_client_auth?' do
-      it "returns true when 'udap_authn' is in udap_profiles_supported" do
+      it "returns true when 'udap_authn' profile and a valid token_endpoint are both present" do
         expect(metadata.supports_jwt_client_auth?).to be(true)
       end
 
@@ -441,15 +448,45 @@ RSpec.describe Safire::Protocols::UdapMetadata do
 
         expect(m.supports_jwt_client_auth?).to be(false)
       end
+
+      it 'returns false when token_endpoint is absent' do
+        m = described_class.new(full_metadata.except('token_endpoint'))
+
+        expect(m.supports_jwt_client_auth?).to be(false)
+      end
+
+      it 'returns false when token_endpoint is not a valid HTTPS URL' do
+        m = described_class.new(full_metadata.merge('token_endpoint' => 'http://remote.example.com/token'))
+
+        expect(m.supports_jwt_client_auth?).to be(false)
+      end
     end
 
     describe '#supports_client_authorization?' do
-      it "returns true when 'udap_authz' is in udap_profiles_supported" do
+      it "returns true when 'udap_authz' profile, client_credentials grant, and valid token_endpoint are all present" do
         expect(metadata.supports_client_authorization?).to be(true)
       end
 
       it "returns false when 'udap_authz' is absent" do
         m = described_class.new(full_metadata.merge('udap_profiles_supported' => %w[udap_dcr udap_authn]))
+
+        expect(m.supports_client_authorization?).to be(false)
+      end
+
+      it "returns false when 'client_credentials' is absent from grant_types_supported" do
+        m = described_class.new(full_metadata.merge('grant_types_supported' => ['authorization_code']))
+
+        expect(m.supports_client_authorization?).to be(false)
+      end
+
+      it 'returns false when token_endpoint is absent' do
+        m = described_class.new(full_metadata.except('token_endpoint'))
+
+        expect(m.supports_client_authorization?).to be(false)
+      end
+
+      it 'returns false when token_endpoint is not a valid HTTPS URL' do
+        m = described_class.new(full_metadata.merge('token_endpoint' => 'http://remote.example.com/token'))
 
         expect(m.supports_client_authorization?).to be(false)
       end
@@ -516,7 +553,7 @@ RSpec.describe Safire::Protocols::UdapMetadata do
     end
 
     describe '#supports_signed_metadata?' do
-      it 'returns true when signed_metadata is present' do
+      it 'returns true when signed_metadata is a compact-JWS string' do
         expect(metadata.supports_signed_metadata?).to be(true)
       end
 
@@ -526,8 +563,14 @@ RSpec.describe Safire::Protocols::UdapMetadata do
         expect(m.supports_signed_metadata?).to be(false)
       end
 
-      it 'returns false when signed_metadata is not compact-JWS format' do
+      it 'returns false when signed_metadata has fewer than three dot-separated segments' do
         m = described_class.new(full_metadata.merge('signed_metadata' => 'not-a-jwt'))
+
+        expect(m.supports_signed_metadata?).to be(false)
+      end
+
+      it 'returns false when a segment contains non-base64url characters' do
+        m = described_class.new(full_metadata.merge('signed_metadata' => 'not a.jwt.!!!'))
 
         expect(m.supports_signed_metadata?).to be(false)
       end

--- a/spec/safire/protocols/udap_metadata_spec.rb
+++ b/spec/safire/protocols/udap_metadata_spec.rb
@@ -423,6 +423,12 @@ RSpec.describe Safire::Protocols::UdapMetadata do
 
         expect(m.supports_dynamic_registration?).to be(false)
       end
+
+      it 'returns false when registration_endpoint is not a valid HTTPS URL' do
+        m = described_class.new(full_metadata.merge('registration_endpoint' => 'http://fhir.example.com/register'))
+
+        expect(m.supports_dynamic_registration?).to be(false)
+      end
     end
 
     describe '#supports_jwt_client_auth?' do
@@ -516,6 +522,12 @@ RSpec.describe Safire::Protocols::UdapMetadata do
 
       it 'returns false when signed_metadata is absent' do
         m = described_class.new(full_metadata.except('signed_metadata'))
+
+        expect(m.supports_signed_metadata?).to be(false)
+      end
+
+      it 'returns false when signed_metadata is not compact-JWS format' do
+        m = described_class.new(full_metadata.merge('signed_metadata' => 'not-a-jwt'))
 
         expect(m.supports_signed_metadata?).to be(false)
       end

--- a/spec/safire/uri_validation_spec.rb
+++ b/spec/safire/uri_validation_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+RSpec.describe Safire::URIValidation do
+  subject(:host) do
+    Class.new do
+      include Safire::URIValidation
+
+      public :classify_uri
+    end.new
+  end
+
+  describe '#classify_uri' do
+    it 'returns nil for an absolute HTTPS URL' do
+      expect(host.classify_uri('https://example.com/path')).to be_nil
+    end
+
+    it 'returns :non_https for HTTP on a remote host' do
+      expect(host.classify_uri('http://example.com/path')).to eq(:non_https)
+    end
+
+    it 'returns :non_https for an FTP URL on a remote host' do
+      expect(host.classify_uri('ftp://example.com/path')).to eq(:non_https)
+    end
+
+    it 'returns nil for HTTP on localhost' do
+      expect(host.classify_uri('http://localhost/path')).to be_nil
+    end
+
+    it 'returns nil for HTTP on localhost with a port' do
+      expect(host.classify_uri('http://localhost:3000/path')).to be_nil
+    end
+
+    it 'returns nil for HTTP on 127.0.0.1' do
+      expect(host.classify_uri('http://127.0.0.1/path')).to be_nil
+    end
+
+    it 'returns :non_https for FTP on localhost (only HTTP is exempt)' do
+      expect(host.classify_uri('ftp://localhost/path')).to eq(:non_https)
+    end
+
+    it 'returns :non_https for WS on localhost (only HTTP is exempt)' do
+      expect(host.classify_uri('ws://localhost/path')).to eq(:non_https)
+    end
+
+    it 'returns :invalid for a string without a scheme or host' do
+      expect(host.classify_uri('not-a-url')).to eq(:invalid)
+    end
+
+    it 'returns :invalid for an empty string' do
+      expect(host.classify_uri('')).to eq(:invalid)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Safire::Protocols::UdapMetadata`, a typed entity for UDAP Security STU2 discovery responses from `/.well-known/udap`
- `valid?` enforces all twelve required fields plus eight value-level STU2 constraints (fixed arrays, conditional presence, cross-field relationships)
- Exposes a two-tier helper API: profile checks (`dynamic_registration_profile?` etc.) test advertisement only; capability checks (`supports_dynamic_registration?` etc.) combine profile advertisement with any additional preconditions
- Documents the design in ADR-011, covering the structural/cryptographic validation split and the `nil?` vs `blank?` presence rationale

## Test plan

- [x] `bundle exec rspec spec/safire/protocols/udap_metadata_spec.rb` — 58 examples, 0 failures
- [x] `bundle exec rspec` — full suite, 451 examples, 0 failures
- [x] `bundle exec rubocop lib/safire/protocols/udap_metadata.rb spec/safire/protocols/udap_metadata_spec.rb` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)