### PR TITLE
Document UDAP Security STU2 discovery: metadata validation, conformance helpers, and error handling

### DIFF
--- a/docs/configuration/client-setup.md
+++ b/docs/configuration/client-setup.md
@@ -52,7 +52,7 @@ client = Safire::Client.new(config)
 
 ## Protocol and Client Type
 
-`protocol:` and `client_type:` are keyword arguments to `Safire::Client.new`. They are independent of each other.
+`protocol:` and `client_type:` are keyword arguments to `Safire::Client.new`. `protocol:` selects the protocol implementation; `client_type:` selects the SMART authentication style and is not used for UDAP.
 
 ```ruby
 client = Safire::Client.new(config, protocol: :smart, client_type: :confidential_symmetric)
@@ -65,9 +65,42 @@ Selects the authorization protocol. Defaults to `:smart`.
 | Value | Status | Description |
 |-------|--------|-------------|
 | `:smart` | Implemented | SMART App Launch 2.2.0 |
-| `:udap` | Partial | UDAP Security STU2 — `server_metadata` (with optional `community:`) is implemented; auth flows raise `NotImplementedError` |
+| `:udap` | Partial | UDAP Security STU2 discovery — `server_metadata` validates `signed_metadata`, supports optional `community:`, and accepts trust policy keywords (`trusted_anchors:`, `crls:`, `revocation_checker:`, `verify_chain:`); auth flows raise `NotImplementedError` |
 
-For UDAP, `client_type:` is not applicable. Passing any explicit value raises `ConfigurationError`. Future UDAP authentication flows will use signed JWT assertions rather than SMART client types.
+For UDAP, `client_type:` is not applicable. Passing any explicit value, either at initialization or through `client.client_type=`, raises `Safire::Errors::ConfigurationError`. Future UDAP authentication flows will use signed JWT assertions rather than SMART client types.
+
+```ruby
+client = Safire::Client.new(
+  { base_url: 'https://fhir.example.com' },
+  protocol: :udap
+)
+
+metadata = client.server_metadata(verify_chain: false) # development/test only
+```
+
+Production UDAP discovery must validate `signed_metadata` with trust anchors and an explicit revocation policy:
+
+```ruby
+ca_cert = OpenSSL::X509::Certificate.new(File.read('udap_ca.pem'))
+ca_crl  = OpenSSL::X509::CRL.new(File.read('udap_ca.crl'))
+
+metadata = client.server_metadata(
+  trusted_anchors: [ca_cert],
+  crls:            [ca_crl]
+)
+```
+
+Pass `community:` when the server participates in a specific UDAP trust community:
+
+```ruby
+metadata = client.server_metadata(
+  community:       'https://udap.example.org/community1',
+  trusted_anchors: [ca_cert],
+  crls:            [ca_crl]
+)
+```
+
+See [UDAP]({{ site.baseurl }}/udap/) for validation helpers, 404/204 discovery behavior, and the `verify_chain: false` development caveat.
 
 ### Client Type
 
@@ -119,7 +152,7 @@ For a decision guide on which workflow to use, see [SMART App Launch — Choosin
 All URI parameters are validated at initialization. Safire raises `Safire::Errors::ConfigurationError` for any violation:
 
 - URIs must be well-formed (scheme + host required)
-- URIs must use `https` — required by SMART App Launch 2.2.0
+- URIs must use `https` — required for SMART App Launch and UDAP discovery
 - **Exception:** `http` is permitted for `localhost` and `127.0.0.1` (local development only)
 
 The following attributes are validated:
@@ -134,6 +167,8 @@ The following attributes are validated:
 | `jwks_uri` | When provided |
 
 If you need to bypass discovery and provide endpoints directly, set `authorization_endpoint` and `token_endpoint` in your config. Safire will use them as-is instead of fetching `/.well-known/smart-configuration`.
+
+UDAP discovery always uses the FHIR `base_url` and the `/.well-known/udap` endpoint. UDAP endpoint values are taken from discovered, signed metadata rather than from SMART endpoint overrides.
 
 ---
 
@@ -160,5 +195,6 @@ config.inspect
 ## Next Steps
 
 - [Logging]({{ site.baseurl }}/configuration/logging/) — configure Safire's logger and HTTP request logging
+- [UDAP Discovery]({{ site.baseurl }}/udap/) — discover and validate UDAP Security STU2 server metadata
 - [Dynamic Client Registration]({{ site.baseurl }}/smart-on-fhir/dynamic-client-registration/) — obtain a `client_id` at runtime using RFC 7591
 - [SMART App Launch Workflows]({{ site.baseurl }}/smart-on-fhir/) — step-by-step authorization flow guides

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -29,7 +29,8 @@ Safire raises typed errors so you can handle each failure category separately:
 | Error class | When raised |
 |-------------|-------------|
 | `Safire::Errors::ConfigurationError` | Missing or invalid client configuration — caught at construction time |
-| `Safire::Errors::DiscoveryError` | SMART metadata fetch failed (HTTP error, invalid JSON, missing field) |
+| `Safire::Errors::DiscoveryError` | SMART or UDAP metadata discovery failed (HTTP error, invalid JSON, missing SMART `token_endpoint` when required, or UDAP `signed_metadata` validation failure) |
+| `Safire::Errors::CertificateError` | UDAP `x5c` certificate data could not be parsed during `signed_metadata` validation |
 | `Safire::Errors::RegistrationError` | Dynamic Client Registration failed (server error, or 2xx response missing `client_id`) |
 | `Safire::Errors::TokenError` | Token exchange or refresh failed (OAuth error, missing fields) |
 | `Safire::Errors::NetworkError` | Transport-level failure (connection refused, timeout, blocked redirect) |
@@ -52,6 +53,50 @@ rescue Safire::Errors::NetworkError => e
   render plain: 'Server temporarily unavailable', status: :service_unavailable
 end
 ```
