### PR TITLE
Document UDAP discovery release notes and roadmap

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -5,7 +5,7 @@ on:
   # base branch, so a PR cannot rewrite the prompt, schema, or posting logic
   # that reviews that same PR.
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened]
     branches: [main]
   workflow_dispatch:
     inputs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,43 +9,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `Safire::Protocols::UdapSignedMetadataValidator` validates the `signed_metadata` JWT per UDAP
-  Security STU2: RS256 algorithm, `x5c` leaf certificate, JWT signature, X.509 chain and
-  revocation validation, and all required claims (`iss`, `sub`, `exp`, `jti`, `token_endpoint`,
-  `registration_endpoint`, conditionally `authorization_endpoint`). Signed endpoint claims are
-  returned for merging over unsigned discovery values.
-
-- `Udap#server_metadata` now validates `signed_metadata` on every fetch and merges the
-  authoritative signed endpoint claims into the returned `UdapMetadata`. Raises
-  `Safire::Errors::DiscoveryError` if validation fails. Accepts `trusted_anchors:` and
-  `crls:` or `revocation_checker:` for production chain and revocation validation, plus
-  `verify_chain:` (`verify_chain: false` for dev/test only). Cached UDAP metadata is
-  revalidated before reuse and refetched if its signed JWT, certificate chain, or revocation
-  policy no longer validates.
-
-- `UdapMetadata#signed_metadata_valid?` for explicit cryptographic re-validation of the
-  `signed_metadata` JWT against a specific set of trust anchors and revocation policy.
-
-- The Sinatra demo now includes a protocol-aware UDAP Discovery workflow with community-scoped
-  discovery, signed metadata validation status, and configurable UDAP trust material.
-
-- `Safire::Client.new(..., protocol: :udap).server_metadata` now works end-to-end:
-  `Protocols::Udap` fetches and parses `/.well-known/udap`, supports the optional `community:` URI
-  parameter, caches results per community, and raises `DiscoveryError` on HTTP errors or a 204 response.
-
-- Added `Safire::Protocols::UdapMetadata` for HL7 UDAP Security STU2 discovery metadata,
-  including structural `valid?` checks and helper methods for advertised UDAP profiles and capabilities.
-
-- `Safire::Errors::DiscoveryError` accepts a `label:` keyword argument (default: `'SMART configuration'`)
-  and exposes it as a readable attribute; consumers can inspect `error.label` to identify which
-  protocol's discovery failed
+- UDAP Security STU2 discovery is now available with
+  `Safire::Client.new(..., protocol: :udap).server_metadata`. Safire fetches
+  `/.well-known/udap`, supports community-scoped discovery via `community:`, accepts
+  `trusted_anchors:`, `crls:`, `revocation_checker:`, and `verify_chain:` for
+  signed metadata trust validation (`verify_chain: false` is for development/test
+  only), parses metadata into `Safire::Protocols::UdapMetadata`, and raises
+  `DiscoveryError` for HTTP errors, 204 responses, a response body that is not a
+  JSON object, or failed signed metadata validation.
+- `Safire::Protocols::UdapMetadata` provides STU2 structural validation and helper
+  predicates for advertised UDAP profiles and capabilities.
+- `Safire::Protocols::UdapSignedMetadataValidator` validates the `signed_metadata`
+  JWT per UDAP Security STU2, including RS256, `x5c`, JWT signature, certificate
+  chain and revocation checks, issuer/subject/time claims, `jti`, and signed
+  endpoint claims.
+- UDAP signed endpoint claims are merged over unsigned discovery metadata after
+  successful validation. Cached UDAP metadata is revalidated before reuse and
+  refetched if the signed JWT, certificate chain, or revocation policy no longer
+  validates.
+- `UdapMetadata#signed_metadata_valid?` allows explicit cryptographic re-validation
+  against caller-provided trust anchors and revocation material.
+- The Sinatra demo includes a protocol-aware UDAP Discovery workflow with
+  community-scoped discovery, signed metadata validation status, and configurable
+  UDAP trust material.
+- `Safire::Errors::DiscoveryError` accepts a `label:` keyword argument (default:
+  `'SMART configuration'`) and exposes it as a readable attribute so callers can
+  identify which protocol's discovery failed.
 
 ### Changed
 
 - Ruby requirement changed from >= 4.0.2 to >= 4.0.4.
 - `Safire::Client` now raises `ConfigurationError` when `client_type:` is passed explicitly for
   `protocol: :udap`, both at construction and via `client_type=`; previously the value was
