### PR TITLE
Add UDAP client certificate chain configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Safire::ClientConfig` accepts a leaf-first `certificate_chain` of PEM strings
+  or `OpenSSL::X509::Certificate` instances as the client signing identity
+  foundation for UDAP Dynamic Client Registration. The chain is defensively
+  stored and masked alongside private keys and client secrets in configuration
+  output; end-to-end UDAP registration remains planned.
 - UDAP Security STU2 discovery is now available with
   `Safire::Client.new(..., protocol: :udap).server_metadata`. Safire fetches
   `/.well-known/udap`, supports community-scoped discovery via `community:`, accepts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Safire::ClientConfig` accepts a leaf-first `certificate_chain` of PEM strings
   or `OpenSSL::X509::Certificate` instances as the client signing identity
-  foundation for UDAP Dynamic Client Registration. The chain is defensively
-  stored and masked alongside private keys and client secrets in configuration
-  output; end-to-end UDAP registration remains planned.
+  foundation for UDAP Dynamic Client Registration. Configured chains must be
+  non-empty; certificate objects are stored as DER snapshots, and the chain is
+  masked alongside private keys and client secrets in configuration output.
+  End-to-end UDAP registration remains planned.
 - UDAP Security STU2 discovery is now available with
   `Safire::Client.new(..., protocol: :udap).server_metadata`. Safire fetches
   `/.well-known/udap`, supports community-scoped discovery via `community:`, accepts

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,13 +50,13 @@ GEM
     dotenv (3.2.0)
     drb (2.2.3)
     erb (6.0.4)