+
+---
+
+## Discovery Errors
+
+### SMART discovery
+
+SMART clients fetch `/.well-known/smart-configuration` lazily when metadata or an auth flow needs it. A `DiscoveryError` means the SMART metadata endpoint returned an HTTP error, did not return a JSON object, or a token request needed discovery but the response did not include `token_endpoint`.
+
+```ruby
+begin
+  metadata = smart_client.server_metadata
+rescue Safire::Errors::DiscoveryError => e
+  Rails.logger.error("SMART discovery failed: #{e.message}")
+end
+```
+
+### UDAP discovery
+
+UDAP clients fetch `/.well-known/udap` and validate the required `signed_metadata` JWT before returning metadata. In production, pass trust anchors plus CRLs or a custom revocation checker:
+
+```ruby
+metadata = udap_client.server_metadata(
+  trusted_anchors: [ca_cert],
+  crls:            [ca_crl]
+)
+```
+
+Common UDAP discovery outcomes:
+
+| Response or condition | Meaning |
+|-----------------------|---------|
+| `404 Not Found` | Per UDAP Security STU2, treat this as "UDAP workflows are not supported" for that server |
+| `204 No Content` | No UDAP workflows are supported for the requested `community:`; Safire raises `DiscoveryError` before parsing the body |
+| `signed_metadata validation failed` | Safire could not validate the JWT signature, certificate chain, revocation status, issuer/SAN relationship, required claims, or signed endpoint URLs |
+| `ConfigurationError` for `community:` | The community value was not a URI string; Safire raises before making an HTTP request |
+
+For development and tests only, `verify_chain: false` skips X.509 chain and revocation validation:
+
+```ruby
+metadata = udap_client.server_metadata(verify_chain: false)
+```
+
+Never use `verify_chain: false` in production.
 
 ---
 
