### PR TITLE
Share OAuth response handling for UDAP DCR

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,6 +55,12 @@ RSpec/MultipleMemoizedHelpers:
 RSpec/NestedGroups:
   Enabled: false
 
+RSpec/SpecFilePathFormat:
+  CustomTransform:
+    OAuthResponseHandling: oauth_response_handling
+    RuboCop: rubocop
+    RSpec: rspec
+
 # Integration tests describe workflows, not classes
 RSpec/DescribeClass:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- SMART Dynamic Client Registration now requires successful RFC 7591 responses
+  to contain a non-blank string `client_id`. Malformed identifiers that were
+  previously accepted now raise `Safire::Errors::RegistrationError`; valid
+  registration responses are unchanged.
 - Ruby requirement relaxed from `>= 4.0.4` to `>= 3.2` to support Rails 7.1+ apps still
   running on Ruby 3.x. The minimum is 3.2 because the gem uses anonymous keyword splat
   forwarding (`**` without a name), which was introduced in Ruby 3.2.

--- a/docs/adr/ADR-009-oauth-error-hierarchy.md
+++ b/docs/adr/ADR-009-oauth-error-hierarchy.md
@@ -78,3 +78,54 @@ Each subclass defines only `operation_label` and, when needed, overrides `build_
 **Trade-offs:**
 - The `operation_label` template method raises `NotImplementedError` at runtime if a subclass forgets to define it; a compile-time check is not possible in Ruby
 - `ReceivesFields` modifies the constructor via `super(**)` forwarding, which requires care when the inheritance chain has multiple `initialize` overrides
+
+---
+
+## Amendment: Shared protocol response handling
+
+UDAP Dynamic Client Registration uses the same RFC 7591 success and OAuth-style
+error response shapes as SMART registration. Keeping response translation as
+private methods on `Protocols::Smart` would either couple UDAP to SMART or
+duplicate parsing at the protocol trust boundary.
+
+`Protocols::OAuthResponseHandling` now owns two private transformations shared
+by protocol implementations:
+
+- converting a Faraday error response into a typed `OAuthError` subclass
+- validating and normalizing an RFC 7591 registration success response
+
+The module accepts already-received response bodies. It does not send HTTP
+requests, select endpoints, log response values, or apply protocol-specific
+policy.
+
+Registration success responses are normalized to string-keyed hashes and must
+contain a non-blank string `client_id`, as required by RFC 7591. Missing
+`client_id` responses continue to report only the received field names. A
+present but blank or non-string `client_id` raises `RegistrationError` with a
+structural error description. This intentionally hardens SMART registration:
+valid RFC 7591 responses are unchanged, while malformed identifiers that were
+previously accepted through `present?` now fail closed.
+
+Malformed or non-object OAuth error bodies produce an error containing the HTTP
+status only. Parsed JSON objects preserve their protocol error codes, including
+UDAP-specific values such as `invalid_software_statement`.
+
+### Amendment consequences
+
+**Benefits:**
+
+- SMART and UDAP share one auditable response boundary without sharing request
+  construction or endpoint policy
+- response key normalization makes direct and middleware-parsed hashes behave
+  consistently
+- malformed successful registrations fail before an invalid identifier reaches
+  application state
+
+**Trade-offs:**
+
+- the private module contains generic OAuth error translation and
+  registration-specific success validation; splitting two small transformations
+  into separate objects would add indirection without creating an independent
+  responsibility
+- SMART servers returning a non-string `client_id` are now rejected even if an
+  earlier Safire version accepted the malformed value

--- a/docs/smart-on-fhir/dynamic-client-registration/response.md
+++ b/docs/smart-on-fhir/dynamic-client-registration/response.md
@@ -107,7 +107,8 @@ rescue Safire::Errors::DiscoveryError => e
 
 ### `Safire::Errors::RegistrationError`
 
-Raised when the server returns an HTTP error response (4xx or 5xx), or when a 2xx response does not include `client_id`.
+Raised when the server returns an HTTP error response (4xx or 5xx), or when a
+2xx response does not contain a non-blank string `client_id`.
 
 ```ruby
 rescue Safire::Errors::RegistrationError => e
@@ -116,10 +117,18 @@ rescue Safire::Errors::RegistrationError => e
   puts e.error_code        # "invalid_redirect_uri"
   puts e.error_description # "Redirect URI must use HTTPS"
 
