### PR TITLE
Relax Ruby and ActiveSupport version constraints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: CI
 
 on:
   workflow_call:
+    inputs:
+      ruby-version:
+        description: 'Ruby version to use'
+        type: string
+        default: '4.0.5'
 
 permissions:
   contents: read
@@ -16,7 +21,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '4.0.5'
+          ruby-version: ${{ inputs.ruby-version || '4.0.5' }}
           bundler-cache: true
 
       - name: Run tests and collect coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
         description: 'Ruby version to use'
         type: string
         default: '4.0.5'
+      gemfile:
+        description: 'Gemfile to use (relative path)'
+        type: string
+        default: 'Gemfile'
 
 permissions:
   contents: read
@@ -21,7 +25,8 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ inputs.ruby-version || '4.0.5' }}
+          ruby-version: ${{ inputs.ruby-version }}
+          bundler-gemfile: ${{ inputs.gemfile }}
           bundler-cache: true
 
       - name: Run tests and collect coverage

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,12 +17,13 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['3.2', '4.0.5']
+        gemfile: ['Gemfile']
         include:
-          # Lowest-supported ActiveSupport: exercises the >= 7.1 gemspec lower bound
-          - ruby: '3.4'
+          # Floor combination: Ruby 3.2 (declared minimum) + AS 7.1 (declared minimum)
+          - ruby: '3.2'
             gemfile: 'gemfiles/activesupport_71.gemfile'
     uses: ./.github/workflows/ci.yml
     with:
       ruby-version: ${{ matrix.ruby }}
-      gemfile: ${{ matrix.gemfile || 'Gemfile' }}
+      gemfile: ${{ matrix.gemfile }}
     secrets: inherit

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,12 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['3.2', '4.0.5']
+        include:
+          # Lowest-supported ActiveSupport: exercises the >= 7.1 gemspec lower bound
+          - ruby: '3.4'
+            gemfile: 'gemfiles/activesupport_71.gemfile'
     uses: ./.github/workflows/ci.yml
     with:
       ruby-version: ${{ matrix.ruby }}
+      gemfile: ${{ matrix.gemfile || 'Gemfile' }}
     secrets: inherit

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,5 +13,11 @@ permissions:
 
 jobs:
   ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['3.2', '4.0.5']
     uses: ./.github/workflows/ci.yml
+    with:
+      ruby-version: ${{ matrix.ruby }}
     secrets: inherit

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ plugins:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 4.0
+  TargetRubyVersion: 3.2
   NewCops: enable
   Exclude:
     - 'vendor/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Ruby requirement changed from >= 4.0.2 to >= 4.0.4.
+- Ruby requirement relaxed from `>= 4.0.4` to `>= 3.2` to support Rails 7.1+ apps still
+  running on Ruby 3.x. The minimum is 3.2 because the gem uses anonymous keyword splat
+  forwarding (`**` without a name), which was introduced in Ruby 3.2.
+- ActiveSupport requirement relaxed from `~> 8.0.0` to `>= 7.1, < 9`, resolving the
+  bundler conflict that prevented the gem from being used in Rails 8.1 apps or any app
+  pinning ActiveSupport 8.1.x.
 - `Safire::Client` now raises `ConfigurationError` when `client_type:` is passed explicitly for
   `protocol: :udap`, both at construction and via `client_type=`; previously the value was
   ignored silently.

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -37,7 +37,7 @@ This project adheres to a [Code of Conduct](CODE_OF_CONDUCT.md). By participatin
 
 ### Requirements
 
-- Ruby 4.0.4 or later
+- Ruby 3.2 or later
 - Bundler
 
 ### Setup

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-ruby '4.0.5'
-
 gemspec
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     safire (0.3.0)
-      activesupport (~> 8.0.0)
+      activesupport (>= 7.1, < 9)
       addressable (~> 2.8)
       faraday (~> 2.14)
       faraday-follow_redirects (~> 0.4)
@@ -199,9 +199,6 @@ DEPENDENCIES
   timecop (~> 0.9)
   webmock (~> 3.18)
   yard (~> 0.9)
