### PR TITLE
Wire Protocols::Udap into Client with community-scoped discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Safire::Client.new(..., protocol: :udap).server_metadata` now works end-to-end:
+  `Protocols::Udap` fetches and parses `/.well-known/udap`, supports the optional `community:` URI
+  parameter, caches results per community, and raises `DiscoveryError` on HTTP errors or a 204 response
+
 - Added `Safire::Protocols::UdapMetadata` for HL7 UDAP Security STU2 discovery metadata,
   including structural `valid?` checks and helper methods for advertised UDAP profiles and capabilities.
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,24 @@ Safire is a Ruby gem implementing the [SMART App Launch 2.2.0](https://hl7.org/f
 - POST-Based Authorization
 - Backend Services (`client_credentials` grant, JWT assertion, no user interaction or PKCE; scope defaults to `system/*.rs`)
 
-### UDAP
+### UDAP Security (STU2)
 
-> Planned. See [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md) for details.
+Server metadata discovery is implemented. Pass `protocol: :udap` to fetch `/.well-known/udap`:
+
+```ruby
+client = Safire::Client.new(
+  { base_url: 'https://fhir.example.com' },
+  protocol: :udap
+)
+
+metadata = client.server_metadata
+# => #<Safire::Protocols::UdapMetadata ...>
+
+# Community-scoped discovery
+metadata = client.server_metadata(community: 'https://udap.example.org/community1')
+```
+
+Auth flows (DCR, JWT assertion, Tiered OAuth) are planned. See [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md) for details.
 
 ---
 

--- a/docs/adr/ADR-006-lazy-discovery.md
+++ b/docs/adr/ADR-006-lazy-discovery.md
@@ -1,11 +1,11 @@
 ---
 layout: default
-title: "ADR-006: Lazy SMART discovery — no HTTP in constructors"
+title: "ADR-006: Lazy discovery — no HTTP in constructors"
 parent: Architecture Decision Records
 nav_order: 6
 ---
 
-# ADR-006: Lazy SMART discovery — no HTTP in constructors
+# ADR-006: Lazy discovery — no HTTP in constructors
 
 **Status:** Accepted
 
@@ -53,7 +53,9 @@ With eager discovery, changing `client_type` must not trigger re-discovery — t
 
 ## Decision
 
-Discovery is lazy and memoised at the `Protocols::Smart` instance level:
+Discovery is lazy and memoised at the protocol instance level. Both `Protocols::Smart` and `Protocols::Udap` follow this pattern.
+
+**SMART** memoises a single metadata object at the instance level:
 
 ```ruby
 def server_metadata
@@ -68,6 +70,29 @@ end
 
 `Safire::Client` memoises the protocol client itself (`@protocol_client ||= ...`), so changing `client_type=` reuses the existing `Protocols::Smart` instance — and thus its already-fetched `@server_metadata` — rather than constructing a new one. This is the mechanism that prevents double-discovery on `client_type=` changes.
 
+**UDAP** memoises a Hash keyed by community URI string or `:default`, because the same server can host multiple communities at separate `?community=<uri>` scopes:
+
+```ruby
+def server_metadata(community: nil)
+  community = normalize_community(community)
+  cache_key = community || :default
+  return @metadata_cache[cache_key] if @metadata_cache.key?(cache_key)
+
+  @metadata_cache[cache_key] = fetch_metadata(community:)
+end
+
+def fetch_metadata(community:)
+  endpoint = well_known_endpoint(community:)
+  response = @http_client.get(endpoint)
+  check_204!(response, endpoint:, community:)
+  UdapMetadata.new(parse_discovery_body(response.body, endpoint))
+end
+```
+
+`server_metadata(community:)` is a UDAP-specific parameter. Calling it on a SMART client raises `ArgumentError` from Ruby's own keyword argument checking — this is intentional and correct, since community scoping is a UDAP concept.
+
+A 204 response means the server has no UDAP workflows for that community. `Protocols::Udap` raises `DiscoveryError` before the body is parsed, with a descriptive message that identifies the community when one was requested.
+
 ---
 
 ## Consequences
@@ -76,7 +101,8 @@ end
 - `Safire::Client.new` is instantaneous — no network calls, no stubs required at construction time
 - Configuration errors are raised before any HTTP call
 - Callers control when discovery happens — supports application-level caching patterns (see [Advanced Examples]({{ site.baseurl }}/advanced/#metadata-caching))
-- `client_type=` mutation preserves cached metadata — no re-discovery
+- `client_type=` mutation preserves cached SMART metadata — no re-discovery
+- UDAP community-keyed cache allows a single client instance to serve multiple communities without redundant HTTP calls
 
 **Trade-offs:**
 - Discovery errors surface at first use (e.g. `authorization_url`), not at construction — callers must handle `Errors::DiscoveryError` in their flow logic rather than at the `new` call site

--- a/docs/configuration/client-setup.md
+++ b/docs/configuration/client-setup.md
@@ -65,7 +65,7 @@ Selects the authorization protocol. Defaults to `:smart`.
 | Value | Status | Description |
 |-------|--------|-------------|
 | `:smart` | Implemented | SMART App Launch 2.2.0 |
-| `:udap` | Planned | UDAP Security 1.0 — accepted by the validator, raises `NotImplementedError` until implemented |
+| `:udap` | Partial | UDAP Security STU2 — `server_metadata` (with optional `community:`) is implemented; auth flows raise `NotImplementedError` |
 
 For UDAP, `client_type:` is not applicable. Passing any explicit value raises `ConfigurationError`. UDAP clients always authenticate via a JWT signed by their private key.
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -29,7 +29,7 @@ flowchart TD
     A -->|"resolves config"| B
     A -->|"validates protocol + client_type"| C
     C -->|":smart (default)"| D
-    C -->|":udap (planned)"| G["Protocols::Udap\n(future)"]
+    C -->|":udap"| G["Protocols::Udap\n— discovery implemented\n— auth flows planned"]
     D -->|"lazily fetches"| E
     E -->|"HTTP"| F
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ A lean Ruby gem implementing **[SMART App Launch](https://hl7.org/fhir/smart-app
 | [Getting Started]({{ site.baseurl }}/installation/) | Install Safire and quick start guide |
 | [Configuration]({{ site.baseurl }}/configuration/) | All configuration options and parameters |
 | [SMART]({{ site.baseurl }}/smart-on-fhir/) | App Launch (Public, Confidential Symmetric, Confidential Asymmetric) and Backend Services |
-| [UDAP]({{ site.baseurl }}/udap/) | UDAP protocol overview and planned support |
+| [UDAP]({{ site.baseurl }}/udap/) | UDAP Security discovery (implemented) and planned auth flows |
 | [Security Guide]({{ site.baseurl }}/security/) | HTTPS, credential protection, token storage, key rotation |
 | [Advanced Examples]({{ site.baseurl }}/advanced/) | Caching, multi-server, token management, complete Rails integration |
 | [Troubleshooting]({{ site.baseurl }}/troubleshooting/) | Common issues and solutions |
@@ -37,9 +37,11 @@ A lean Ruby gem implementing **[SMART App Launch](https://hl7.org/fhir/smart-app
 - POST-Based Authorization
 - Backend Services (client_credentials grant, JWT assertion, no user interaction or PKCE)
 
-### UDAP
+### UDAP Security (STU2)
 
-> Planned. See [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md) for details (coming soon).
+- Discovery (`/.well-known/udap`) with optional community scoping
+
+Auth flows (DCR, JWT assertion, Tiered OAuth) are planned. See [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md) for details.
 
 ## Demo Application
 

--- a/docs/udap.md
+++ b/docs/udap.md
@@ -63,6 +63,7 @@ The result is cached separately from the default (no-community) request, so call
 |-----------|-------------|
 | HTTP 4xx/5xx | `Safire::Errors::DiscoveryError` with `status` populated |
 | Server returns HTTP 204 | `Safire::Errors::DiscoveryError` (server signals no UDAP workflows for that community) |
+| Connection failure, timeout, SSL error, or redirect to a non-HTTPS URL | `Safire::Errors::NetworkError` |
 | `community:` is not a valid URI string | `Safire::Errors::ConfigurationError` (raised before any HTTP call) |
 
 ---

--- a/docs/udap.md
+++ b/docs/udap.md
@@ -3,7 +3,7 @@ layout: default
 title: UDAP
 nav_order: 5
 permalink: /udap/
-description: "Overview of planned UDAP Security protocol support in Safire, including UDAP discovery, dynamic client registration, JWT client authentication, and tiered OAuth for healthcare data exchange."
+description: "UDAP Security STU2 server metadata discovery in Safire, with community-scoped discovery, plus planned auth flows including dynamic client registration, JWT client authentication, and tiered OAuth."
 ---
 
 # UDAP
@@ -11,7 +11,7 @@ description: "Overview of planned UDAP Security protocol support in Safire, incl
 {: .no_toc }
 
 <div class="code-example" markdown="1">
-**Status:** Planned — see [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md) for timeline and progress.
+**Discovery** (`/.well-known/udap`) is implemented, including optional community scoping. Auth flows (DCR, JWT assertion, Tiered OAuth) are planned. See [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md).
 </div>
 
 ## Table of contents
@@ -24,21 +24,54 @@ description: "Overview of planned UDAP Security protocol support in Safire, incl
 
 ## Overview
 
-UDAP (Unified Data Access Profiles) is a security framework for healthcare data exchange defined by the [UDAP Security Implementation Guide](https://hl7.org/fhir/us/udap-security/). It extends standard OAuth 2.0 with X.509 certificate-based identity, dynamic client registration, and trust community models — designed primarily for backend system-to-system integration and cross-organizational data access.
+UDAP (Unified Data Access Profiles) is a security framework for healthcare data exchange defined by the [UDAP Security Implementation Guide](https://hl7.org/fhir/us/udap-security/). It extends standard OAuth 2.0 with X.509 certificate-based identity, dynamic client registration, and trust community models, designed primarily for backend system-to-system integration and cross-organizational data access.
 
-UDAP is a separate protocol from SMART. In Safire, it is selected via `protocol: :udap` rather than a `client_type:`. Watch the [GitHub repository](https://github.com/vanessuniq/safire) for release announcements.
+UDAP is a separate protocol from SMART. In Safire, select it via `protocol: :udap` rather than a `client_type:`.
+
+---
+
+## Discovery
+
+UDAP server metadata discovery fetches `/.well-known/udap` and parses the response into a `UdapMetadata` object. Results are cached per community within a client instance, so repeated calls for the same community make at most one HTTP request.
+
+```ruby
+client = Safire::Client.new(
+  { base_url: 'https://fhir.example.com' },
+  protocol: :udap
+)
+
+metadata = client.server_metadata
+puts metadata.token_endpoint
+puts metadata.udap_versions_supported.inspect
+puts metadata.udap_profiles_supported.inspect
+```
+
+### Community-scoped discovery
+
+Many UDAP servers host multiple trust communities at the same base URL, each scoped by a community URI. Pass `community:` to target a specific community:
+
+```ruby
+metadata = client.server_metadata(community: 'https://udap.example.org/community1')
+puts metadata.token_endpoint
+```
+
+The result is cached separately from the default (no-community) request, so calling `server_metadata` and `server_metadata(community: ...)` on the same client instance each makes at most one HTTP request.
+
+### Error handling
+
+| Condition | Error raised |
+|-----------|-------------|
+| HTTP 4xx/5xx | `Safire::Errors::DiscoveryError` with `status` populated |
+| Server returns HTTP 204 | `Safire::Errors::DiscoveryError` (server signals no UDAP workflows for that community) |
+| `community:` is not a valid URI string | `Safire::Errors::ConfigurationError` (raised before any HTTP call) |
 
 ---
 
 ## Planned Features
 
-### Discovery
-
-- **UDAP Discovery** (`/.well-known/udap`) — fetch server metadata and trust anchors
-
 ### Client Flows
 
-- **Dynamic Client Registration (DCR)** — one-time registration using a signed software statement to obtain a `client_id`; required only when the client has not previously registered with the server and if the server supports DCR
+- **Dynamic Client Registration (DCR)** — one-time registration using a signed software statement to obtain a `client_id`; required only when the client has not previously registered with the server and the server supports DCR
 - **JWT Client Authentication** — authenticate on every request using a signed JWT assertion (Authentication Token, AnT) with an X.509 certificate chain in the `x5c` header; the registered `client_id` is reused as `iss` and `sub` in each assertion
 - **Tiered OAuth** — delegated authorization for multi-system access per the UDAP Security IG
 - **Pushed Authorization Requests (RFC 9126)** — PAR support for pre-registering authorization requests
@@ -50,7 +83,17 @@ UDAP is a separate protocol from SMART. In Safire, it is selected via `protocol:
 
 ---
 
-## When to Use UDAP
+## Comparison with SMART
+
+| Feature | SMART | UDAP |
+|---------|-------|------|
+| Primary use case | User-facing apps, EHR launch | B2B, backend services, cross-org access |
+| Client registration | Pre-registered per server, optional DCR (recommended) | Dynamic (DCR) or pre-registered |
+| Authentication | Client secrets or `private_key_jwt` | Signed JWT assertions (AnT) with X.509 `x5c` chain |
+| Trust model | Per-server registration | Certificate-based trust communities |
+| Safire selection | `client_type: :public / :confidential_symmetric / :confidential_asymmetric` | `protocol: :udap` |
+
+### When to use UDAP
 
 | Scenario | Why UDAP |
 |----------|----------|
@@ -58,18 +101,6 @@ UDAP is a separate protocol from SMART. In Safire, it is selected via `protocol:
 | **Dynamic Client Registration** | Clients can register programmatically without manual server-side approval |
 | **Cross-Organization Access** | Trust communities allow clients to be recognized across participant organizations without per-server registration |
 | **High-Assurance Identity** | X.509 certificates provide stronger identity guarantees than client secrets |
-
----
-
-## Comparison with SMART
-
-| Feature | SMART | UDAP |
-|---------|---------------|------|
-| Primary use case | User-facing apps, EHR launch | B2B, backend services, cross-org access |
-| Client registration | Pre-registered per server, optional DCR (recommended) | Dynamic (DCR) or pre-registered |
-| Authentication | Client secrets or `private_key_jwt` | Signed JWT assertions (AnT) with X.509 `x5c` chain |
-| Trust model | Per-server registration | Certificate-based trust communities |
-| Safire selection | `client_type: :public / :confidential_symmetric / :confidential_asymmetric` | `protocol: :udap` (planned) |
 
 ### Resources
 

--- a/lib/safire/client.rb
+++ b/lib/safire/client.rb
@@ -24,7 +24,7 @@ module Safire
   # The +protocol:+ keyword selects the authorization protocol:
   #
   # * :smart (default) — SMART App Launch 2.2.0
-  # * :udap             — UDAP Security (future; not yet implemented)
+  # * :udap             — UDAP Security STU2
   #
   # The +client_type:+ keyword controls how the SMART client authenticates at the token endpoint.
   # Defaults to +nil+, which resolves to +:public+ for SMART. For UDAP, +client_type:+ is not
@@ -41,7 +41,7 @@ module Safire
   # client_credentials grant without prior DCR when identity can be fully determined from
   # certificate attributes alone.
   #
-  # @note Future kwargs (not yet implemented):
+  # @note Future kwargs (not yet implemented for UDAP):
   #
   #   flow: [Symbol] the authorization flow for UDAP clients (protocol: :udap):
   #     :b2b          — client_credentials grant, server-to-server
@@ -194,7 +194,7 @@ module Safire
     def build_protocol_client
       case @protocol
       when :smart then Protocols::Smart.new(config, client_type:)
-      when :udap  then raise NotImplementedError, 'UDAP protocol client is not yet implemented'
+      when :udap  then Protocols::Udap.new(config)
       end
     end
 

--- a/lib/safire/protocols/udap.rb
+++ b/lib/safire/protocols/udap.rb
@@ -35,8 +35,10 @@ module Safire
       #
       # @param community [String, nil] optional UDAP community URI; scopes discovery
       # @return [Safire::Protocols::UdapMetadata] parsed UDAP metadata
-      # @raise [Safire::Errors::DiscoveryError] if the request fails, the server
-      #   returns 204, or the response body is not a JSON object
+      # @raise [Safire::Errors::DiscoveryError] if the server returns an HTTP error,
+      #   a 204 response, or a body that is not a JSON object
+      # @raise [Safire::Errors::NetworkError] on connection failure, timeout, SSL error,
+      #   or a redirect to a non-HTTPS URL
       # @raise [Safire::Errors::ConfigurationError] if +community+ is not a URI
       def server_metadata(community: nil)
         community = normalize_community(community)

--- a/lib/safire/protocols/udap.rb
+++ b/lib/safire/protocols/udap.rb
@@ -83,7 +83,7 @@ module Safire
 
       def valid_uri?(value)
         uri = Addressable::URI.parse(value)
-        uri.scheme.present? && (uri.host.present? || uri.path.present? || uri.opaque.present?)
+        uri.scheme.present? && (uri.host.present? || uri.path.present?)
       rescue Addressable::URI::InvalidURIError
         false
       end

--- a/lib/safire/protocols/udap.rb
+++ b/lib/safire/protocols/udap.rb
@@ -1,0 +1,122 @@
+module Safire
+  module Protocols
+    # UDAP Security STU2 protocol implementation.
+    #
+    # Handles server metadata discovery from the UDAP well-known endpoint
+    # (per {https://hl7.org/fhir/us/udap-security/STU2/discovery.html STU2 §2}).
+    # Results are cached per community within each instance.
+    #
+    # All other UDAP flows (B2B client credentials, B2C authorization code,
+    # Tiered OAuth, Dynamic Client Registration) raise {NotImplementedError}
+    # and are planned for future PRs.
+    #
+    # This is an internal class used exclusively by {Safire::Client}. Do not
+    # instantiate it directly — use {Safire::Client} instead.
+    #
+    # @note For internal use by {Safire::Client} only.
+    # @api private
+    class Udap
+      include Behaviours
+
+      WELL_KNOWN_PATH = '/.well-known/udap'.freeze
+
+      def initialize(config)
+        @base_url       = config.base_url
+        @http_client    = Safire::HTTPClient.new
+        @metadata_cache = {}
+      end
+
+      # Retrieves and parses UDAP server metadata from the well-known endpoint.
+      #
+      # When a +community+ URI is provided, the request is scoped to that community
+      # by appending +?community=<encoded-uri>+ to the endpoint URL. Results are
+      # cached per community — subsequent calls with the same +community+ return the
+      # cached result without a second HTTP request.
+      #
+      # @param community [String, nil] optional UDAP community URI; scopes discovery
+      # @return [Safire::Protocols::UdapMetadata] parsed UDAP metadata
+      # @raise [Safire::Errors::DiscoveryError] if the request fails, the server
+      #   returns 204, or the response body is not a JSON object
+      # @raise [Safire::Errors::ConfigurationError] if +community+ is not a URI
+      def server_metadata(community: nil)
+        community = normalize_community(community)
+        cache_key = community || :default
+        return @metadata_cache[cache_key] if @metadata_cache.key?(cache_key)
+
+        @metadata_cache[cache_key] = fetch_metadata(community:)
+      end
+
+      private
+
+      def fetch_metadata(community:)
+        endpoint = well_known_endpoint(community:)
+        response = @http_client.get(endpoint)
+        check_204!(response, endpoint:, community:)
+        UdapMetadata.new(parse_discovery_body(response.body, endpoint))
+      rescue Faraday::Error => e
+        status = e.response&.dig(:status)
+        Safire.logger.error("UDAP discovery failed for `#{endpoint}`: HTTP #{status}")
+        raise Errors::DiscoveryError.new(endpoint: endpoint, status:, label: 'UDAP metadata')
+      end
+
+      def normalize_community(community)
+        return if community.nil?
+
+        return invalid_community!(community) unless community.respond_to?(:to_str)
+
+        community = community.to_str.strip
+        return if community.blank?
+        return community if valid_uri?(community)
+
+        invalid_community!(community)
+      end
+
+      def invalid_community!(community)
+        raise Errors::ConfigurationError.new(
+          invalid_attribute: :community,
+          invalid_value: community,
+          valid_values: ['URI string']
+        )
+      end
+
+      def valid_uri?(value)
+        uri = Addressable::URI.parse(value)
+        uri.scheme.present? && (uri.host.present? || uri.path.present? || uri.opaque.present?)
+      rescue Addressable::URI::InvalidURIError
+        false
+      end
+
+      def well_known_endpoint(community:)
+        base = "#{@base_url.to_s.chomp('/')}#{WELL_KNOWN_PATH}"
+        return base unless community
+
+        uri = Addressable::URI.parse(base)
+        uri.query_values = { 'community' => community }
+        uri.to_s
+      end
+
+      def check_204!(response, endpoint:, community:)
+        return unless response.status == 204
+
+        description = 'no UDAP workflows supported'
+        description += " for community #{community}" if community
+        raise Errors::DiscoveryError.new(
+          endpoint: endpoint,
+          status: 204,
+          error_description: description,
+          label: 'UDAP metadata'
+        )
+      end
+
+      def parse_discovery_body(body, endpoint)
+        return body if body.is_a?(Hash)
+
+        raise Errors::DiscoveryError.new(
+          endpoint: endpoint,
+          error_description: 'response is not a JSON object',
+          label: 'UDAP metadata'
+        )
+      end
+    end
+  end
+end

--- a/spec/integration/udap_discovery_flow_spec.rb
+++ b/spec/integration/udap_discovery_flow_spec.rb
@@ -1,0 +1,119 @@
+require 'spec_helper'
+
+RSpec.describe 'UDAP Discovery Flow', type: :integration do
+  #
+  # Tests UDAP well-known discovery per HL7 UDAP Security STU2.
+  # https://hl7.org/fhir/us/udap-security/STU2/discovery.html
+  #
+  # Flow:
+  # 1. GET /.well-known/udap (optionally with ?community=<URI>)
+  # 2. Parse and validate UdapMetadata
+  #
+
+  # ---------- Test Data ----------
+
+  let(:base_url) { 'https://fhir.example.com' }
+  let(:well_known_url) { "#{base_url}/.well-known/udap" }
+
+  let(:udap_metadata_body) do
+    {
+      'udap_versions_supported' => ['1'],
+      'udap_profiles_supported' => %w[udap_dcr udap_authn udap_authz],
+      'udap_authorization_extensions_supported' => ['hl7-b2b'],
+      'udap_authorization_extensions_required' => ['hl7-b2b'],
+      'udap_certifications_supported' => [],
+      'grant_types_supported' => %w[client_credentials authorization_code],
+      'scopes_supported' => %w[system/*.rs openid profile],
+      'token_endpoint' => "#{base_url}/token",
+      'token_endpoint_auth_methods_supported' => ['private_key_jwt'],
+      'token_endpoint_auth_signing_alg_values_supported' => %w[RS256 ES256],
+      'registration_endpoint' => "#{base_url}/register",
+      'registration_endpoint_jwt_signing_alg_values_supported' => %w[RS256 ES256],
+      'authorization_endpoint' => "#{base_url}/authorize",
+      'signed_metadata' => 'eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwcyJ9.c2ln'
+    }
+  end
+
+  let(:config) { Safire::ClientConfig.new(base_url: base_url) }
+  let(:client) { Safire::Client.new(config, protocol: :udap) }
+
+  # ---------- Basic Discovery ----------
+
+  context 'when discovery succeeds' do
+    before do
+      stub_request(:get, well_known_url)
+        .to_return(status: 200, body: udap_metadata_body.to_json, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns a UdapMetadata instance' do
+      expect(client.server_metadata).to be_a(Safire::Protocols::UdapMetadata)
+    end
+
+    it 'exposes the token endpoint from the response' do
+      expect(client.server_metadata.token_endpoint).to eq("#{base_url}/token")
+    end
+
+    it 'caches discovery and avoids duplicate HTTP requests' do
+      2.times { client.server_metadata }
+      expect(a_request(:get, well_known_url)).to have_been_made.once
+    end
+
+    it 'passes valid? for a conformant response' do
+      expect(client.server_metadata.valid?).to be(true)
+    end
+  end
+
+  # ---------- Community-Scoped Discovery ----------
+
+  context 'with a community URI' do
+    let(:community) { 'https://udap.example.org/community' }
+
+    before do
+      stub_request(:get, well_known_url)
+        .with(query: { 'community' => community })
+        .to_return(status: 200, body: udap_metadata_body.to_json, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'passes the community as a query parameter' do
+      client.server_metadata(community: community)
+      expect(a_request(:get, well_known_url).with(query: { 'community' => community })).to have_been_made.once
+    end
+
+    it 'returns a UdapMetadata instance scoped to the community' do
+      expect(client.server_metadata(community: community)).to be_a(Safire::Protocols::UdapMetadata)
+    end
+  end
+
+  # ---------- Error Cases ----------
+
+  context 'when server returns 204 (no UDAP support)' do
+    before do
+      stub_request(:get, well_known_url)
+        .to_return(status: 204, body: '', headers: {})
+    end
+
+    it 'raises DiscoveryError' do
+      expect { client.server_metadata }.to raise_error(Safire::Errors::DiscoveryError)
+    end
+
+    it 'reports no UDAP workflows supported' do
+      expect { client.server_metadata }
+        .to raise_error(Safire::Errors::DiscoveryError, /no UDAP workflows supported/)
+    end
+  end
+
+  context 'when server returns a 404' do
+    before do
+      stub_request(:get, well_known_url)
+        .to_return(status: 404, body: '{"error":"not_found"}', headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'raises DiscoveryError with the HTTP status' do
+      expect { client.server_metadata }
+        .to raise_error(Safire::Errors::DiscoveryError) do |e|
+          expect(e.status).to eq(404)
+          expect(e.message).to include('UDAP metadata')
+        end
+    end
+  end
+end

--- a/spec/safire/client_spec.rb
+++ b/spec/safire/client_spec.rb
@@ -153,14 +153,39 @@ RSpec.describe Safire::Client do
     end
   end
 
-  # ---------- UDAP (not yet implemented) ----------
+  # ---------- UDAP delegation ----------
 
   describe 'UDAP delegation' do
-    it 'raises NotImplementedError when a delegated method is called' do
-      client = described_class.new(config, protocol: :udap)
+    let(:well_known_url) { "#{base_url}/.well-known/udap" }
+    let(:udap_metadata_body) do
+      {
+        'udap_versions_supported' => ['1'],
+        'udap_profiles_supported' => %w[udap_dcr udap_authn],
+        'udap_authorization_extensions_supported' => [],
+        'udap_certifications_supported' => [],
+        'grant_types_supported' => ['client_credentials'],
+        'scopes_supported' => ['system/*.rs'],
+        'token_endpoint' => "#{base_url}/token",
+        'token_endpoint_auth_methods_supported' => ['private_key_jwt'],
+        'token_endpoint_auth_signing_alg_values_supported' => ['RS256'],
+        'registration_endpoint' => "#{base_url}/register",
+        'registration_endpoint_jwt_signing_alg_values_supported' => ['RS256'],
+        'signed_metadata' => 'eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwcyJ9.c2ln'
+      }
+    end
+    let(:udap_client) { described_class.new(config, protocol: :udap) }
 
-      expect { client.server_metadata }
-        .to raise_error(NotImplementedError, /UDAP protocol client is not yet implemented/)
+    before do
+      stub_request(:get, well_known_url)
+        .to_return(status: 200, body: udap_metadata_body.to_json, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'delegates server_metadata to Protocols::Udap and returns a UdapMetadata instance' do
+      expect(udap_client.server_metadata).to be_a(Safire::Protocols::UdapMetadata)
+    end
+
+    it 'raises NotImplementedError for unimplemented UDAP flows' do
+      expect { udap_client.authorization_url }.to raise_error(NotImplementedError)
     end
   end
 

--- a/spec/safire/protocols/udap_spec.rb
+++ b/spec/safire/protocols/udap_spec.rb
@@ -111,6 +111,11 @@ RSpec.describe Safire::Protocols::Udap do
           .to raise_error(Safire::Errors::ConfigurationError, /community/)
       end
 
+      it 'raises ConfigurationError for a scheme-only URI with no host or path' do
+        expect { udap.server_metadata(community: 'foo:') }
+          .to raise_error(Safire::Errors::ConfigurationError, /community/)
+      end
+
       it 'raises ConfigurationError when the value is not a string' do
         expect { udap.server_metadata(community: 123) }
           .to raise_error(Safire::Errors::ConfigurationError, /community/)

--- a/spec/safire/protocols/udap_spec.rb
+++ b/spec/safire/protocols/udap_spec.rb
@@ -1,0 +1,242 @@
+require 'spec_helper'
+
+RSpec.describe Safire::Protocols::Udap do
+  subject(:udap) { described_class.new(config) }
+
+  let(:base_url) { 'https://fhir.example.com' }
+  let(:config) { instance_double(Safire::ClientConfig, base_url: base_url) }
+  let(:well_known_url) { "#{base_url}/.well-known/udap" }
+
+  let(:valid_metadata) do
+    {
+      'udap_versions_supported' => ['1'],
+      'udap_profiles_supported' => %w[udap_dcr udap_authn],
+      'udap_authorization_extensions_supported' => [],
+      'udap_certifications_supported' => [],
+      'grant_types_supported' => ['client_credentials'],
+      'scopes_supported' => ['system/*.rs'],
+      'token_endpoint' => 'https://fhir.example.com/token',
+      'token_endpoint_auth_methods_supported' => ['private_key_jwt'],
+      'token_endpoint_auth_signing_alg_values_supported' => ['RS256'],
+      'registration_endpoint' => 'https://fhir.example.com/register',
+      'registration_endpoint_jwt_signing_alg_values_supported' => ['RS256'],
+      'signed_metadata' => 'eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwcyJ9.c2ln'
+    }
+  end
+
+  def stub_udap(url: well_known_url, status: 200, body: valid_metadata, content_type: 'application/json')
+    stub_request(:get, url).to_return(
+      status: status,
+      body: body ? body.to_json : '',
+      headers: { 'Content-Type' => content_type }
+    )
+  end
+
+  # ---------- server_metadata — default (no community) ----------
+
+  describe '#server_metadata' do
+    context 'without community parameter' do
+      before { stub_udap }
+
+      it 'returns a UdapMetadata instance' do
+        expect(udap.server_metadata).to be_a(Safire::Protocols::UdapMetadata)
+      end
+
+      it 'populates the metadata from the response body' do
+        expect(udap.server_metadata.token_endpoint).to eq('https://fhir.example.com/token')
+      end
+
+      it 'caches the result and makes only one HTTP request' do
+        2.times { udap.server_metadata }
+        expect(a_request(:get, well_known_url)).to have_been_made.once
+      end
+    end
+
+    # ---------- server_metadata — community-scoped ----------
+
+    context 'with a community parameter' do
+      let(:community) { 'https://udap.example.org/community1' }
+      let(:success_return) do
+        { status: 200, body: valid_metadata.to_json, headers: { 'Content-Type' => 'application/json' } }
+      end
+
+      before do
+        stub_request(:get, well_known_url)
+          .with(query: { 'community' => community })
+          .to_return(**success_return)
+        stub_request(:get, well_known_url)
+          .to_return(**success_return)
+      end
+
+      it 'appends the community as a query parameter' do
+        udap.server_metadata(community: community)
+        expect(a_request(:get, well_known_url).with(query: { 'community' => community })).to have_been_made.once
+      end
+
+      it 'caches per community independently from the default cache' do
+        2.times { udap.server_metadata }
+        2.times { udap.server_metadata(community: community) }
+        # Each distinct endpoint fetched exactly once; two total HTTP requests
+        expect(a_request(:get, %r{\.well-known/udap})).to have_been_made.twice
+        expect(a_request(:get, well_known_url).with(query: { 'community' => community })).to have_been_made.once
+      end
+
+      it 'normalizes surrounding whitespace before building the request and cache key' do
+        udap.server_metadata(community: "  #{community}  ")
+        udap.server_metadata(community: community)
+
+        expect(a_request(:get, well_known_url).with(query: { 'community' => community })).to have_been_made.once
+      end
+    end
+
+    context 'with a blank community parameter' do
+      before { stub_udap }
+
+      it 'treats it as the default discovery request' do
+        udap.server_metadata(community: '   ')
+        udap.server_metadata
+
+        expect(a_request(:get, well_known_url)).to have_been_made.once
+      end
+    end
+
+    context 'with an invalid community parameter' do
+      it 'raises ConfigurationError when the value is not a URI' do
+        expect { udap.server_metadata(community: 'not a uri') }
+          .to raise_error(Safire::Errors::ConfigurationError, /community/)
+      end
+
+      it 'raises ConfigurationError when the value does not identify a community' do
+        expect { udap.server_metadata(community: 'https:') }
+          .to raise_error(Safire::Errors::ConfigurationError, /community/)
+      end
+
+      it 'raises ConfigurationError when the value is not a string' do
+        expect { udap.server_metadata(community: 123) }
+          .to raise_error(Safire::Errors::ConfigurationError, /community/)
+      end
+
+      it 'does not make an HTTP request' do
+        expect { udap.server_metadata(community: 'not a uri') }
+          .to raise_error(Safire::Errors::ConfigurationError)
+
+        expect(a_request(:get, %r{\.well-known/udap})).not_to have_been_made
+      end
+    end
+
+    # ---------- server_metadata — 204 No Content ----------
+
+    context 'when server returns 204 (no community)' do
+      before { stub_udap(status: 204, body: nil, content_type: '') }
+
+      it 'raises DiscoveryError' do
+        expect { udap.server_metadata }.to raise_error(Safire::Errors::DiscoveryError)
+      end
+
+      it 'reports HTTP 204 in the error' do
+        expect { udap.server_metadata }
+          .to raise_error(Safire::Errors::DiscoveryError, /204/)
+      end
+
+      it 'reports no UDAP workflows supported' do
+        expect { udap.server_metadata }
+          .to raise_error(Safire::Errors::DiscoveryError, /no UDAP workflows supported/)
+      end
+    end
+
+    context 'when server returns 204 for a community' do
+      let(:community) { 'https://udap.example.org/community1' }
+
+      before do
+        stub_request(:get, well_known_url)
+          .with(query: { 'community' => community })
+          .to_return(status: 204, body: '', headers: {})
+      end
+
+      it 'includes the community in the error message' do
+        expect { udap.server_metadata(community: community) }
+          .to raise_error(Safire::Errors::DiscoveryError, /community/)
+      end
+    end
+
+    # ---------- server_metadata — non-Hash body ----------
+
+    context 'when response body is not a JSON object' do
+      before do
+        stub_request(:get, well_known_url)
+          .to_return(status: 200, body: '"just a string"', headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'raises DiscoveryError' do
+        expect { udap.server_metadata }.to raise_error(Safire::Errors::DiscoveryError, /not a JSON object/)
+      end
+    end
+
+    # ---------- server_metadata — HTTP errors ----------
+
+    context 'when server returns an HTTP error' do
+      before do
+        stub_request(:get, well_known_url)
+          .to_return(status: 404, body: '{"error":"not_found"}', headers: { 'Content-Type' => 'application/json' })
+        allow(Safire.logger).to receive(:error)
+      end
+
+      it 'raises DiscoveryError' do
+        expect { udap.server_metadata }.to raise_error(Safire::Errors::DiscoveryError)
+      end
+
+      it 'includes the HTTP status in the error' do
+        expect { udap.server_metadata }
+          .to raise_error(Safire::Errors::DiscoveryError) { |e| expect(e.status).to eq(404) }
+      end
+
+      it 'logs the failure' do
+        expect { udap.server_metadata }.to raise_error(Safire::Errors::DiscoveryError)
+        expect(Safire.logger).to have_received(:error).with(/UDAP discovery failed/)
+      end
+
+      it 'includes the label UDAP metadata in the error message' do
+        expect { udap.server_metadata }
+          .to raise_error(Safire::Errors::DiscoveryError) { |e| expect(e.message).to include('UDAP metadata') }
+      end
+    end
+  end
+
+  # ---------- Unimplemented Behaviours ----------
+
+  describe '#authorization_url' do
+    it 'raises NotImplementedError' do
+      expect { udap.authorization_url }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#request_access_token' do
+    it 'raises NotImplementedError' do
+      expect { udap.request_access_token }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#refresh_token' do
+    it 'raises NotImplementedError' do
+      expect { udap.refresh_token }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#token_response_valid?' do
+    it 'raises NotImplementedError' do
+      expect { udap.token_response_valid?({}) }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#request_backend_token' do
+    it 'raises NotImplementedError' do
+      expect { udap.request_backend_token }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#register_client' do
+    it 'raises NotImplementedError' do
+      expect { udap.register_client({}) }.to raise_error(NotImplementedError)
+    end
+  end
+end


### PR DESCRIPTION
This PR completes the UDAP server metadata discovery flow end-to-end. `Protocols::Udap` fetches `/.well-known/udap`, parses the response into a `UdapMetadata` object, and is now wired into `Safire::Client` so that `Client.new(..., protocol: :udap).server_metadata` works in production. Discovery results are cached per community within a client instance, so repeated calls for the same community make only one HTTP request. The optional `community:` keyword argument is validated before any network call: non-strings, unparseable values, and strings that don't identify a resource are all rejected with a `ConfigurationError`; blank strings fall back to the default (no-community) endpoint. A 204 response from the server raises `DiscoveryError` with a plain-English message that names the community when one was requested. All other HTTP failures are caught from Faraday and re-raised as `DiscoveryError` with the status code attached. ADR-006 is updated to document the community-keyed caching design alongside the existing SMART memoisation section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)