@@ -89,12 +134,22 @@ FHIR_BASE_URL=https://launch.smarthealthit.org/v/r4/sim/eyJoIjoiMSJ9/fhir
 
 Visit [launch.smarthealthit.org](https://launch.smarthealthit.org) to configure simulated patients and launch contexts.
 
+### Test discovery endpoints manually
+
+```sh
+curl https://fhir.example.com/.well-known/smart-configuration
+curl https://fhir.example.com/.well-known/udap
+curl 'https://fhir.example.com/.well-known/udap?community=https%3A%2F%2Fudap.example.org%2Fcommunity1'
+```
+
+SMART metadata is unsigned JSON. UDAP metadata must include `signed_metadata`; Safire validates that JWT before returning `UdapMetadata`.
+
 ---
 
 ## Getting Help
 
 - **Check the logs first** — Safire logs one line per error with all relevant context
-- **Test endpoints manually** — `curl https://fhir.example.com/.well-known/smart-configuration`
+- **Test endpoints manually** — check the SMART or UDAP well-known endpoint for the protocol you selected
 - **Open an issue** — [github.com/vanessuniq/safire/issues](https://github.com/vanessuniq/safire/issues)
 
 When reporting an issue, include: Safire version (`Safire::VERSION`), Ruby version, the error message and backtrace, and the server type if known. Never include credentials or tokens.

--- a/docs/udap.md
+++ b/docs/udap.md
@@ -11,7 +11,7 @@ description: "UDAP Security STU2 server metadata discovery in Safire, with commu
 {: .no_toc }
 
 <div class="code-example" markdown="1">
-**Discovery** (`/.well-known/udap`) is implemented, including optional community scoping. Auth flows (DCR, JWT assertion, Tiered OAuth) are planned. See [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md).
+**Implemented now:** UDAP Security STU2 discovery (`/.well-known/udap`), including signed metadata validation and optional community scoping. UDAP DCR, JWT client authentication, and Tiered OAuth flows remain planned. See [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md).
 </div>
 
 ## Table of contents
@@ -27,6 +27,15 @@ description: "UDAP Security STU2 server metadata discovery in Safire, with commu
 UDAP (Unified Data Access Profiles) is a security framework for healthcare data exchange defined by the [UDAP Security STU2 / v2.0.0 Implementation Guide](https://hl7.org/fhir/us/udap-security/STU2/index.html). It extends standard OAuth 2.0 with X.509 certificate-based identity, dynamic client registration, and trust community models, designed primarily for backend system-to-system integration and cross-organizational data access.
 
 UDAP is a separate protocol from SMART. In Safire, select it via `protocol: :udap` rather than a `client_type:`.
+
+```ruby
+client = Safire::Client.new(
+  { base_url: 'https://fhir.example.com' },
+  protocol: :udap
+)
+```
+
+`client_type:` is not applicable to UDAP. Passing one explicitly, or assigning `client.client_type = ...` on a UDAP client, raises `Safire::Errors::ConfigurationError`.
 
 ---
 
@@ -78,12 +87,67 @@ puts metadata.token_endpoint
 
 Results are cached separately per community and trust policy. Calling `server_metadata` with different community, `trusted_anchors`, `crls`, or `revocation_checker` arguments uses a separate cache entry, and each cached entry is revalidated before reuse.
 
+### Validation helpers
+
+`UdapMetadata#valid?` checks the structure and STU2 value rules in the discovered JSON. It verifies required fields, fixed STU2 values such as `udap_versions_supported == ["1"]`, required profile advertisements, array types, conditional fields, and endpoint URL shape. It logs warnings and returns `false` for non-conformant metadata.
+
+```ruby
+metadata = client.server_metadata(trusted_anchors: [ca_cert], crls: [ca_crl])
+
+unless metadata.valid?
+  # Safire.logger.warn has already logged each conformance violation.
+  raise 'UDAP metadata is structurally non-conformant'
+end
+```
+
+`server_metadata` already validates `signed_metadata` before returning. Use `signed_metadata_valid?` when you need to re-check an existing metadata object against a different trust policy:
+
+```ruby
+metadata.signed_metadata_valid?(
+  base_url:         'https://fhir.example.com',
+  trusted_anchors: [alternate_ca],
+  crls:            [alternate_crl]
+)
+```
+
+Support helpers expose advertised profiles and usable discovery capabilities. Capability helpers combine profile or grant signals with the endpoint preconditions Safire can verify during discovery. These describe what the server advertises; Safire's UDAP DCR, JWT client authentication, and Tiered OAuth flows are still planned.
+
+| Helper | Checks |
+|--------|--------|
+| `supports_dynamic_registration?` | `udap_dcr` profile and a valid HTTPS `registration_endpoint` |
+| `supports_jwt_client_auth?` | `udap_authn` profile and a valid HTTPS `token_endpoint` |
+| `supports_client_authorization?` | `udap_authz` profile, `client_credentials` grant, and a valid HTTPS `token_endpoint` |
+| `supports_authorization_code?` | `authorization_code` appears in `grant_types_supported` |
+| `supports_refresh_token?` | `refresh_token` appears in `grant_types_supported` |
+| `supports_tiered_oauth?` | `udap_to` profile is advertised |
+| `supports_signed_metadata?` | `signed_metadata` is present in compact-JWS format |
+
+```ruby
+metadata.supports_dynamic_registration?
+metadata.supports_jwt_client_auth?
+metadata.supports_client_authorization?
+metadata.supports_authorization_code?
+metadata.supports_refresh_token?
+metadata.supports_tiered_oauth?
+metadata.supports_signed_metadata?
+```
+
+Profile-only helpers check only whether a profile string appears in `udap_profiles_supported`; they do not check endpoints or grant types. Use these when you need to inspect the raw advertisement separately from capability readiness.
+
+```ruby
+metadata.dynamic_registration_profile?
+metadata.jwt_client_auth_profile?
+metadata.client_authorization_profile?
+metadata.tiered_oauth_profile?
+```
+
 ### Error handling
 
 | Condition | Error raised |
 |-----------|-------------|
-| HTTP 4xx/5xx | `Safire::Errors::DiscoveryError` with `status` populated |
-| Server returns HTTP 204 | `Safire::Errors::DiscoveryError` (server signals no UDAP workflows for that community) |
+| HTTP 404 | `Safire::Errors::DiscoveryError` with `status` set to `404`; per STU2, clients should treat this as "UDAP workflows are not supported" |
+| Other HTTP 4xx/5xx | `Safire::Errors::DiscoveryError` with `status` populated |
+| Server returns HTTP 204 | `Safire::Errors::DiscoveryError` (server signals no UDAP workflows for the requested community) |
 | `signed_metadata` JWT validation fails | `Safire::Errors::DiscoveryError` (invalid signature, chain, revocation status, endpoint claim, or missing required claim) |
 | Malformed DER certificate in `x5c` header | `Safire::Errors::CertificateError` |
 | Connection failure, timeout, SSL error, or redirect to a non-HTTPS URL | `Safire::Errors::NetworkError` |
@@ -133,4 +197,4 @@ Results are cached separately per community and trust policy. Calling `server_me
 - [UDAP JWT Client Auth](https://www.udap.org/udap-jwt-client-auth.html) — JWT assertion specification
 - [UDAP Dynamic Client Registration](https://www.udap.org/udap-dynamic-client-registration.html) — DCR specification
 - [RFC 9126 — Pushed Authorization Requests](https://datatracker.ietf.org/doc/html/rfc9126)
-- [UDAP Tiered OAuth](https://hl7.org/fhir/us/udap-security/STU2/b2b.html) — Delegated authorization
+- [UDAP Tiered OAuth](https://hl7.org/fhir/us/udap-security/STU2/user.html) — Tiered OAuth for User Authentication


### PR DESCRIPTION
This PR fills out the UDAP documentation to match what was shipped in the signed metadata validator PR. The UDAP guide now covers how to call `valid?` to check structural STU2 conformance, how to use `signed_metadata_valid?` when re-validating against a different trust policy, and a full table of support helpers distinguishing capability checks (which verify both profile advertisement and endpoint availability) from profile-only checks. The client setup page updates the `:udap` protocol description to reflect signed metadata validation and the trust policy keywords added in the previous PR, with working code examples for development, production, and community-scoped discovery. The troubleshooting page separates SMART and UDAP discovery errors into their own sections, adds `CertificateError` to the error type reference, and includes manual `curl` commands for checking both well-known endpoints.