-
-RUBY VERSION
-   ruby 4.0.5p0
 
 BUNDLED WITH
    2.7.1

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Auth flows (DCR, JWT assertion, Tiered OAuth) are planned. See [ROADMAP.md](http
 
 ## Installation
 
-Requires Ruby ≥ 4.0.4.
+Requires Ruby ≥ 3.2.
 
 ```ruby
 gem 'safire'

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -85,9 +85,9 @@ Feedback, bug reports, and pull requests are welcome via the [issue tracker](htt
 
 | Component | Version |
 |-----------|---------|
-| Ruby | ≥ 4.0.4 |
-| ActiveSupport | ~> 8.0 |
-| Rails (optional) | 7.x, 8.x |
+| Ruby | ≥ 3.2 |
+| ActiveSupport | ≥ 7.1, < 9 |
+| Rails (optional) | 7.1, 7.2, 8.x |
 | SMART App Launch | 2.2.0 (STU2) |
 | UDAP Security | 2.0.0 (STU2 discovery implemented; DCR/auth flows planned) |
 | FHIR | R4, R4B |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,7 +87,7 @@ Feedback, bug reports, and pull requests are welcome via the [issue tracker](htt
 |-----------|---------|
 | Ruby | ≥ 3.2 |
 | ActiveSupport | ≥ 7.1, < 9 |
-| Rails (optional) | 7.1, 7.2, 8.x |
+| Rails (optional) | ≥ 7.1 |
 | SMART App Launch | 2.2.0 (STU2) |
 | UDAP Security | 2.0.0 (STU2 discovery implemented; DCR/auth flows planned) |
 | FHIR | R4, R4B |

--- a/docs/adr/ADR-001-activesupport-dependency.md
+++ b/docs/adr/ADR-001-activesupport-dependency.md
@@ -31,7 +31,7 @@ Safire is also commonly used alongside Rails applications, where ActiveSupport i
 
 ## Decision
 
-Use `require 'active_support/all'` and treat ActiveSupport as a first-class runtime dependency (`spec.add_dependency 'activesupport', '~> 8.0.0'`).
+Use `require 'active_support/all'` and treat ActiveSupport as a first-class runtime dependency (`spec.add_dependency 'activesupport', '>= 7.1', '< 9'`).
 
 ActiveSupport utilities (`present?`, `blank?`, `fetch`, safe navigation, etc.) may be used freely throughout the codebase without needing to track individual requires.
 
@@ -46,5 +46,5 @@ ActiveSupport utilities (`present?`, `blank?`, `fetch`, safe navigation, etc.) m
 - Minimal overhead in non-Rails applications due to AS autoloading
 
 **Trade-offs:**
-- `activesupport` is pinned to `~> 8.0.0` — non-Rails Ruby applications must accept this dependency; a future major AS version bump requires a Safire dependency update
+- `activesupport` is constrained to `>= 7.1, < 9` — non-Rails Ruby applications must accept this dependency; a future major AS version bump (v9) requires a Safire dependency update
 - Developers unfamiliar with AS may not recognise AS methods as external — mitigated by the fact that AS conventions (`present?`, `blank?`) are widely known in the Ruby ecosystem

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,7 +20,7 @@ description: "How to install the Safire Ruby gem and get started with SMART App 
 
 ## Install
 
-**Requirements:** Ruby ≥ 4.0.4. OpenSSL is bundled with Ruby — no separate install needed.
+**Requirements:** Ruby ≥ 3.2. OpenSSL is bundled with Ruby — no separate install needed.
 
 Add to your Gemfile:
 

--- a/examples/sinatra_app/Gemfile.lock
+++ b/examples/sinatra_app/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ../..
   specs:
     safire (0.3.0)
-      activesupport (~> 8.0.0)
+      activesupport (>= 7.1, < 9)
       addressable (~> 2.8)
       faraday (~> 2.14)
       faraday-follow_redirects (~> 0.4)

--- a/gemfiles/activesupport_71.gemfile
+++ b/gemfiles/activesupport_71.gemfile
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'activesupport', '~> 7.1.0'
+
+gemspec path: '..'
+
+group :development, :test do
+  gem 'bundler-audit', '~> 0.9'
+  gem 'debug'
+  gem 'pry'
+  gem 'pry-byebug'
+  gem 'rspec', '~> 3.12'
+  gem 'rubocop', '~> 1.57'
+  gem 'rubocop-rspec', '~> 3.0', require: false
+  gem 'timecop', '~> 0.9'
+end
+
+group :development do
+  gem 'yard', '~> 0.9'
+end
+
+group :test do
+  gem 'dotenv', '~> 3.0'
+  gem 'simplecov', require: false
+  gem 'simplecov-cobertura', require: false
+  gem 'sinatra', '~> 4.0'
+  gem 'webmock', '~> 3.18'
+end

--- a/gemfiles/activesupport_71.gemfile.lock
+++ b/gemfiles/activesupport_71.gemfile.lock
@@ -1,0 +1,291 @@
+PATH
+  remote: ..
+  specs:
+    safire (0.3.0)
+      activesupport (>= 7.1, < 9)
+      addressable (~> 2.8)
+      faraday (~> 2.14)
+      faraday-follow_redirects (~> 0.4)
+      jwt (~> 2.8)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (7.1.6)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      mutex_m
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
+      thor (~> 1.0)
+    byebug (13.0.0)
+      reline (>= 0.6.0)
+    coderay (1.1.3)
+    concurrent-ruby (1.3.7)
+    connection_pool (3.0.2)
+    crack (1.0.1)
+      bigdecimal
+      rexml
+    date (3.5.1)
+    debug (1.11.1)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
+    diff-lcs (1.6.2)
+    docile (1.4.1)
+    dotenv (3.2.0)
+    drb (2.2.3)
+    erb (6.0.4)
+    faraday (2.14.3)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-follow_redirects (0.5.0)
+      faraday (>= 1, < 3)
+    faraday-net_http (3.4.4)
+      net-http (~> 0.5)
+    hashdiff (1.2.1)
+    i18n (1.15.0)
+      concurrent-ruby (~> 1.0)
+    io-console (0.8.2)
+    irb (1.18.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
+    json (2.19.9)
+    jwt (2.10.3)
+      base64
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    logger (1.7.0)
+    method_source (1.1.0)
+    minitest (5.27.0)
+    mustermann (3.1.1)
+    mutex_m (0.3.0)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    parallel (2.1.0)
+    parser (3.3.11.1)
+      ast (~> 2.4.1)
+      racc
+    pp (0.6.3)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.9.0)
+    pry (0.16.0)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+      reline (>= 0.6.0)
+    pry-byebug (3.12.0)
+      byebug (~> 13.0)
+      pry (>= 0.13, < 0.17)
+    psych (5.4.0)
+      date
+      stringio
+    public_suffix (7.0.5)
+    racc (1.8.1)
+    rack (3.2.6)
+    rack-protection (4.2.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rainbow (3.1.1)
+    rdoc (7.2.0)
+      erb
+      psych (>= 4.0.0)
+      tsort
+    regexp_parser (2.12.0)
+    reline (0.6.3)
+      io-console (~> 0.5)
+    rexml (3.4.4)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+    rubocop (1.88.0)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (>= 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.49.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    rubocop-rspec (3.10.2)
+      lint_roller (~> 1.1)
+      regexp_parser (>= 2.0)
+      rubocop (~> 1.86, >= 1.86.2)
+    ruby-progressbar (1.13.0)
+    securerandom (0.4.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (3.2.0)
+      rexml
+      simplecov (~> 0.19)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
+    sinatra (4.2.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.2.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    stringio (3.2.0)
+    thor (1.5.0)
+    tilt (2.7.0)
+    timecop (0.9.11)
+    tsort (0.2.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
+    uri (1.1.1)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    yard (0.9.44)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  activesupport (~> 7.1.0)
+  bundler-audit (~> 0.9)
+  debug
+  dotenv (~> 3.0)
+  pry
+  pry-byebug
+  rspec (~> 3.12)
+  rubocop (~> 1.57)
+  rubocop-rspec (~> 3.0)
+  safire!
+  simplecov
+  simplecov-cobertura
+  sinatra (~> 4.0)
+  timecop (~> 0.9)
+  webmock (~> 3.18)
+  yard (~> 0.9)
+
+CHECKSUMS
+  activesupport (7.1.6) sha256=7f12140a813b1c4922a322663e547129aef1840fc512fa262378f6d7e7fd3a7c
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
+  byebug (13.0.0) sha256=d2263efe751941ca520fa29744b71972d39cbc41839496706f5d9b22e92ae05d
+  coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
+  concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
+  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
+  date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
+  debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
+  diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
+  dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
+  faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
+  faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
+  faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
+  hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
+  i18n (1.15.0) sha256=ed20037ed7ca75dd36ec486b5fb9696e8e0cfe48f4f80980017932d93e70527f
+  io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
+  irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
+  json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
+  jwt (2.10.3) sha256=e4d9352fbc7309b1a7448c7dd713dfe4d8c47077af80759cdbed8f878ea0b484
+  language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  method_source (1.1.0) sha256=181301c9c45b731b4769bc81e8860e72f9161ad7d66dd99103c9ab84f560f5c5
+  minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
+  mustermann (3.1.1) sha256=4c6170c7234d5499c345562ba7c7dfe73e1754286dcc1abb053064d66a127198
+  mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
+  net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
+  parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
+  parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
+  pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
+  prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  pry (0.16.0) sha256=d76c69065698ed1f85e717bd33d7942c38a50868f6b0673c636192b3d1b6054e
+  pry-byebug (3.12.0) sha256=594e094ae8a8390a7ad4c7b36ae36e13304ed02664c67417d108dc5f7213d1b7
+  psych (5.4.0) sha256=14f72d69a611af663d7d70e4a7b67d9eb1f3ae9f8d916b478961d5a0075ba5b7
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
+  rack-protection (4.2.1) sha256=cf6e2842df8c55f5e4d1a4be015e603e19e9bc3a7178bae58949ccbb58558bac
+  rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
+  rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
+  rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
+  rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
+  rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
+  rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
+  rubocop (1.88.0) sha256=e420ddf1662d0ef34bc8a2910ac4b396a7ddda0b51a708264405241734b08e0b
+  rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
+  rubocop-rspec (3.10.2) sha256=0b3e2ecc592cd10ecbf0095bb58d1e357905276e069643523cc19eb7495f65e2
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  safire (0.3.0)
+  securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
+  simplecov-cobertura (3.2.0) sha256=70d702658677fcb20e5aceb6915ccf8bc62ff2ccd38b62b3ad5c9db5c0888740
+  simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
+  simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
+  sinatra (4.2.1) sha256=b7aeb9b11d046b552972ade834f1f9be98b185fa8444480688e3627625377080
+  stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
+  thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
+  tilt (2.7.0) sha256=0d5b9ba69f6a36490c64b0eee9f6e9aad517e20dcc848800a06eb116f08c6ab3
+  timecop (0.9.11) sha256=41284dc6e5041f2184f781ace766f942108c842f8d8c1386a26e6343decc7542
+  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
+  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+  webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90
+  yard (0.9.44) sha256=eb087e9b631ccd887b049f303d489963945452d5e2a7eb49a5a74a7cf6887f28
+
+BUNDLED WITH
+  4.0.10

--- a/safire.gemspec
+++ b/safire.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
                                '(client_credentials) grant.'
   spec.homepage              = 'https://github.com/vanessuniq/safire'
   spec.license               = 'Apache-2.0'
-  spec.required_ruby_version = Gem::Requirement.new('>= 4.0.4')
+  spec.required_ruby_version = '>= 3.2'
 
   spec.metadata['source_code_uri']   = spec.homepage
   spec.metadata['changelog_uri']     = "#{spec.homepage}/blob/main/CHANGELOG.md"
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Runtime deps
-  spec.add_dependency 'activesupport', '~> 8.0.0'
+  spec.add_dependency 'activesupport', '>= 7.1', '< 9'
   spec.add_dependency 'addressable', '~> 2.8'
   spec.add_dependency 'faraday', '~> 2.14'
   spec.add_dependency 'faraday-follow_redirects', '~> 0.4'


### PR DESCRIPTION
The gem's declared version floors were accidentally ratcheted up by Renovate auto-updates to require Ruby >= 4.0.4 and pin ActiveSupport to ~> 8.0.0 (minor-patch pessimistic), even though the code is compatible with much older versions. This locked out Ruby 3.x users entirely and caused bundler conflicts in any app using Rails 8.1 (which ships ActiveSupport 8.1.x).

This PR relaxes both constraints to their actual minimum: `>= 3.2` for Ruby (the anonymous keyword splat forwarding used in `errors.rb` was introduced in Ruby 3.2) and `>= 7.1, < 9` for ActiveSupport (the gem only uses methods available since AS 4.x). The RuboCop `TargetRubyVersion` is updated to `3.2` to match. A Ruby version matrix (`3.2` and `4.0.5`) is added to CI so the declared floor is actually tested, preventing the same problem from recurring. The `ruby '4.0.5'` Bundler pin is removed from `Gemfile` so `bundle install` works on any supported Ruby version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)