-    faraday (2.14.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-follow_redirects (0.5.0)
       faraday (>= 1, < 3)
-    faraday-net_http (3.4.3)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
     hashdiff (1.2.1)
     i18n (1.14.8)

--- a/docs/adr/ADR-004-clientconfig-immutability-and-entity-masking.md
+++ b/docs/adr/ADR-004-clientconfig-immutability-and-entity-masking.md
@@ -13,7 +13,9 @@ nav_order: 4
 
 ## Context
 
-`ClientConfig` holds all credentials and endpoints for a Safire client — including `client_secret` and `private_key`. Two separate concerns need to be addressed:
+`ClientConfig` holds all credentials and endpoints for a Safire client — including
+`client_secret`, `private_key`, and the client certificate chain intended for
+UDAP signing. Two separate concerns need to be addressed:
 
 **Concern 1 — Mutability:** should `ClientConfig` allow attributes to be changed after construction?
 
@@ -27,11 +29,16 @@ These two concerns are related: if `ClientConfig` is mutable, masking is harder 
 
 ## Decision
 
-**`ClientConfig` is immutable after construction.** All attributes are `attr_reader` only — no setters. Validation runs once at construction. After `initialize` returns, the object's state cannot change.
+**The `ClientConfig` configuration surface is immutable after construction.**
+All attributes are `attr_reader` only — no setters — and validation runs once
+at construction. Mutable credential collections that require a stable order,
+such as `certificate_chain`, are defensively stored as described below.
 
 **Sensitive attributes are masked at two layers** via the `Entity` base class:
 
-**Layer 1 — `#to_hash`:** the `sensitive_attributes` hook (overridden in `ClientConfig` to return `[:client_secret, :private_key]`) causes those values to appear as `'[FILTERED]'` in any hash serialisation.
+**Layer 1 — `#to_hash`:** the `sensitive_attributes` hook (overridden in
+`ClientConfig` to return `[:client_secret, :private_key, :certificate_chain]`)
+causes those values to appear as `'[FILTERED]'` in any hash serialisation.
 
 ```ruby
 def to_hash
@@ -44,12 +51,22 @@ end
 
 **Layer 2 — `#inspect`:** `ClientConfig` overrides `inspect` directly, emitting `[FILTERED]` for sensitive attributes. This prevents credential leakage in exception backtraces, IRB/pry sessions, and logging middleware that calls `inspect` on objects.
 
+Although X.509 certificates contain public material, `certificate_chain` is
+masked because it can be large and identifies the client's operational signing
+identity. The configured chain collection is defensively copied and frozen,
+and PEM strings are copied and frozen. Certificate parsing, private-key
+matching, validity checks, and URI SAN checks remain the responsibility of the
+UDAP software-statement builder. The leaf-first ordering follows the
+[UDAP Security STU2 JWT header requirements](https://hl7.org/fhir/us/udap-security/STU2/general.html#jwt-headers).
+
 ---
 
 ## Consequences
 
 **Benefits:**
-- Thread-safe by default — a `ClientConfig` shared across threads has no mutable state
+- Configuration attributes cannot be reassigned through `ClientConfig`
+- The order and PEM contents of a configured certificate-chain collection
+  cannot be changed through the original input array or strings
 - Credentials cannot leak through `inspect`, `to_s`, exception trackers, or log output
 - Validation at construction means invalid configs are caught early, before any network calls
 - The `sensitive_attributes` hook is extensible — subclasses can add fields without modifying `Entity`
@@ -57,3 +74,6 @@ end
 **Trade-offs:**
 - Callers cannot modify a `ClientConfig` in place — they must construct a new one; this is intentional and makes state changes explicit
 - `private_key` masking means the key object itself is not serialisable via `to_hash` — callers needing to inspect or store the key must access it directly via `config.private_key`
+- `certificate_chain` masking similarly means callers must access
+  `config.certificate_chain` directly when passing the configured identity to a
+  signing operation

--- a/docs/adr/ADR-004-clientconfig-immutability-and-entity-masking.md
+++ b/docs/adr/ADR-004-clientconfig-immutability-and-entity-masking.md
@@ -53,10 +53,14 @@ end
 
 Although X.509 certificates contain public material, `certificate_chain` is
 masked because it can be large and identifies the client's operational signing
-identity. The configured chain collection is defensively copied and frozen,
-and PEM strings are copied and frozen. Certificate parsing, private-key
-matching, validity checks, and URI SAN checks remain the responsibility of the
-UDAP software-statement builder. The leaf-first ordering follows the
+identity. The configured chain collection is defensively copied and frozen.
+PEM strings are copied and frozen; certificate objects are stored as immutable
+DER snapshots and materialized as fresh `OpenSSL::X509::Certificate` instances
+whenever the public accessor is called. Mutating either the caller-owned
+certificate or an accessor result therefore cannot alter the configured
+identity. Certificate parsing from PEM, private-key matching, validity checks,
+and URI SAN checks remain the responsibility of the UDAP software-statement
+builder. The leaf-first ordering follows the
 [UDAP Security STU2 JWT header requirements](https://hl7.org/fhir/us/udap-security/STU2/general.html#jwt-headers).
 
 ---

--- a/docs/configuration/client-setup.md
+++ b/docs/configuration/client-setup.md
@@ -102,6 +102,39 @@ metadata = client.server_metadata(
 
 See [UDAP]({{ site.baseurl }}/udap/) for validation helpers, 404/204 discovery behavior, and the `verify_chain: false` development caveat.
 
+#### UDAP client signing credentials
+
+UDAP software statements use a client private key and a leaf-first X.509
+certificate chain. Configure these reusable credentials on the client:
+
+```ruby
+config = Safire::ClientConfig.new(
+  base_url:   'https://fhir.example.com',
+  private_key: File.read(ENV.fetch('UDAP_CLIENT_PRIVATE_KEY_PATH')),
+  certificate_chain: [
+    File.read(ENV.fetch('UDAP_CLIENT_CERTIFICATE_PATH')),
+    File.read(ENV.fetch('UDAP_CLIENT_ISSUING_CA_PATH'))
+  ],
+  jwt_algorithm: 'RS256'
+)
+
+client = Safire::Client.new(config, protocol: :udap)
+```
+
+`certificate_chain` accepts PEM strings or
+`OpenSSL::X509::Certificate` instances. The leaf certificate must be first, as
+required by the
+[UDAP Security STU2 JWT header profile](https://hl7.org/fhir/us/udap-security/STU2/general.html#jwt-headers).
+`ClientConfig` validates the collection shape, copies and freezes the chain,
+and defers certificate parsing, private-key matching, validity checks, and URI
+SAN checks until a software statement is built.
+
+Configured credentials are intended to serve as defaults, with per-call
+overrides for applications that select signing identities dynamically. The
+end-to-end UDAP Dynamic Client Registration API is not available yet. These
+fields provide its configuration foundation; UDAP discovery does not access
+them.
+
 ### Client Type
 
 Selects the SMART authentication method. Applies only when `protocol: :smart`. Defaults to `:public`.
@@ -174,13 +207,17 @@ UDAP discovery always uses the FHIR `base_url` and the `/.well-known/udap` endpo
 
 ## Credential Protection
 
-`ClientConfig` prevents `client_secret` and `private_key` from leaking in logs or REPL output.
+`ClientConfig` prevents `client_secret`, `private_key`, and
+`certificate_chain` from leaking in logs or REPL output. The certificate chain
+is masked even though certificates are public because the full chain can be
+large and identifies the client's operational signing identity.
 
 `#to_hash` replaces sensitive fields with `'[FILTERED]'`:
 
 ```ruby
-config.to_hash[:client_secret]  # => "[FILTERED]"
-config.to_hash[:base_url]       # => "https://fhir.example.com"
+config.to_hash[:client_secret]      # => "[FILTERED]"
+config.to_hash[:certificate_chain] # => "[FILTERED]"
+config.to_hash[:base_url]           # => "https://fhir.example.com"
 ```
 
 `#inspect` is overridden to mask sensitive fields and omit `nil` attributes, so REPL sessions and error messages never expose credentials:

--- a/docs/configuration/client-setup.md
+++ b/docs/configuration/client-setup.md
@@ -125,9 +125,11 @@ client = Safire::Client.new(config, protocol: :udap)
 `OpenSSL::X509::Certificate` instances. The leaf certificate must be first, as
 required by the
 [UDAP Security STU2 JWT header profile](https://hl7.org/fhir/us/udap-security/STU2/general.html#jwt-headers).
-`ClientConfig` validates the collection shape, copies and freezes the chain,
-and defers certificate parsing, private-key matching, validity checks, and URI
-SAN checks until a software statement is built.
+`ClientConfig` requires a non-empty collection, copies and freezes PEM strings,
+and snapshots certificate objects as DER. Accessing the chain returns fresh
+certificate objects, so subsequent caller mutations cannot alter the configured
+identity. Safire defers PEM parsing, private-key matching, validity checks, and
+URI SAN checks until a software statement is built.
 
 Configured credentials are intended to serve as defaults, with per-call
 overrides for applications that select signing identities dynamically. The

--- a/docs/configuration/client-setup.md
+++ b/docs/configuration/client-setup.md
@@ -218,7 +218,7 @@ large and identifies the client's operational signing identity.
 
 ```ruby
 config.to_hash[:client_secret]      # => "[FILTERED]"
-config.to_hash[:certificate_chain] # => "[FILTERED]"
+config.to_hash[:certificate_chain]  # => "[FILTERED]"
 config.to_hash[:base_url]           # => "https://fhir.example.com"
 ```
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -46,13 +46,18 @@ flowchart TD
 | `protocol:` | Symbol | No | `:smart` | Authorization protocol — `:smart` or `:udap` |
 | `client_type:` | Symbol | No | `nil` (→ `:public` for SMART) | SMART client type — `:public`, `:confidential_symmetric`, or `:confidential_asymmetric`; not applicable for `:udap` (any explicit value raises `ConfigurationError`) |
 | `client_secret` | String | No | — | Required for `:confidential_symmetric` |
-| `private_key` | OpenSSL::PKey / String | No | — | RSA/EC private key; required for `:confidential_asymmetric` and Backend Services |
+| `private_key` | OpenSSL::PKey / String | No | — | RSA/EC private key; used by SMART asymmetric clients and as the UDAP client signing key |
+| `certificate_chain` | Array of PEM strings / OpenSSL::X509::Certificate | No | — | Leaf-first client certificate chain for UDAP software-statement signing |
 | `kid` | String | No | — | Key ID matching the public key registered with the server |
-| `jwt_algorithm` | String | No | auto | `RS384` or `ES384`; auto-detected from key type |
+| `jwt_algorithm` | String | No | auto | SMART: `RS384` or `ES384`; UDAP registration: `RS256`, `RS384`, `ES256`, or `ES384`, constrained by the key and server metadata |
 | `jwks_uri` | String | No | — | URL to client's public JWKS, included as `jku` in JWT header |
 | `scopes` | Array | No | — | Default scopes for authorization requests |
 | `authorization_endpoint` | String | No | — | Override the discovered authorization endpoint |
 | `token_endpoint` | String | No | — | Override the discovered token endpoint |
+
+`certificate_chain` and the UDAP algorithm values are configuration groundwork
+for Dynamic Client Registration. The current UDAP runtime supports discovery;
+registration is not available yet.
 
 ## In This Section
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -47,7 +47,7 @@ flowchart TD
 | `client_type:` | Symbol | No | `nil` (→ `:public` for SMART) | SMART client type — `:public`, `:confidential_symmetric`, or `:confidential_asymmetric`; not applicable for `:udap` (any explicit value raises `ConfigurationError`) |
 | `client_secret` | String | No | — | Required for `:confidential_symmetric` |
 | `private_key` | OpenSSL::PKey / String | No | — | RSA/EC private key; used by SMART asymmetric clients and as the UDAP client signing key |
-| `certificate_chain` | Array of PEM strings / OpenSSL::X509::Certificate | No | — | Leaf-first client certificate chain for UDAP software-statement signing |
+| `certificate_chain` | Array of PEM strings / OpenSSL::X509::Certificate | No | — | Non-empty, leaf-first client certificate chain for UDAP software-statement signing |
 | `kid` | String | No | — | Key ID matching the public key registered with the server |
 | `jwt_algorithm` | String | No | auto | SMART: `RS384` or `ES384`; UDAP registration: `RS256`, `RS384`, `ES256`, or `ES384`, constrained by the key and server metadata |
 | `jwks_uri` | String | No | — | URL to client's public JWKS, included as `jku` in JWT header |

--- a/lib/safire/client.rb
+++ b/lib/safire/client.rb
@@ -16,9 +16,14 @@ module Safire
   # * :scopes [Array<String>] default scopes; falls back to +["system/*.rs"]+ for
   #     backend services when not provided
   # * :client_secret [String, optional] required for confidential_symmetric clients
-  # * :private_key [OpenSSL::PKey, String, optional] private key for asymmetric clients and backend services
+  # * :private_key [OpenSSL::PKey, String, optional] private key for SMART asymmetric clients,
+  #     backend services, and planned UDAP software-statement signing
+  # * :certificate_chain [Array<String, OpenSSL::X509::Certificate>, optional] leaf-first X.509
+  #     certificate chain for planned UDAP software-statement signing
   # * :kid [String, optional] key ID matching the registered public key for asymmetric clients and backend services
-  # * :jwt_algorithm [String, optional] JWT signing algorithm (RS384 or ES384). Auto-detected if not provided
+  # * :jwt_algorithm [String, optional] JWT signing algorithm. SMART supports RS384 or ES384;
+  #     planned UDAP registration supports RS256, RS384, ES256, or ES384 subject to key
+  #     compatibility and server discovery. Selected automatically when omitted
   # * :jwks_uri [String, optional] URL to client's JWKS for jku header in JWT assertions
   #
   # The +protocol:+ keyword selects the authorization protocol:

--- a/lib/safire/client_config.rb
+++ b/lib/safire/client_config.rb
@@ -30,7 +30,8 @@ module Safire
   # @!attribute [r] certificate_chain
   #   @return [Array<String, OpenSSL::X509::Certificate>, nil] leaf-first X.509 certificate chain
   #     for planned UDAP software-statement signing. Entries may be PEM strings or certificate objects.
-  #     Parsing and identity validation occur when the software statement is built.
+  #     Certificate objects are stored as DER snapshots and returned as fresh copies. Parsing PEM
+  #     strings and identity validation occur when the software statement is built.
   # @!attribute [r] kid
   #   @return [String, nil] the key ID matching the public key registered with the authorization server.
   #     Required for confidential asymmetric authentication.
@@ -71,12 +72,21 @@ module Safire
       private_key certificate_chain kid jwt_algorithm jwks_uri
     ].freeze
 
-    attr_reader(*ATTRIBUTES)
+    CertificateSnapshot = Data.define(:der)
+    private_constant :CertificateSnapshot
+
+    attr_reader(*(ATTRIBUTES - [:certificate_chain]))
+
+    def certificate_chain
+      return if @certificate_chain.nil?
+
+      @certificate_chain.map { |entry| materialize_certificate_entry(entry) }.freeze
+    end
 
     def initialize(config)
       super(config, ATTRIBUTES)
 
-      @certificate_chain = normalize_certificate_chain(certificate_chain)
+      @certificate_chain = normalize_certificate_chain(@certificate_chain)
       @issuer ||= base_url
       validate!
     end
@@ -96,7 +106,7 @@ module Safire
     # @api private
     def inspect
       attrs = ATTRIBUTES.map do |attr|
-        value = send(attr)
+        value = instance_variable_get(:"@#{attr}")
         next if value.nil?
 
         masked = SENSITIVE_ATTRIBUTES.include?(attr) ? '[FILTERED]' : value.inspect
@@ -118,25 +128,38 @@ module Safire
       return if chain.nil?
 
       validate_certificate_chain_type!(chain)
-      chain.map { |certificate| certificate.is_a?(String) ? certificate.dup.freeze : certificate }.freeze
+      chain.map { |entry| snapshot_certificate_entry(entry) }.freeze
     end
 
     def validate_certificate_chain_type!(chain)
-      unless chain.is_a?(Array)
-        raise Errors::ConfigurationError.new(
-          invalid_attribute: :certificate_chain,
-          invalid_value: chain.class,
-          valid_values: [Array]
-        )
-      end
+      raise_invalid_certificate_chain!(chain.class, [Array]) unless chain.is_a?(Array)
+      raise_invalid_certificate_chain!(chain.class, ['non-empty Array']) if chain.empty?
 
       invalid_entry = chain.find { |entry| CERTIFICATE_CHAIN_ENTRY_TYPES.none? { |type| entry.is_a?(type) } }
       return unless invalid_entry
 
+      raise_invalid_certificate_chain!(invalid_entry.class, CERTIFICATE_CHAIN_ENTRY_TYPES)
+    end
+
+    def snapshot_certificate_entry(entry)
+      return entry.dup.freeze if entry.is_a?(String)
+
+      CertificateSnapshot.new(der: entry.to_der.dup.freeze)
+    rescue OpenSSL::X509::CertificateError
+      raise_invalid_certificate_chain!(entry.class, ['serializable OpenSSL::X509::Certificate'])
+    end
+
+    def materialize_certificate_entry(entry)
+      return entry unless entry.is_a?(CertificateSnapshot)
+
+      OpenSSL::X509::Certificate.new(entry.der)
+    end
+
+    def raise_invalid_certificate_chain!(invalid_value, valid_values)
       raise Errors::ConfigurationError.new(
         invalid_attribute: :certificate_chain,
-        invalid_value: invalid_entry.class,
-        valid_values: CERTIFICATE_CHAIN_ENTRY_TYPES
+        invalid_value:,
+        valid_values:
       )
     end
 

--- a/lib/safire/client_config.rb
+++ b/lib/safire/client_config.rb
@@ -1,7 +1,6 @@
 module Safire
-  # Client configuration entity providing necessary attributes to perform different
-  # auth flows such as SMART public, confidential symmetric, confidential asymmetric
-  # clients, and backend services.
+  # Client configuration entity providing attributes for SMART authorization flows,
+  # backend services, UDAP discovery, and UDAP client signing credentials.
   # The ClientConfig instance is passed to Safire::Client upon initialization.
   #
   # @!attribute [r] base_url
@@ -27,13 +26,19 @@ module Safire
   #   =>  Optional, will be retrieved from the well-known smart-configuration if not provided
   # @!attribute [r] private_key
   #   @return [OpenSSL::PKey::RSA, OpenSSL::PKey::EC, String, nil] the private key for signing
-  #     JWT assertions in confidential asymmetric auth. Can be an OpenSSL key object or PEM string.
+  #     SMART JWT assertions or planned UDAP software statements. Can be an OpenSSL key object or PEM string.
+  # @!attribute [r] certificate_chain
+  #   @return [Array<String, OpenSSL::X509::Certificate>, nil] leaf-first X.509 certificate chain
+  #     for planned UDAP software-statement signing. Entries may be PEM strings or certificate objects.
+  #     Parsing and identity validation occur when the software statement is built.
   # @!attribute [r] kid
   #   @return [String, nil] the key ID matching the public key registered with the authorization server.
   #     Required for confidential asymmetric authentication.
   # @!attribute [r] jwt_algorithm
-  #   @return [String, nil] the JWT signing algorithm (RS384 or ES384).
-  #     Optional, auto-detected from key type if not provided.
+  #   @return [String, nil] the JWT signing algorithm. SMART supports RS384 or ES384;
+  #     planned UDAP registration supports RS256, RS384, ES256, or ES384 subject to key
+  #     compatibility and server discovery. Optional; selected from the key and protocol
+  #     requirements when omitted.
   # @!attribute [r] jwks_uri
   #   @return [String, nil] URL to the client's JWKS containing the public key.
   #     Optional, included as jku header in JWT assertions when provided.
@@ -63,7 +68,7 @@ module Safire
     ATTRIBUTES = %i[
       base_url issuer client_id client_secret redirect_uri
       scopes authorization_endpoint token_endpoint
-      private_key kid jwt_algorithm jwks_uri
+      private_key certificate_chain kid jwt_algorithm jwks_uri
     ].freeze
 
     attr_reader(*ATTRIBUTES)
@@ -71,6 +76,7 @@ module Safire
     def initialize(config)
       super(config, ATTRIBUTES)
 
+      @certificate_chain = normalize_certificate_chain(certificate_chain)
       @issuer ||= base_url
       validate!
     end
@@ -81,10 +87,11 @@ module Safire
       end
     end
 
-    SENSITIVE_ATTRIBUTES = %i[client_secret private_key].freeze
+    CERTIFICATE_CHAIN_ENTRY_TYPES = [String, OpenSSL::X509::Certificate].freeze
+    SENSITIVE_ATTRIBUTES = %i[client_secret private_key certificate_chain].freeze
     URI_ATTRS = %i[base_url redirect_uri issuer authorization_endpoint token_endpoint jwks_uri].freeze
     OPTIONAL_URI_ATTRS = %i[redirect_uri authorization_endpoint token_endpoint jwks_uri].freeze
-    private_constant :SENSITIVE_ATTRIBUTES, :URI_ATTRS, :OPTIONAL_URI_ATTRS
+    private_constant :CERTIFICATE_CHAIN_ENTRY_TYPES, :SENSITIVE_ATTRIBUTES, :URI_ATTRS, :OPTIONAL_URI_ATTRS
 
     # @api private
     def inspect
@@ -106,6 +113,32 @@ module Safire
     end
 
     private
+
+    def normalize_certificate_chain(chain)
+      return if chain.nil?
+
+      validate_certificate_chain_type!(chain)
+      chain.map { |certificate| certificate.is_a?(String) ? certificate.dup.freeze : certificate }.freeze
+    end
+
+    def validate_certificate_chain_type!(chain)
+      unless chain.is_a?(Array)
+        raise Errors::ConfigurationError.new(
+          invalid_attribute: :certificate_chain,
+          invalid_value: chain.class,
+          valid_values: [Array]
+        )
+      end
+
+      invalid_entry = chain.find { |entry| CERTIFICATE_CHAIN_ENTRY_TYPES.none? { |type| entry.is_a?(type) } }
+      return unless invalid_entry
+
+      raise Errors::ConfigurationError.new(
+        invalid_attribute: :certificate_chain,
+        invalid_value: invalid_entry.class,
+        valid_values: CERTIFICATE_CHAIN_ENTRY_TYPES
+      )
+    end
 
     # Validates all URI attributes for structure and HTTPS requirement.
     #

--- a/lib/safire/client_config.rb
+++ b/lib/safire/client_config.rb
@@ -106,6 +106,7 @@ module Safire
     # @api private
     def inspect
       attrs = ATTRIBUTES.map do |attr|
+        # Read stored values directly so masked compound types are not materialized before being discarded.
         value = instance_variable_get(:"@#{attr}")
         next if value.nil?
 
@@ -135,16 +136,17 @@ module Safire
       raise_invalid_certificate_chain!(chain.class, [Array]) unless chain.is_a?(Array)
       raise_invalid_certificate_chain!(chain.class, ['non-empty Array']) if chain.empty?
 
-      invalid_entry = chain.find { |entry| CERTIFICATE_CHAIN_ENTRY_TYPES.none? { |type| entry.is_a?(type) } }
-      return unless invalid_entry
+      chain.each do |entry|
+        next if CERTIFICATE_CHAIN_ENTRY_TYPES.any? { |type| entry.is_a?(type) }
 
-      raise_invalid_certificate_chain!(invalid_entry.class, CERTIFICATE_CHAIN_ENTRY_TYPES)
+        raise_invalid_certificate_chain!(entry.class, CERTIFICATE_CHAIN_ENTRY_TYPES)
+      end
     end
 
     def snapshot_certificate_entry(entry)
       return entry.dup.freeze if entry.is_a?(String)
 
-      CertificateSnapshot.new(der: entry.to_der.dup.freeze)
+      CertificateSnapshot.new(der: entry.to_der.freeze)
     rescue OpenSSL::X509::CertificateError
       raise_invalid_certificate_chain!(entry.class, ['serializable OpenSSL::X509::Certificate'])
     end

--- a/lib/safire/client_config_builder.rb
+++ b/lib/safire/client_config_builder.rb
@@ -50,6 +50,15 @@ module Safire
       self
     end
 
+    # Sets the leaf-first X.509 certificate chain used for UDAP signing.
+    #
+    # @param certificate_chain [Array<String, OpenSSL::X509::Certificate>, nil]
+    # @return [self]
+    def certificate_chain(certificate_chain)
+      @config[:certificate_chain] = certificate_chain
+      self
+    end
+
     def kid(kid)
       @config[:kid] = kid
       self

--- a/spec/safire/client_config_builder_spec.rb
+++ b/spec/safire/client_config_builder_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe Safire::ClientConfigBuilder do
 
   let(:certificate_chain) do
     [
-      "-----BEGIN CERTIFICATE-----\nleaf-certificate\n-----END CERTIFICATE-----\n",
-      OpenSSL::X509::Certificate.new
+      "-----BEGIN CERTIFICATE-----\nleaf-certificate\n-----END CERTIFICATE-----\n"
     ]
   end
 

--- a/spec/safire/client_config_builder_spec.rb
+++ b/spec/safire/client_config_builder_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe Safire::ClientConfigBuilder do
+  subject(:builder) { Safire::ClientConfig.builder }
+
+  let(:certificate_chain) do
+    [
+      "-----BEGIN CERTIFICATE-----\nleaf-certificate\n-----END CERTIFICATE-----\n",
+      OpenSSL::X509::Certificate.new
+    ]
+  end
+
+  it 'builds a ClientConfig with a certificate chain' do
+    config = builder
+             .base_url('https://fhir.example.com')
+             .certificate_chain(certificate_chain)
+             .build
+
+    expect(config).to be_a(Safire::ClientConfig)
+    expect(config.certificate_chain).to eq(certificate_chain)
+  end
+end

--- a/spec/safire/client_config_spec.rb
+++ b/spec/safire/client_config_spec.rb
@@ -1,6 +1,14 @@
 require 'spec_helper'
 
 RSpec.describe Safire::ClientConfig do
+  let(:certificate) { OpenSSL::X509::Certificate.new }
+  let(:certificate_pem) do
+    <<~PEM
+      -----BEGIN CERTIFICATE-----
+      certificate-data
+      -----END CERTIFICATE-----
+    PEM
+  end
   let(:valid_attrs) do
     {
       base_url: 'https://fhir.example.com',
@@ -160,6 +168,53 @@ RSpec.describe Safire::ClientConfig do
     end
   end
 
+  # ---------- Certificate chain configuration ----------
+
+  describe 'certificate chain configuration' do
+    it 'defaults certificate_chain to nil' do
+      expect(described_class.new(valid_attrs).certificate_chain).to be_nil
+    end
+
+    it 'accepts PEM strings and OpenSSL certificates without parsing them' do
+      config = described_class.new(valid_attrs.merge(certificate_chain: [certificate_pem, certificate]))
+
+      expect(config.certificate_chain).to eq([certificate_pem, certificate])
+    end
+
+    it 'rejects a non-array certificate_chain without exposing its value' do
+      expect { described_class.new(valid_attrs.merge(certificate_chain: certificate_pem)) }
+        .to raise_error(Safire::Errors::ConfigurationError) { |error|
+          expect(error.message).to include('certificate_chain', 'Array')
+          expect(error.message).not_to include('certificate-data')
+        }
+    end
+
+    it 'rejects unsupported certificate entry types without exposing their values' do
+      expect { described_class.new(valid_attrs.merge(certificate_chain: [Object.new])) }
+        .to raise_error(Safire::Errors::ConfigurationError) { |error|
+          expect(error.message).to include('certificate_chain', 'String', 'OpenSSL::X509::Certificate')
+          expect(error.message).not_to match(/#<Object/)
+        }
+    end
+
+    it 'defensively copies and freezes the chain and PEM strings' do
+      source_pem = certificate_pem.dup
+      source_chain = [source_pem]
+      config = described_class.new(valid_attrs.merge(certificate_chain: source_chain))
+
+      source_pem << 'mutated'
+      source_chain << certificate
+
+      expect(config.certificate_chain).to eq([certificate_pem])
+      expect(config.certificate_chain).to be_frozen
+      expect(config.certificate_chain.first).to be_frozen
+    end
+
+    it 'does not expose a certificate_chain writer' do
+      expect(described_class.new(valid_attrs)).not_to respond_to(:certificate_chain=)
+    end
+  end
+
   # ---------- to_hash ----------
 
   describe '#to_hash' do
@@ -179,6 +234,11 @@ RSpec.describe Safire::ClientConfig do
     it 'masks private_key with [FILTERED]' do
       config = described_class.new(valid_attrs.merge(private_key: 'pem_key_data'))
       expect(config.to_hash[:private_key]).to eq('[FILTERED]')
+    end
+
+    it 'masks certificate_chain with [FILTERED]' do
+      config = described_class.new(valid_attrs.merge(certificate_chain: [certificate_pem]))
+      expect(config.to_hash[:certificate_chain]).to eq('[FILTERED]')
     end
 
     it 'leaves nil client_secret as nil' do
@@ -215,6 +275,16 @@ RSpec.describe Safire::ClientConfig do
       expect(config.inspect).to include('[FILTERED]')
     end
 
+    it 'does not expose certificate_chain in output' do
+      config = described_class.new(valid_attrs.merge(certificate_chain: [certificate_pem]))
+      expect(config.inspect).not_to include('certificate-data')
+    end
+
+    it 'shows [FILTERED] in place of certificate_chain' do
+      config = described_class.new(valid_attrs.merge(certificate_chain: [certificate_pem]))
+      expect(config.inspect).to include('certificate_chain: [FILTERED]')
+    end
+
     it 'includes non-sensitive attributes in output' do
       config = described_class.new(valid_attrs)
       expect(config.inspect).to include('base_url')
@@ -225,6 +295,7 @@ RSpec.describe Safire::ClientConfig do
       config = described_class.new(valid_attrs)
       expect(config.inspect).not_to include('client_secret')
       expect(config.inspect).not_to include('private_key')
+      expect(config.inspect).not_to include('certificate_chain')
     end
   end
 end

--- a/spec/safire/client_config_spec.rb
+++ b/spec/safire/client_config_spec.rb
@@ -1,7 +1,19 @@
 require 'spec_helper'
 
 RSpec.describe Safire::ClientConfig do
-  let(:certificate) { OpenSSL::X509::Certificate.new }
+  let(:certificate) do
+    key = OpenSSL::PKey::RSA.generate(2048)
+    cert = OpenSSL::X509::Certificate.new
+    cert.version = 2
+    cert.serial = 1
+    cert.subject = OpenSSL::X509::Name.parse('/CN=client.example.com')
+    cert.issuer = cert.subject
+    cert.public_key = key.public_key
+    cert.not_before = Time.now
+    cert.not_after = Time.now + 3600
+    cert.sign(key, OpenSSL::Digest.new('SHA256'))
+    cert
+  end
   let(:certificate_pem) do
     <<~PEM
       -----BEGIN CERTIFICATE-----
@@ -175,10 +187,15 @@ RSpec.describe Safire::ClientConfig do
       expect(described_class.new(valid_attrs).certificate_chain).to be_nil
     end
 
-    it 'accepts PEM strings and OpenSSL certificates without parsing them' do
+    it 'accepts PEM strings and OpenSSL certificates while preserving order' do
       config = described_class.new(valid_attrs.merge(certificate_chain: [certificate_pem, certificate]))
 
       expect(config.certificate_chain).to eq([certificate_pem, certificate])
+    end
+
+    it 'rejects an empty certificate_chain' do
+      expect { described_class.new(valid_attrs.merge(certificate_chain: [])) }
+        .to raise_error(Safire::Errors::ConfigurationError, /certificate_chain.*non-empty Array/)
     end
 
     it 'rejects a non-array certificate_chain without exposing its value' do
@@ -197,6 +214,13 @@ RSpec.describe Safire::ClientConfig do
         }
     end
 
+    it 'rejects certificate objects that cannot be snapshotted' do
+      incomplete_certificate = OpenSSL::X509::Certificate.new
+
+      expect { described_class.new(valid_attrs.merge(certificate_chain: [incomplete_certificate])) }
+        .to raise_error(Safire::Errors::ConfigurationError, /certificate_chain.*serializable/)
+    end
+
     it 'defensively copies and freezes the chain and PEM strings' do
       source_pem = certificate_pem.dup
       source_chain = [source_pem]
@@ -208,6 +232,25 @@ RSpec.describe Safire::ClientConfig do
       expect(config.certificate_chain).to eq([certificate_pem])
       expect(config.certificate_chain).to be_frozen
       expect(config.certificate_chain.first).to be_frozen
+    end
+
+    it 'snapshots certificate objects independently of the caller-owned instance' do
+      original_der = certificate.to_der
+      config = described_class.new(valid_attrs.merge(certificate_chain: [certificate]))
+
+      certificate.serial = 99
+
+      expect(config.certificate_chain.first.to_der).to eq(original_der)
+    end
+
+    it 'returns fresh certificate objects so accessor mutations do not alter the stored chain' do
+      config = described_class.new(valid_attrs.merge(certificate_chain: [certificate]))
+      returned_certificate = config.certificate_chain.first
+
+      returned_certificate.serial = 99
+
+      expect(config.certificate_chain.first.serial.to_i).to eq(1)
+      expect(config.certificate_chain.first).not_to equal(returned_certificate)
     end
 
     it 'does not expose a certificate_chain writer' do

--- a/spec/safire/client_config_spec.rb
+++ b/spec/safire/client_config_spec.rb
@@ -214,6 +214,11 @@ RSpec.describe Safire::ClientConfig do
         }
     end
 
+    it 'rejects nil entries within the certificate_chain' do
+      expect { described_class.new(valid_attrs.merge(certificate_chain: [certificate_pem, nil])) }
+        .to raise_error(Safire::Errors::ConfigurationError, /certificate_chain.*NilClass/)
+    end
+
     it 'rejects certificate objects that cannot be snapshotted' do
       incomplete_certificate = OpenSSL::X509::Certificate.new
 


### PR DESCRIPTION
## Summary

This PR adds the reusable client signing credential foundation needed for UDAP Dynamic Client Registration. ClientConfig and its fluent builder now accept a leaf-first certificate_chain containing PEM strings or OpenSSL certificate objects, defensively preserve the configured order, and mask the chain from inspect and to_hash output alongside other operational credentials. It also updates the public YARD documentation, ADR-004, configuration guides, and changelog while making clear that certificate parsing, identity checks, and the end-to-end registration flow remain intentionally deferred to later UDAP DCR work.

## Validation

- 672 RSpec examples passed
- RuboCop passed with no offenses
- Focused ClientConfig coverage reached 100%
- YARD generation and the Jekyll documentation build passed
- Library load check passed