-  ignored silently
+  ignored silently.
 
 ## [0.3.0] - 2026-04-15
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,11 @@
 # Safire Roadmap
 
-## Current Release — v0.3.0
+## Latest Published Release — v0.3.0
 
 Safire is in early development (pre-release). The API is functional but not yet stable — breaking changes may occur before v1.0.0. Published to [RubyGems](https://rubygems.org/gems/safire).
+
+The `main` branch may include features not yet published to RubyGems; see the
+[Unreleased section of CHANGELOG.md](CHANGELOG.md#unreleased).
 
 Feedback, bug reports, and pull requests are welcome via the [issue tracker](https://github.com/vanessuniq/safire/issues).
 
@@ -22,13 +25,24 @@ Feedback, bug reports, and pull requests are welcome via the [issue tracker](htt
 - **Backend Services** — `client_credentials` grant for system-to-system flows; JWT assertion (RS384/ES384); no user interaction, redirect, or PKCE required; scope defaults to `system/*.rs` when not configured
 - **Dynamic Client Registration** — runtime client registration per [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591); endpoint discovered from SMART metadata or supplied explicitly; supports initial access token
 
+### UDAP Security (STU2 / v2.0.0)
+
+- **UDAP Discovery** — lazy fetch of `/.well-known/udap`; optional
+  community-scoped discovery; STU2 metadata parsing and structural validation
+- **Signed Metadata Validation** — validates `signed_metadata` JWTs using RS256,
+  JOSE `x5c`, certificate chain and revocation policy, required claims, and
+  signed endpoint claim precedence
+- **Protocol-Aware Client Facade** — `Safire::Client.new(..., protocol: :udap)`
+  exposes UDAP discovery while rejecting SMART-only `client_type:` values
+- **Demo Workflow** — Sinatra demo supports protocol-aware server setup and a
+  UDAP Discovery screen with signed metadata trust status
+
 ---
 
 ## Planned Features
 
 ### UDAP Security
 
-- **UDAP Discovery** — `/.well-known/udap` metadata fetch and validation
 - **UDAP Dynamic Client Registration** — signed software statements and client registration
 - **UDAP JWT Client Auth** — B2B and consumer-facing authorization flows
 - **Tiered OAuth** — identity chaining for multi-system access
@@ -74,5 +88,5 @@ Feedback, bug reports, and pull requests are welcome via the [issue tracker](htt
 | ActiveSupport | ~> 8.0 |
 | Rails (optional) | 7.x, 8.x |
 | SMART App Launch | 2.2.0 (STU2) |
-| UDAP Security | 2.0.0 ( STU2 - planned) |
+| UDAP Security | 2.0.0 (STU2 discovery implemented; DCR/auth flows planned) |
 | FHIR | R4, R4B |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,8 @@ Feedback, bug reports, and pull requests are welcome via the [issue tracker](htt
 ### UDAP Security (STU2 / v2.0.0)
 
 - **UDAP Discovery** — lazy fetch of `/.well-known/udap`; optional
-  community-scoped discovery; STU2 metadata parsing and structural validation
+  community-scoped discovery; STU2 metadata parsing plus explicit
+  `UdapMetadata#valid?` structural validation
 - **Signed Metadata Validation** — validates `signed_metadata` JWTs using RS256,
   JOSE `x5c`, certificate chain and revocation policy, required claims, and
   signed endpoint claim precedence


### PR DESCRIPTION
This final UDAP Discovery series PR cleans up the release-facing documentation now that the feature has landed. It consolidates the [Unreleased] changelog entries into feature-oriented notes, documents the primary UDAP discovery API and trust-policy kwargs, and moves UDAP Discovery from planned to implemented in the roadmap while keeping UDAP Dynamic Client Registration, JWT client authentication, and Tiered OAuth listed as planned work.