-  # Structural failure path — 2xx response missing client_id
+  # Structural failure path — client_id key is missing
   puts e.received_fields   # ["error", "error_description"]
   puts e.message           # "Registration response missing client_id; received fields: ..."
+
+  # Structural failure path — client_id is nil, blank, or not a string
+  puts e.error_description # "response client_id must be a non-blank string"
 ```
+
+For a missing `client_id` key, `received_fields` contains the field names from
+the response. When the key is present but its value is invalid,
+`error_description` describes the validation failure and `received_fields` is
+`nil`.
 
 To rescue any OAuth protocol error in one clause, use `Safire::Errors::OAuthError`, the shared base class for `RegistrationError`, `TokenError`, and `AuthError`.
 

--- a/docs/troubleshooting/client-errors.md
+++ b/docs/troubleshooting/client-errors.md
@@ -49,13 +49,36 @@ rescue Safire::Errors::RegistrationError => e
   puts e.error_description # "Redirect URI must use HTTPS"
 ```
 
-### `RegistrationError`: 2xx response missing `client_id`
+### `RegistrationError`: 2xx response has a missing or invalid `client_id`
 
 ```
 Safire::Errors::RegistrationError: Registration response missing client_id; received fields: error, error_description
 ```
 
-The server returned a successful HTTP status but did not include `client_id`. This typically means the server returned an error body with a 2xx status code, which is a server-side bug. Check `e.received_fields` to see what was returned.
+The server returned a successful HTTP status without a valid `client_id`. A
+successful registration response must contain a non-blank string `client_id`.
+
+If the response omitted the key, check `e.received_fields` to see what the
+server returned:
+
+```ruby
+rescue Safire::Errors::RegistrationError => e
+  puts e.received_fields # ["error", "error_description"]
+end
+```
+
+If the key was present but its value was `nil`, blank, or not a string,
+`e.error_description` reports the validation failure and `e.received_fields`
+is `nil`:
+
+```ruby
+rescue Safire::Errors::RegistrationError => e
+  puts e.error_description # "response client_id must be a non-blank string"
+end
+```
+
+Either response is a server-side protocol error and should not be treated as a
+successful registration.
 
 ---
 

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -31,7 +31,7 @@ Safire raises typed errors so you can handle each failure category separately:
 | `Safire::Errors::ConfigurationError` | Missing or invalid client configuration — caught at construction time |
 | `Safire::Errors::DiscoveryError` | SMART or UDAP metadata discovery failed (HTTP error, invalid JSON, missing SMART `token_endpoint` when required, or UDAP `signed_metadata` validation failure) |
 | `Safire::Errors::CertificateError` | UDAP `x5c` certificate data could not be parsed during `signed_metadata` validation |
-| `Safire::Errors::RegistrationError` | Dynamic Client Registration failed (server error, or 2xx response missing `client_id`) |
+| `Safire::Errors::RegistrationError` | Dynamic Client Registration failed (server error, or 2xx response with a missing or invalid `client_id`) |
 | `Safire::Errors::TokenError` | Token exchange or refresh failed (OAuth error, missing fields) |
 | `Safire::Errors::NetworkError` | Transport-level failure (connection refused, timeout, blocked redirect) |
 

--- a/lib/safire/errors.rb
+++ b/lib/safire/errors.rb
@@ -209,7 +209,8 @@ module Safire
     #   provide +received_fields+ or +error_description+
     #
     # @!attribute [r] received_fields
-    #   @return [Array<String>, nil] field names present in a response missing +client_id+ (no values logged)
+    #   @return [Array<String>, nil] field names from a response whose +client_id+ key is absent
+    #     (no values logged); +nil+ when +client_id+ is present but invalid or the server returns an HTTP error
     class RegistrationError < OAuthError
       include ReceivesFields
 

--- a/lib/safire/errors.rb
+++ b/lib/safire/errors.rb
@@ -205,7 +205,8 @@ module Safire
     #
     # Two usage paths:
     # - HTTP failure: provide +status+, +error_code+, and/or +error_description+
-    # - Structural failure (missing +client_id+ in a 2xx response): provide +received_fields+
+    # - Structural failure (missing or invalid +client_id+ in a 2xx response):
+    #   provide +received_fields+ or +error_description+
     #
     # @!attribute [r] received_fields
     #   @return [Array<String>, nil] field names present in a response missing +client_id+ (no values logged)

--- a/lib/safire/protocols/oauth_response_handling.rb
+++ b/lib/safire/protocols/oauth_response_handling.rb
@@ -1,0 +1,48 @@
+module Safire
+  module Protocols
+    # Shared translation of OAuth-style wire responses into Safire values and errors.
+    #
+    # Protocol implementations remain responsible for HTTP requests, endpoint
+    # selection, and protocol-specific policy.
+    #
+    # @api private
+    module OAuthResponseHandling
+      private
+
+      def oauth_error_from(faraday_error, error_class)
+        response = faraday_error.response
+        status = response&.dig(:status)
+        body = json_object(response&.dig(:body))
+
+        error_class.new(
+          status:,
+          error_code: body&.fetch('error', nil),
+          error_description: body&.fetch('error_description', nil)
+        )
+      end
+
+      def parse_registration_response(body)
+        response = json_object(body)
+        raise Errors::RegistrationError.new(error_description: 'response is not a JSON object') unless response
+
+        client_id = response['client_id']
+        return response if client_id.is_a?(String) && client_id.present?
+
+        if response.key?('client_id')
+          raise Errors::RegistrationError.new(
+            error_description: 'response client_id must be a non-blank string'
+          )
+        end
+
+        raise Errors::RegistrationError.new(received_fields: response.keys)
+      end
+
+      def json_object(body)
+        parsed = body.is_a?(String) ? JSON.parse(body) : body
+        parsed.deep_stringify_keys if parsed.is_a?(Hash)
+      rescue JSON::ParserError
+        nil
+      end
+    end
+  end
+end

--- a/lib/safire/protocols/smart.rb
+++ b/lib/safire/protocols/smart.rb
@@ -15,6 +15,7 @@ module Safire
     # @api private
     class Smart
       include Behaviours
+      include OAuthResponseHandling
       include URIValidation
 
       ATTRIBUTES = %i[
@@ -239,7 +240,7 @@ module Safire
       # @raise [Safire::Errors::ConfigurationError] if the endpoint (explicit or discovered)
       #   uses HTTP on a non-localhost host
       # @raise [Safire::Errors::RegistrationError] if the server returns an error
-      #   response or a 2xx response missing +client_id+
+      #   response or a 2xx response with a missing, blank, or non-string +client_id+
       # @raise [Safire::Errors::NetworkError] on connection failure, timeout, or SSL error
       def register_client(metadata, registration_endpoint: nil, authorization: nil)
         endpoint = registration_endpoint.presence || discovered_registration_endpoint
@@ -486,21 +487,6 @@ module Safire
         oauth_error_from(faraday_error, Errors::RegistrationError)
       end
 
-      def oauth_error_from(faraday_error, error_class)
-        response = faraday_error.response
-        status   = response&.dig(:status)
-        raw_body = response&.dig(:body)
-        body = raw_body.is_a?(Hash) ? raw_body : JSON.parse(raw_body.to_s)
-
-        error_class.new(
-          status:,
-          error_code: body.is_a?(Hash) ? body['error'] : nil,
-          error_description: body.is_a?(Hash) ? body['error_description'] : nil
-        )
-      rescue JSON::ParserError
-        error_class.new(status:)
-      end
-
       def discovered_token_endpoint
         endpoint = server_metadata.token_endpoint
         return endpoint if endpoint.present?
@@ -528,14 +514,6 @@ module Safire
         when :invalid   then raise Errors::ConfigurationError.new(invalid_uri_attributes: [:registration_endpoint])
         when :non_https then raise Errors::ConfigurationError.new(non_https_uri_attributes: [:registration_endpoint])
         end
-      end
-
-      def parse_registration_response(body)
-        raise Errors::RegistrationError.new(error_description: 'response is not a JSON object') unless body.is_a?(Hash)
-
-        return body if body['client_id'].present?
-
-        raise Errors::RegistrationError.new(received_fields: body.keys)
       end
 
       def well_known_endpoint

--- a/spec/safire/protocols/oauth_response_handling_spec.rb
+++ b/spec/safire/protocols/oauth_response_handling_spec.rb
@@ -1,0 +1,182 @@
+require 'spec_helper'
+
+RSpec.describe Safire::Protocols::OAuthResponseHandling do
+  subject(:handler) { handler_class.new }
+
+  let(:handler_class) do
+    Class.new do
+      include Safire::Protocols::OAuthResponseHandling
+
+      def parse_registration(body)
+        parse_registration_response(body)
+      end
+
+      def build_oauth_error(faraday_error, error_class)
+        oauth_error_from(faraday_error, error_class)
+      end
+    end
+  end
+
+  describe '#parse_registration_response' do
+    it 'returns a valid string-keyed registration response' do
+      body = { 'client_id' => 'client-123', 'client_name' => 'Example App' }
+
+      expect(handler.parse_registration(body)).to eq(body)
+    end
+
+    it 'normalizes symbol keys to strings' do
+      body = {
+        client_id: 'client-123',
+        redirect_uris: [{ uri: 'https://app.example.com/callback' }]
+      }
+
+      expect(handler.parse_registration(body)).to eq(
+        'client_id' => 'client-123',
+        'redirect_uris' => [{ 'uri' => 'https://app.example.com/callback' }]
+      )
+    end
+
+    it 'raises RegistrationError with field names when client_id is missing' do
+      expect { handler.parse_registration('client_name' => 'Example App', 'expires_at' => 1234) }
+        .to raise_error(Safire::Errors::RegistrationError) { |error|
+          expect(error.received_fields).to contain_exactly('client_name', 'expires_at')
+          expect(error.message).not_to include('Example App', '1234')
+        }
+    end
+
+    it 'rejects a blank client_id' do
+      expect { handler.parse_registration('client_id' => '  ') }
+        .to raise_error(
+          Safire::Errors::RegistrationError,
+          /client_id must be a non-blank string/
+        )
+    end
+
+    it 'rejects a non-string client_id' do
+      expect { handler.parse_registration('client_id' => 123) }
+        .to raise_error(
+          Safire::Errors::RegistrationError,
+          /client_id must be a non-blank string/
+        )
+    end
+
+    it 'rejects a nil client_id' do
+      expect { handler.parse_registration('client_id' => nil) }
+        .to raise_error(
+          Safire::Errors::RegistrationError,
+          /client_id must be a non-blank string/
+        )
+    end
+
+    it 'rejects a non-object JSON value' do
+      expect { handler.parse_registration(%w[not an object]) }
+        .to raise_error(Safire::Errors::RegistrationError, /not a JSON object/)
+    end
+
+    it 'rejects a malformed JSON body that was not parsed by middleware' do
+      expect { handler.parse_registration('{not-json') }
+        .to raise_error(Safire::Errors::RegistrationError, /not a JSON object/)
+    end
+  end
+
+  describe '#oauth_error_from' do
+    it 'extracts OAuth error fields from a parsed Hash' do
+      faraday_error = instance_double(
+        Faraday::Error,
+        response: {
+          status: 400,
+          body: {
+            'error' => 'invalid_client_metadata',
+            'error_description' => 'Client metadata is invalid'
+          }
+        }
+      )
+
+      error = handler.build_oauth_error(faraday_error, Safire::Errors::RegistrationError)
+
+      expect(error.status).to eq(400)
+      expect(error.error_code).to eq('invalid_client_metadata')
+      expect(error.error_description).to eq('Client metadata is invalid')
+    end
+
+    it 'extracts OAuth error fields from a JSON string' do
+      faraday_error = instance_double(
+        Faraday::Error,
+        response: {
+          status: 400,
+          body: {
+            error: 'invalid_redirect_uri',
+            error_description: 'Redirect URI is invalid'
+          }.to_json
+        }
+      )
+
+      error = handler.build_oauth_error(faraday_error, Safire::Errors::RegistrationError)
+
+      expect(error.error_code).to eq('invalid_redirect_uri')
+      expect(error.error_description).to eq('Redirect URI is invalid')
+    end
+
+    it 'preserves UDAP registration error codes' do
+      faraday_error = instance_double(
+        Faraday::Error,
+        response: {
+          status: 400,
+          body: {
+            'error' => 'invalid_software_statement',
+            'error_description' => 'The software statement is invalid'
+          }
+        }
+      )
+
+      error = handler.build_oauth_error(faraday_error, Safire::Errors::RegistrationError)
+
+      expect(error.error_code).to eq('invalid_software_statement')
+      expect(error.error_description).to eq('The software statement is invalid')
+    end
+
+    it 'preserves an unapproved_software_statement UDAP error code' do
+      faraday_error = instance_double(
+        Faraday::Error,
+        response: {
+          status: 401,
+          body: {
+            'error' => 'unapproved_software_statement',
+            'error_description' => 'Software statement is not approved for this community'
+          }
+        }
+      )
+
+      error = handler.build_oauth_error(faraday_error, Safire::Errors::RegistrationError)
+
+      expect(error.error_code).to eq('unapproved_software_statement')
+      expect(error.error_description).to eq('Software statement is not approved for this community')
+    end
+
+    it 'returns a status-only error for malformed JSON' do
+      faraday_error = instance_double(
+        Faraday::Error,
+        response: { status: 502, body: '{not-json' }
+      )
+
+      error = handler.build_oauth_error(faraday_error, Safire::Errors::RegistrationError)
+
+      expect(error.status).to eq(502)
+      expect(error.error_code).to be_nil
+      expect(error.error_description).to be_nil
+    end
+
+    it 'returns a status-only error for a non-object JSON value' do
+      faraday_error = instance_double(
+        Faraday::Error,
+        response: { status: 400, body: ['invalid_request'] }
+      )
+
+      error = handler.build_oauth_error(faraday_error, Safire::Errors::RegistrationError)
+
+      expect(error.status).to eq(400)
+      expect(error.error_code).to be_nil
+      expect(error.error_description).to be_nil
+    end
+  end
+end

--- a/spec/safire/protocols/oauth_response_handling_spec.rb
+++ b/spec/safire/protocols/oauth_response_handling_spec.rb
@@ -24,6 +24,15 @@ RSpec.describe Safire::Protocols::OAuthResponseHandling do
       expect(handler.parse_registration(body)).to eq(body)
     end
 
+    it 'parses a valid JSON-string registration response' do
+      body = '{"client_id":"client-123","client_name":"Example App"}'
+
+      expect(handler.parse_registration(body)).to eq(
+        'client_id' => 'client-123',
+        'client_name' => 'Example App'
+      )
+    end
+
     it 'normalizes symbol keys to strings' do
       body = {
         client_id: 'client-123',

--- a/spec/safire/protocols/smart_spec.rb
+++ b/spec/safire/protocols/smart_spec.rb
@@ -1215,6 +1215,22 @@ RSpec.describe Safire::Protocols::Smart do
       end
     end
 
+    context 'when a 2xx response contains a non-string client_id' do
+      before do
+        stub_request(:post, registration_endpoint).to_return(
+          status: 201,
+          body: { 'client_id' => 123, 'client_name' => 'My App' }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+
+      it 'raises RegistrationError instead of accepting malformed RFC 7591 metadata' do
+        expect do
+          described_class.new(no_client_id_config).register_client(client_metadata, registration_endpoint:)
+        end.to raise_error(Safire::Errors::RegistrationError)
+      end
+    end
+
     context 'when the response body is not a JSON object' do
       before do
         stub_request(:post, registration_endpoint).to_return(

--- a/spec/safire/protocols/smart_spec.rb
+++ b/spec/safire/protocols/smart_spec.rb
@@ -1227,7 +1227,10 @@ RSpec.describe Safire::Protocols::Smart do
       it 'raises RegistrationError instead of accepting malformed RFC 7591 metadata' do
         expect do
           described_class.new(no_client_id_config).register_client(client_metadata, registration_endpoint:)
-        end.to raise_error(Safire::Errors::RegistrationError)
+        end.to raise_error(
+          Safire::Errors::RegistrationError,
+          /client_id must be a non-blank string/
+        )
       end
     end
 


### PR DESCRIPTION
## Summary

This PR begins the UDAP Dynamic Client Registration series by extracting OAuth-style error parsing and RFC 7591 registration response validation from `Protocols::Smart` into a private `OAuthResponseHandling` module. SMART now uses the shared boundary without changing valid response behavior, while malformed success responses fail closed unless `client_id` is a non-blank string. The module normalizes parsed responses to string keys, safely handles malformed or non-object error bodies, and preserves UDAP error codes for the upcoming registration flow.

ADR-009 documents the shared response boundary and its ownership limits. The changelog records the intentional SMART response hardening, and RuboCop is configured to preserve the repository's `oauth_...` filename convention.

## Verification

- `COVERAGE=true bundle exec rspec` - 659 examples, 0 failures
- `XDG_CACHE_HOME=/tmp bundle exec rubocop` - 59 files, no offenses
- `bin/docs` - generated successfully with existing YARD warnings only
- New response-handling module: 100% line coverage
