### PR TITLE
Add UDAP software statement signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   five-minute lifetime, fresh `jti`, RSA/EC algorithm negotiation constrained
   by discovery and key type, and local certificate/key/SAN consistency checks.
   End-to-end UDAP registration remains planned.
-- `Safire::ClientConfig` accepts a leaf-first `certificate_chain` of PEM strings
-  or `OpenSSL::X509::Certificate` instances as the client signing identity
-  foundation for UDAP Dynamic Client Registration. Configured chains must be
-  non-empty; certificate objects are stored as DER snapshots, and the chain is
-  masked alongside private keys and client secrets in configuration output.
+- `Safire::ClientConfig` accepts a leaf-first, issuer-ordered
+  `certificate_chain` of PEM strings or `OpenSSL::X509::Certificate` instances
+  as the client signing identity foundation for UDAP Dynamic Client
+  Registration. Configured chains must be non-empty; certificate objects are
+  stored as DER snapshots, and the chain is masked alongside private keys and
+  client secrets in configuration output.
   End-to-end UDAP registration remains planned.
 - UDAP Security STU2 discovery is now available with
   `Safire::Client.new(..., protocol: :udap).server_metadata`. Safire fetches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Registration. Configured chains must be non-empty; certificate objects are
   stored as DER snapshots, and the chain is masked alongside private keys and
   client secrets in configuration output.
-  End-to-end UDAP registration remains planned.
 - UDAP Security STU2 discovery is now available with
   `Safire::Client.new(..., protocol: :udap).server_metadata`. Safire fetches
   `/.well-known/udap`, supports community-scoped discovery via `community:`, accepts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fields, JSON-compatible extensions, and immutable canonical output. An
   explicit `allow_insecure_localhost: true` option permits development-only
   HTTP loopback URIs without allowing remote HTTP.
+- Safire can construct UDAP Security STU2 X.509-backed software statements for
+  Dynamic Client Registration. The signing foundation produces compact JWS
+  values with minimal `alg`/`x5c` headers, exact `iss`/`sub`/`aud` claims, a
+  five-minute lifetime, fresh `jti`, RSA/EC algorithm negotiation constrained
+  by discovery and key type, and local certificate/key/SAN consistency checks.
+  End-to-end UDAP registration remains planned.
 - `Safire::ClientConfig` accepts a leaf-first `certificate_chain` of PEM strings
   or `OpenSSL::X509::Certificate` instances as the client signing identity
   foundation for UDAP Dynamic Client Registration. Configured chains must be

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Coverage](https://codecov.io/gh/vanessuniq/safire/branch/main/graph/badge.svg)](https://codecov.io/gh/vanessuniq/safire)
 [![Documentation](https://img.shields.io/badge/docs-yard-blue.svg)](https://vanessuniq.github.io/safire)
 
-Safire is a Ruby gem for healthcare client applications that implements [SMART App Launch 2.2.0](https://hl7.org/fhir/smart-app-launch/) and [UDAP Security STU2 / v2.0.0](https://hl7.org/fhir/us/udap-security/STU2/index.html) server metadata discovery and registration metadata validation. It handles SMART OAuth 2.0 authorization against HL7 FHIR servers, covering PKCE, private key JWT assertions, and the Backend Services system-to-system flow, so you can focus on your application rather than protocol plumbing.
+Safire is a Ruby gem for healthcare client applications that implements [SMART App Launch 2.2.0](https://hl7.org/fhir/smart-app-launch/) and [UDAP Security STU2 / v2.0.0](https://hl7.org/fhir/us/udap-security/STU2/index.html) server metadata discovery plus UDAP registration metadata and software-statement foundations. It handles SMART OAuth 2.0 authorization against HL7 FHIR servers, covering PKCE, private key JWT assertions, and the Backend Services system-to-system flow, so you can focus on your application rather than protocol plumbing.
 
 ---
 
@@ -58,7 +58,7 @@ registration_metadata = Safire::Protocols::UdapRegistrationMetadata.new(
 registration_metadata.to_h
 ```
 
-UDAP software-statement signing, registration submission, JWT client authentication, and Tiered OAuth are planned. See [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md) for details.
+UDAP registration submission, JWT client authentication, and Tiered OAuth are planned. See [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md) for details.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,6 +37,8 @@ Feedback, bug reports, and pull requests are welcome via the [issue tracker](htt
   exposes UDAP discovery while rejecting SMART-only `client_type:` values
 - **Demo Workflow** — Sinatra demo supports protocol-aware server setup and a
   UDAP Discovery screen with signed metadata trust status
+- **UDAP DCR Foundations** — registration metadata validation and internal
+  X.509-backed software statement signing
 
 ---
 
@@ -44,7 +46,8 @@ Feedback, bug reports, and pull requests are welcome via the [issue tracker](htt
 
 ### UDAP Security
 
-- **UDAP Dynamic Client Registration** — signed software statements and client registration
+- **UDAP Dynamic Client Registration Submission** — signed registration request
+  envelope POST and response handling
 - **UDAP JWT Client Auth** — B2B and consumer-facing authorization flows
 - **Tiered OAuth** — identity chaining for multi-system access
 
@@ -89,5 +92,5 @@ Feedback, bug reports, and pull requests are welcome via the [issue tracker](htt
 | ActiveSupport | ≥ 7.1, < 9 |
 | Rails (optional) | ≥ 7.1 |
 | SMART App Launch | 2.2.0 (STU2) |
-| UDAP Security | 2.0.0 (STU2 discovery implemented; DCR/auth flows planned) |
+| UDAP Security | 2.0.0 (STU2 discovery and DCR signing foundations implemented; registration submission/auth flows planned) |
 | FHIR | R4, R4B |

--- a/docs/adr/ADR-013-udap-registration-request-model.md
+++ b/docs/adr/ADR-013-udap-registration-request-model.md
@@ -100,6 +100,6 @@ regular expression.
   boolean opt-in and produces a warning.
 - Extension metadata remains forward-compatible without permitting arbitrary
   Ruby objects into a JWT payload.
-- Metadata validation is available before the software-statement builder and
-  network registration flow are implemented; this ADR does not make UDAP DCR
-  end to end available.
+- Metadata validation remains independent of software-statement signing and the
+  network registration flow; this ADR by itself does not make UDAP DCR end to
+  end available.

--- a/docs/adr/ADR-014-udap-software-statement-signing.md
+++ b/docs/adr/ADR-014-udap-software-statement-signing.md
@@ -1,0 +1,115 @@
+---
+layout: default
+title: "ADR-014: UDAP software-statement signing"
+parent: Architecture Decision Records
+nav_order: 14
+---
+
+# ADR-014: UDAP software-statement signing
+
+**Status:** Accepted
+
+---
+
+## Context
+
+UDAP Dynamic Client Registration submits caller-controlled registration
+metadata inside a signed software statement. HL7 UDAP Security STU2 requires
+that statement to be a compact JWS with an `alg` header, an inline leaf-first
+`x5c` certificate chain, issuer and subject set to the client URI, audience set
+to the authorization server's registration endpoint, a short validity window,
+and a fresh `jti`.
+
+Safire already has `JWTAssertion` for SMART private-key JWT authentication, but
+that class has SMART-specific audiences, claims, headers, algorithms, and key
+distribution assumptions. Reusing it for UDAP would require protocol branches
+in the signing path and make both flows harder to reason about.
+
+---
+
+## Decision
+
+### Use a dedicated builder
+
+`UdapSoftwareStatement` builds only UDAP registration software statements. It
+accepts a validated `UdapRegistrationMetadata` object, a client URI, the
+discovered registration endpoint, a private key, a leaf-first certificate
+chain, and the server-advertised registration signing algorithms.
+
+The builder has no HTTP behavior and does not perform discovery. UDAP protocol
+orchestration will remain responsible for fetching metadata, checking DCR
+capability, and POSTing the request envelope in a later PR.
+
+### Keep URI comparison exact
+
+The client URI is used exactly as `iss` and `sub` and must exactly match a
+`uniformResourceIdentifier` Subject Alternative Name entry in the leaf
+certificate. Safire does not derive it from `ClientConfig#issuer` and does not
+canonicalize case, ports, or trailing slashes.
+
+STU2 does not constrain the URI scheme used for client identifiers, so Safire
+does not require `client_uri` to use HTTPS. HTTP and HTTPS client URIs must have
+a host, while trust-community schemes such as `did:` can be valid when they are
+absolute and exactly match the certificate URI SAN.
+
+The registration endpoint is different: it is a server endpoint used as `aud`
+and must be an absolute HTTPS URI by default. `allow_insecure_localhost: true`
+permits HTTP only on `localhost` or `127.0.0.1` for local development. The value
+is still signed exactly as supplied.
+
+### Generate a minimal JOSE header
+
+Safire includes only the required `alg` and `x5c` header fields. It does not
+emit `typ`, `kid`, `jku`, or `x5u`. STU2's experimental `jku` alternative does
+not apply to registration requests.
+
+`x5c` is generated from the supplied certificate chain in leaf-first order. Each
+entry is Base64 DER with no PEM wrapper.
+
+### Constrain algorithm selection
+
+Safire supports the STU2 algorithm set it can sign safely:
+
+| Key | Algorithms |
+|-----|------------|
+| RSA | `RS256`, `RS384` |
+| EC P-256 | `ES256` |
+| EC P-384 | `ES384` |
+
+An explicit algorithm must be supported by Safire, compatible with the private
+key, and advertised by the server. Without an explicit algorithm, Safire chooses
+the first key-compatible advertised algorithm, preferring `RS256` over `RS384`
+for RSA keys because `RS256` is the STU2 baseline.
+
+### Validate local signing identity, not server trust
+
+Before signing, Safire parses and snapshots the certificate chain, checks
+certificate validity dates with the injected clock, verifies that the private
+key matches the leaf certificate, and checks that the client URI appears in the
+leaf certificate URI SAN.
+
+Safire does not decide whether the authorization server will trust the client
+certificate chain. Chain-building, revocation policy, and community trust for
+the client certificate remain authorization-server decisions during
+registration processing.
+
+### Keep test seams explicit
+
+The builder accepts a clock and a JTI generator. Production defaults are
+`Time.now` and `SecureRandom.uuid`; specs inject deterministic values without
+stubbing global randomness.
+
+---
+
+## Consequences
+
+- SMART JWT assertions and UDAP software statements remain separate, readable
+  signing paths.
+- Invalid local signing configuration fails before a malformed JWT can be
+  produced.
+- The generated JWT is short-lived: `exp` is always `iat + 300`.
+- Private keys, compact JWTs, and certificate contents are not included in
+  validation error messages.
+- End-to-end UDAP registration still requires the protocol orchestration PR
+  that discovers metadata, builds the request envelope, POSTs to the
+  registration endpoint, and parses the response.

--- a/docs/adr/ADR-014-udap-software-statement-signing.md
+++ b/docs/adr/ADR-014-udap-software-statement-signing.md
@@ -63,8 +63,8 @@ Safire includes only the required `alg` and `x5c` header fields. It does not
 emit `typ`, `kid`, `jku`, or `x5u`. STU2's experimental `jku` alternative does
 not apply to registration requests.
 
-`x5c` is generated from the supplied certificate chain in leaf-first order. Each
-entry is Base64 DER with no PEM wrapper.
+`x5c` is generated from the supplied certificate chain in leaf-first issuer
+order. Each entry is Base64 DER with no PEM wrapper.
 
 ### Constrain algorithm selection
 
@@ -83,15 +83,16 @@ for RSA keys because `RS256` is the STU2 baseline.
 
 ### Validate local signing identity, not server trust
 
-Before signing, Safire parses and snapshots the certificate chain, checks
-certificate validity dates with the injected clock, verifies that the private
+Before signing, Safire parses and snapshots the certificate chain, checks that
+the supplied chain is leaf-first and issuer-ordered, verifies that the private
 key matches the leaf certificate, and checks that the client URI appears in the
-leaf certificate URI SAN.
+leaf certificate URI SAN. Certificate validity dates are checked when the
+builder is constructed and rechecked each time a software statement is emitted.
 
 Safire does not decide whether the authorization server will trust the client
-certificate chain. Chain-building, revocation policy, and community trust for
-the client certificate remain authorization-server decisions during
-registration processing.
+certificate chain. Chain-building to trust anchors, revocation policy, and
+community trust for the client certificate remain authorization-server
+decisions during registration processing.
 
 ### Keep test seams explicit
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -25,3 +25,4 @@ Architecture Decision Records (ADRs) document significant design decisions made 
 | [ADR-011]({% link adr/ADR-011-udap-stu2-discovery-conformance.md %}) | `UdapMetadata` entity — structural validation separate from cryptographic validation | Accepted |
 | [ADR-012]({% link adr/ADR-012-udap-signed-metadata-validation.md %}) | `signed_metadata` JWT validation — design and chain verification defaults | Accepted |
 | [ADR-013]({% link adr/ADR-013-udap-registration-request-model.md %}) | UDAP registration metadata as an immutable value object | Accepted |
+| [ADR-014]({% link adr/ADR-014-udap-software-statement-signing.md %}) | UDAP software-statement signing | Accepted |

--- a/docs/configuration/client-setup.md
+++ b/docs/configuration/client-setup.md
@@ -104,8 +104,9 @@ See [UDAP]({{ site.baseurl }}/udap/) for validation helpers, 404/204 discovery b
 
 #### UDAP client signing credentials
 
-UDAP software statements use a client private key and a leaf-first X.509
-certificate chain. Configure these reusable credentials on the client:
+UDAP software statements use a client private key and a leaf-first,
+issuer-ordered X.509 certificate chain. Configure these reusable credentials on
+the client:
 
 ```ruby
 config = Safire::ClientConfig.new(

--- a/docs/configuration/client-setup.md
+++ b/docs/configuration/client-setup.md
@@ -128,14 +128,14 @@ required by the
 `ClientConfig` requires a non-empty collection, copies and freezes PEM strings,
 and snapshots certificate objects as DER. Accessing the chain returns fresh
 certificate objects, so subsequent caller mutations cannot alter the configured
-identity. Safire defers PEM parsing, private-key matching, validity checks, and
-URI SAN checks until a software statement is built.
+identity. Safire performs PEM parsing, private-key matching, validity checks,
+and URI SAN checks when a software statement is built.
 
 Configured credentials are intended to serve as defaults, with per-call
-overrides for applications that select signing identities dynamically. The
-end-to-end UDAP Dynamic Client Registration API is not available yet. These
-fields provide its configuration foundation; UDAP discovery does not access
-them.
+overrides for applications that select signing identities dynamically. Safire
+can build the software statement foundation now; the end-to-end UDAP Dynamic
+Client Registration API is not available yet. UDAP discovery does not access
+these signing credentials.
 
 ### Client Type
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -29,7 +29,7 @@ flowchart TD
     A -->|"resolves config"| B
     A -->|"validates protocol + client_type"| C
     C -->|":smart (default)"| D
-    C -->|":udap"| G["Protocols::Udap\n— discovery implemented\n— auth flows planned"]
+    C -->|":udap"| G["Protocols::Udap\n— discovery implemented\n— DCR foundations implemented\n— auth flows planned"]
     D -->|"lazily fetches"| E
     E -->|"HTTP"| F
 ```
@@ -55,9 +55,9 @@ flowchart TD
 | `authorization_endpoint` | String | No | — | Override the discovered authorization endpoint |
 | `token_endpoint` | String | No | — | Override the discovered token endpoint |
 
-`certificate_chain` and the UDAP algorithm values are configuration groundwork
-for Dynamic Client Registration. The current UDAP runtime supports discovery;
-registration is not available yet.
+`certificate_chain` and the UDAP algorithm values are used by Safire's UDAP
+software-statement signing foundation. Network registration is not available
+yet.
 
 ## In This Section
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -47,7 +47,7 @@ flowchart TD
 | `client_type:` | Symbol | No | `nil` (→ `:public` for SMART) | SMART client type — `:public`, `:confidential_symmetric`, or `:confidential_asymmetric`; not applicable for `:udap` (any explicit value raises `ConfigurationError`) |
 | `client_secret` | String | No | — | Required for `:confidential_symmetric` |
 | `private_key` | OpenSSL::PKey / String | No | — | RSA/EC private key; used by SMART asymmetric clients and as the UDAP client signing key |
-| `certificate_chain` | Array of PEM strings / OpenSSL::X509::Certificate | No | — | Non-empty, leaf-first client certificate chain for UDAP software-statement signing |
+| `certificate_chain` | Array of PEM strings / OpenSSL::X509::Certificate | No | — | Non-empty, leaf-first, issuer-ordered client certificate chain for UDAP software-statement signing |
 | `kid` | String | No | — | Key ID matching the public key registered with the server |
 | `jwt_algorithm` | String | No | auto | SMART: `RS384` or `ES384`; UDAP registration: `RS256`, `RS384`, `ES256`, or `ES384`, constrained by the key and server metadata |
 | `jwks_uri` | String | No | — | URL to client's public JWKS, included as `jku` in JWT header |

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ description: "Safire is a Ruby gem implementing SMART App Launch 2.2.0 and UDAP 
 [![Gem Version](https://badge.fury.io/rb/safire.svg)](https://badge.fury.io/rb/safire)
 [![CI](https://github.com/vanessuniq/safire/workflows/CI/badge.svg)](https://github.com/vanessuniq/safire/actions)
 
-A lean Ruby gem implementing **[SMART App Launch](https://hl7.org/fhir/smart-app-launch/)** flows and **[UDAP Security STU2 / v2.0.0](https://hl7.org/fhir/us/udap-security/STU2/index.html)** server metadata discovery for clients.
+A lean Ruby gem implementing **[SMART App Launch](https://hl7.org/fhir/smart-app-launch/)** flows and **[UDAP Security STU2 / v2.0.0](https://hl7.org/fhir/us/udap-security/STU2/index.html)** discovery and registration foundations for clients.
 
 ## Quick Navigation
 
@@ -20,7 +20,7 @@ A lean Ruby gem implementing **[SMART App Launch](https://hl7.org/fhir/smart-app
 | [Getting Started]({{ site.baseurl }}/installation/) | Install Safire and quick start guide |
 | [Configuration]({{ site.baseurl }}/configuration/) | All configuration options and parameters |
 | [SMART]({{ site.baseurl }}/smart-on-fhir/) | App Launch (Public, Confidential Symmetric, Confidential Asymmetric) and Backend Services |
-| [UDAP]({{ site.baseurl }}/udap/) | UDAP Security discovery (implemented) and planned auth flows |
+| [UDAP]({{ site.baseurl }}/udap/) | UDAP Security discovery plus registration metadata and software-statement foundations |
 | [Security Guide]({{ site.baseurl }}/security/) | HTTPS, credential protection, token storage, key rotation |
 | [Advanced Examples]({{ site.baseurl }}/advanced/) | Caching, multi-server, token management, complete Rails integration |
 | [Troubleshooting]({{ site.baseurl }}/troubleshooting/) | Common issues and solutions |
@@ -41,9 +41,11 @@ A lean Ruby gem implementing **[SMART App Launch](https://hl7.org/fhir/smart-app
 
 - Discovery (`/.well-known/udap`) with optional community scoping
 - Dynamic Client Registration metadata validation and normalization
+- X.509-backed software-statement signing foundation
 
-Software-statement signing, registration submission, JWT assertion authentication,
-and Tiered OAuth are planned. See [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md) for details.
+Registration submission, JWT assertion authentication, and Tiered OAuth are
+planned. See [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md)
+for details.
 
 ## Demo Application
 

--- a/docs/udap.md
+++ b/docs/udap.md
@@ -3,7 +3,7 @@ layout: default
 title: UDAP
 nav_order: 5
 permalink: /udap/
-description: "UDAP Security STU2 discovery and registration-metadata validation in Safire, with community scoping and planned signing, authentication, and authorization flows."
+description: "UDAP Security STU2 discovery, registration metadata validation, and software-statement signing foundations in Safire."
 has_children: true
 ---
 
@@ -15,9 +15,9 @@ has_children: true
 **Implemented now:** UDAP Security STU2 discovery (`/.well-known/udap`),
 including signed metadata validation and optional community scoping. The
 [Dynamic Client Registration guide]({% link udap/dynamic-client-registration/index.md %})
-also covers the implemented registration-metadata validation foundation.
-Software-statement signing, registration submission, JWT client authentication,
-and Tiered OAuth remain planned. See
+also covers implemented registration metadata validation and software-statement
+signing foundations. Registration submission, JWT client authentication, and
+Tiered OAuth remain planned. See
 [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md).
 </div>
 
@@ -125,8 +125,9 @@ metadata.signed_metadata_valid?(
 Support helpers expose advertised profiles and usable discovery capabilities.
 Capability helpers combine profile or grant signals with the endpoint
 preconditions Safire can verify during discovery. These describe what the
-server advertises; Safire's DCR metadata validator is available, while DCR
-signing/submission, JWT client authentication, and Tiered OAuth remain planned.
+server advertises; Safire's DCR metadata validator and software-statement
+signing foundation are available, while DCR submission, JWT client
+authentication, and Tiered OAuth remain planned.
 
 | Helper | Checks |
 |--------|--------|
@@ -175,9 +176,10 @@ metadata.tiered_oauth_profile?
 
 ### Client Flows
 
-- **Dynamic Client Registration (DCR)** — metadata validation is implemented;
-  software-statement signing and submission remain planned for the one-time
-  registration that obtains a `client_id`
+- **Dynamic Client Registration (DCR)** — metadata validation and
+  software-statement signing foundations are implemented; registration
+  submission remains planned for the one-time registration that obtains a
+  `client_id`
 - **JWT Client Authentication** — authenticate on every request using a signed JWT assertion (Authentication Token, AnT) with an X.509 certificate chain in the `x5c` header; the registered `client_id` is reused as `iss` and `sub` in each assertion
 - **Tiered OAuth** — delegated authorization for multi-system access per the UDAP Security IG
 - **Pushed Authorization Requests (RFC 9126)** — PAR support for pre-registering authorization requests

--- a/docs/udap/dynamic-client-registration/index.md
+++ b/docs/udap/dynamic-client-registration/index.md
@@ -4,7 +4,8 @@ title: Dynamic Client Registration
 parent: UDAP
 nav_order: 1
 permalink: /udap/dynamic-client-registration/
-description: "Validate and normalize UDAP Security STU2 Dynamic Client Registration metadata before software-statement signing."
+description: "Validate UDAP Security STU2 registration metadata and prepare X.509-backed software statements."
+has_children: true
 ---
 
 # Dynamic Client Registration
@@ -13,15 +14,15 @@ description: "Validate and normalize UDAP Security STU2 Dynamic Client Registrat
 
 <div class="code-example" markdown="1">
 **Current status:** Safire can validate and normalize UDAP Security STU2
-registration metadata. Software-statement signing and submission to the
-registration endpoint are not implemented yet, so this is a foundation API
-rather than an end-to-end registration workflow.
+registration metadata and construct X.509-backed software statements.
+Submission to the registration endpoint is not implemented yet, so this remains
+a foundation API rather than an end-to-end registration workflow.
 </div>
 
 ## Validate Metadata
 
-Build a `UdapRegistrationMetadata` value object before passing metadata to a
-future software-statement builder:
+Build a `UdapRegistrationMetadata` value object before signing registration
+metadata:
 
 ```ruby
 metadata = Safire::Protocols::UdapRegistrationMetadata.new(
@@ -132,7 +133,11 @@ claims (`iss`, `sub`, `aud`, `iat`, `exp`, `jti`) and request-envelope fields
 (`software_statement`, `certifications`, `udap`). Those values belong to the
 software-statement and registration request builders.
 
+See [Software Statements]({% link udap/dynamic-client-registration/software-statement.md %})
+for the implemented signing foundation, including `x5c`, exact URI comparison,
+algorithm selection, and certificate/key checks.
+
 See the
 [UDAP Security STU2 registration profile](https://hl7.org/fhir/us/udap-security/STU2/registration.html)
 for the normative requirements. End-to-end registration will become available
-after Safire adds software-statement signing and registration submission.
+after Safire adds registration submission.

--- a/docs/udap/dynamic-client-registration/software-statement.md
+++ b/docs/udap/dynamic-client-registration/software-statement.md
@@ -34,16 +34,16 @@ security claims:
 | `jti` | Fresh UUID by default |
 
 The JOSE header contains only `alg` and `x5c`. The `x5c` value is the supplied
-leaf-first certificate chain encoded as Base64 DER strings, without PEM
-wrappers.
+leaf-first, issuer-ordered certificate chain encoded as Base64 DER strings,
+without PEM wrappers.
 
 Safire does not emit `typ`, `kid`, `jku`, or `x5u` for registration software
 statements.
 
 ## Signing Identity
 
-Configure a private key and a leaf-first certificate chain as the client
-signing identity:
+Configure a private key and a leaf-first, issuer-ordered certificate chain as
+the client signing identity:
 
 ```ruby
 config = Safire::ClientConfig.new(
@@ -87,9 +87,10 @@ algorithm must be advertised by the server and compatible with the key.
 Safire performs local consistency checks before signing:
 
 - registration metadata must already be a `UdapRegistrationMetadata` object
-- certificate chains must be non-empty and leaf-first
+- certificate chains must be non-empty, leaf-first, and issuer-ordered
 - certificate entries must be parseable PEM strings or `OpenSSL::X509::Certificate` objects
-- every certificate must be currently valid according to the signing clock
+- every certificate must be valid according to the signing clock when the
+  builder is created and when the JWT is emitted
 - the private key must contain private material and match the leaf certificate
 - the client URI must exactly match a URI SAN in the leaf certificate
 - the registration endpoint must be HTTPS unless `allow_insecure_localhost: true`

--- a/docs/udap/dynamic-client-registration/software-statement.md
+++ b/docs/udap/dynamic-client-registration/software-statement.md
@@ -1,0 +1,103 @@
+---
+layout: default
+title: Software Statements
+parent: Dynamic Client Registration
+grand_parent: UDAP
+nav_order: 2
+permalink: /udap/dynamic-client-registration/software-statement/
+description: "How Safire builds UDAP Security STU2 X.509-backed software statements for Dynamic Client Registration."
+---
+
+# Software Statements
+
+{: .no_toc }
+
+<div class="code-example" markdown="1">
+**Current status:** Safire can validate registration metadata and construct a
+conformant X.509-backed UDAP Security STU2 software statement. Submitting the
+registration request to the server is not implemented yet.
+</div>
+
+## What Safire Builds
+
+UDAP registration metadata is signed into a compact JWS software statement. The
+software statement carries the client registration parameters plus the required
+security claims:
+
+| Claim | Safire behavior |
+|-------|-----------------|
+| `iss` | Exact `client_uri` supplied by the caller |
+| `sub` | Same exact value as `iss` |
+| `aud` | Exact discovered registration endpoint |
+| `iat` | Integer NumericDate from the signing clock |
+| `exp` | `iat + 300` seconds |
+| `jti` | Fresh UUID by default |
+
+The JOSE header contains only `alg` and `x5c`. The `x5c` value is the supplied
+leaf-first certificate chain encoded as Base64 DER strings, without PEM
+wrappers.
+
+Safire does not emit `typ`, `kid`, `jku`, or `x5u` for registration software
+statements.
+
+## Signing Identity
+
+Configure a private key and a leaf-first certificate chain as the client
+signing identity:
+
+```ruby
+config = Safire::ClientConfig.new(
+  base_url: 'https://fhir.example.com',
+  private_key: File.read('client-key.pem'),
+  certificate_chain: [
+    File.read('client-cert.pem'),
+    File.read('issuing-ca.pem')
+  ],
+  jwt_algorithm: 'RS256'
+)
+```
+
+The private key must match the leaf certificate. The leaf certificate must
+contain a URI Subject Alternative Name that exactly matches the `client_uri`
+used for registration. Safire does not canonicalize the URI before comparison:
+case, port, and trailing slash differences are significant.
+
+The `client_uri` is not required to use HTTPS. STU2 permits trust communities to
+use other URI schemes for client identifiers, such as decentralized identifiers.
+If the client URI uses HTTP or HTTPS, it must include a host.
+
+## Algorithms
+
+The registration server advertises supported software-statement algorithms in
+`registration_endpoint_jwt_signing_alg_values_supported`. Safire intersects
+that list with the configured private key:
+
+| Key | Safire-supported algorithms |
+|-----|-----------------------------|
+| RSA | `RS256`, `RS384` |
+| EC P-256 | `ES256` |
+| EC P-384 | `ES384` |
+
+When `jwt_algorithm` is omitted, Safire selects the first compatible advertised
+algorithm. RSA keys prefer `RS256` because it is the STU2 baseline. An explicit
+algorithm must be advertised by the server and compatible with the key.
+
+## Validation Boundaries
+
+Safire performs local consistency checks before signing:
+
+- registration metadata must already be a `UdapRegistrationMetadata` object
+- certificate chains must be non-empty and leaf-first
+- certificate entries must be parseable PEM strings or `OpenSSL::X509::Certificate` objects
+- every certificate must be currently valid according to the signing clock
+- the private key must contain private material and match the leaf certificate
+- the client URI must exactly match a URI SAN in the leaf certificate
+- the registration endpoint must be HTTPS unless `allow_insecure_localhost: true`
+  is explicitly used for an HTTP loopback endpoint in development
+
+Safire does not decide whether the authorization server trusts the client
+certificate. Chain validation, revocation status, and community trust for the
+client certificate are authorization-server decisions during registration.
+
+See [ADR-014]({% link adr/ADR-014-udap-software-statement-signing.md %}) for
+the signing design rationale.

--- a/docs/udap/dynamic-client-registration/software-statement.md
+++ b/docs/udap/dynamic-client-registration/software-statement.md
@@ -13,9 +13,10 @@ description: "How Safire builds UDAP Security STU2 X.509-backed software stateme
 {: .no_toc }
 
 <div class="code-example" markdown="1">
-**Current status:** Safire can validate registration metadata and construct a
-conformant X.509-backed UDAP Security STU2 software statement. Submitting the
-registration request to the server is not implemented yet.
+**Current status:** Safire can validate registration metadata and has the
+internal signing foundation needed to construct conformant X.509-backed UDAP
+Security STU2 software statements. A supported public registration API that
+submits the request to the server is not implemented yet.
 </div>
 
 ## What Safire Builds

--- a/lib/safire/client.rb
+++ b/lib/safire/client.rb
@@ -18,8 +18,8 @@ module Safire
   # * :client_secret [String, optional] required for confidential_symmetric clients
   # * :private_key [OpenSSL::PKey, String, optional] private key for SMART asymmetric clients,
   #     backend services, and UDAP software-statement signing
-  # * :certificate_chain [Array<String, OpenSSL::X509::Certificate>, optional] leaf-first X.509
-  #     certificate chain for UDAP software-statement signing
+  # * :certificate_chain [Array<String, OpenSSL::X509::Certificate>, optional] leaf-first,
+  #     issuer-ordered X.509 certificate chain for UDAP software-statement signing
   # * :kid [String, optional] key ID matching the registered public key for asymmetric clients and backend services
   # * :jwt_algorithm [String, optional] JWT signing algorithm. SMART supports RS384 or ES384;
   #     UDAP software-statement signing supports RS256, RS384, ES256, or ES384 subject to key

--- a/lib/safire/client.rb
+++ b/lib/safire/client.rb
@@ -1,5 +1,5 @@
 module Safire
-  # Unified facade client for SMART and (future) UDAP authorization flows.
+  # Unified facade client for SMART and UDAP protocol support.
   #
   # This class is the main entry point for integrating SMART authorization via Safire.
   # It supports discovery of server metadata and provides a unified interface for building
@@ -17,12 +17,12 @@ module Safire
   #     backend services when not provided
   # * :client_secret [String, optional] required for confidential_symmetric clients
   # * :private_key [OpenSSL::PKey, String, optional] private key for SMART asymmetric clients,
-  #     backend services, and planned UDAP software-statement signing
+  #     backend services, and UDAP software-statement signing
   # * :certificate_chain [Array<String, OpenSSL::X509::Certificate>, optional] leaf-first X.509
-  #     certificate chain for planned UDAP software-statement signing
+  #     certificate chain for UDAP software-statement signing
   # * :kid [String, optional] key ID matching the registered public key for asymmetric clients and backend services
   # * :jwt_algorithm [String, optional] JWT signing algorithm. SMART supports RS384 or ES384;
-  #     planned UDAP registration supports RS256, RS384, ES256, or ES384 subject to key
+  #     UDAP software-statement signing supports RS256, RS384, ES256, or ES384 subject to key
   #     compatibility and server discovery. Selected automatically when omitted
   # * :jwks_uri [String, optional] URL to client's JWKS for jku header in JWT assertions
   #

--- a/lib/safire/client_config.rb
+++ b/lib/safire/client_config.rb
@@ -28,10 +28,10 @@ module Safire
   #   @return [OpenSSL::PKey::RSA, OpenSSL::PKey::EC, String, nil] the private key for signing
   #     SMART JWT assertions or UDAP software statements. Can be an OpenSSL key object or PEM string.
   # @!attribute [r] certificate_chain
-  #   @return [Array<String, OpenSSL::X509::Certificate>, nil] leaf-first X.509 certificate chain
-  #     for UDAP software-statement signing. Entries may be PEM strings or certificate objects.
-  #     Certificate objects are stored as DER snapshots and returned as fresh copies. Parsing PEM
-  #     strings and identity validation occur when the software statement is built.
+  #   @return [Array<String, OpenSSL::X509::Certificate>, nil] leaf-first, issuer-ordered X.509
+  #     certificate chain for UDAP software-statement signing. Entries may be PEM strings or
+  #     certificate objects. Certificate objects are stored as DER snapshots and returned as fresh
+  #     copies. Parsing PEM strings and identity validation occur when the software statement is built.
   # @!attribute [r] kid
   #   @return [String, nil] the key ID matching the public key registered with the authorization server.
   #     Required for confidential asymmetric authentication.

--- a/lib/safire/client_config.rb
+++ b/lib/safire/client_config.rb
@@ -26,10 +26,10 @@ module Safire
   #   =>  Optional, will be retrieved from the well-known smart-configuration if not provided
   # @!attribute [r] private_key
   #   @return [OpenSSL::PKey::RSA, OpenSSL::PKey::EC, String, nil] the private key for signing
-  #     SMART JWT assertions or planned UDAP software statements. Can be an OpenSSL key object or PEM string.
+  #     SMART JWT assertions or UDAP software statements. Can be an OpenSSL key object or PEM string.
   # @!attribute [r] certificate_chain
   #   @return [Array<String, OpenSSL::X509::Certificate>, nil] leaf-first X.509 certificate chain
-  #     for planned UDAP software-statement signing. Entries may be PEM strings or certificate objects.
+  #     for UDAP software-statement signing. Entries may be PEM strings or certificate objects.
   #     Certificate objects are stored as DER snapshots and returned as fresh copies. Parsing PEM
   #     strings and identity validation occur when the software statement is built.
   # @!attribute [r] kid
@@ -37,7 +37,7 @@ module Safire
   #     Required for confidential asymmetric authentication.
   # @!attribute [r] jwt_algorithm
   #   @return [String, nil] the JWT signing algorithm. SMART supports RS384 or ES384;
-  #     planned UDAP registration supports RS256, RS384, ES256, or ES384 subject to key
+  #     UDAP software-statement signing supports RS256, RS384, ES256, or ES384 subject to key
   #     compatibility and server discovery. Optional; selected from the key and protocol
   #     requirements when omitted.
   # @!attribute [r] jwks_uri

--- a/lib/safire/client_config_builder.rb
+++ b/lib/safire/client_config_builder.rb
@@ -50,7 +50,7 @@ module Safire
       self
     end
 
-    # Sets the leaf-first X.509 certificate chain used for UDAP signing.
+    # Sets the leaf-first, issuer-ordered X.509 certificate chain used for UDAP signing.
     #
     # @param certificate_chain [Array<String, OpenSSL::X509::Certificate>, nil]
     # @return [self]

--- a/lib/safire/protocols/udap_software_statement.rb
+++ b/lib/safire/protocols/udap_software_statement.rb
@@ -39,10 +39,11 @@ module Safire
       # @param client_uri [String] absolute client URI used as +iss+ and +sub+
       # @param registration_endpoint [String] discovered registration endpoint used exactly as +aud+
       # @param private_key [OpenSSL::PKey::RSA, OpenSSL::PKey::EC, String] signing private key or PEM
-      # @param certificate_chain [Array<String, OpenSSL::X509::Certificate>] leaf-first client certificate chain
+      # @param certificate_chain [Array<String, OpenSSL::X509::Certificate>] leaf-first,
+      #   issuer-ordered client certificate chain
       # @param supported_algorithms [Array<String>] algorithms advertised by UDAP discovery
       # @param algorithm [String, nil] optional explicit signing algorithm
-      # @param clock [#now] time source for deterministic NumericDate claims
+      # @param clock [#now] time source returning +Time+ for deterministic NumericDate claims
       # @param jti_generator [#call, nil] JTI source; defaults to +SecureRandom.uuid+
       # @param allow_insecure_localhost [Boolean] permit HTTP localhost registration endpoint for development
       # @raise [Safire::Errors::ValidationError] when +metadata+ is not validated registration metadata
@@ -69,14 +70,18 @@ module Safire
       #
       # @return [String]
       # @raise [Safire::Errors::ConfigurationError] when the clock or JTI generator returns an invalid value
+      # @raise [Safire::Errors::CertificateError] when the certificate chain is not valid at signing time
       def to_jwt
-        JWT.encode(payload, @private_key, @algorithm, header)
+        signing_time = current_time
+        validate_certificate_times!(signing_time)
+
+        JWT.encode(payload(signing_time), @private_key, @algorithm, header)
       end
 
       private
 
-      def payload
-        now = current_timestamp
+      def payload(signing_time)
+        now = signing_time.to_i
         @metadata.to_h.merge(
           'iss' => @client_uri,
           'sub' => @client_uri,
@@ -104,7 +109,7 @@ module Safire
       end
 
       def validate_client_uri(value)
-        return value if absolute_client_uri?(value)
+        return immutable_string(value) if absolute_client_uri?(value)
 
         configuration_error!(:client_uri, value.class, ['absolute URI string'])
       end
@@ -123,8 +128,8 @@ module Safire
 
       def validate_registration_endpoint(value, allow_insecure_localhost)
         allow_insecure_localhost = validate_localhost_policy(allow_insecure_localhost)
-        return value if strict_https_uri?(value)
-        return value if allow_insecure_localhost && localhost_http_uri?(value)
+        return immutable_string(value) if strict_https_uri?(value)
+        return immutable_string(value) if allow_insecure_localhost && localhost_http_uri?(value)
 
         configuration_error!(:registration_endpoint, value.class, ['absolute HTTPS URI'])
       end
@@ -190,7 +195,7 @@ module Safire
           configuration_error!(:supported_algorithms, values.class, ['Array<String>'])
         end
 
-        values.dup.freeze
+        values.map { |value| immutable_string(value) }.freeze
       end
 
       def select_algorithm(explicit_algorithm)
@@ -202,9 +207,11 @@ module Safire
       end
 
       def select_explicit_algorithm(algorithm, compatible)
-        return algorithm if SUPPORTED_ALGORITHMS.include?(algorithm) &&
-                            compatible.include?(algorithm) &&
-                            @supported_algorithms.include?(algorithm)
+        if SUPPORTED_ALGORITHMS.include?(algorithm) &&
+           compatible.include?(algorithm) &&
+           @supported_algorithms.include?(algorithm)
+          return immutable_string(algorithm)
+        end
 
         configuration_error!(:algorithm, algorithm, compatible & @supported_algorithms)
       end
@@ -222,9 +229,14 @@ module Safire
 
       def validate_certificate_chain!
         time = current_time
-        @certificate_chain.each { |cert| validate_certificate_time!(cert, time) }
+        validate_certificate_times!(time)
+        validate_chain_order!
         validate_key_matches_leaf!
         validate_leaf_uri_san!
+      end
+
+      def validate_certificate_times!(time)
+        @certificate_chain.each { |cert| validate_certificate_time!(cert, time) }
       end
 
       def validate_certificate_time!(cert, time)
@@ -234,6 +246,19 @@ module Safire
         return unless cert.not_after <= time
 
         raise Errors::CertificateError.new(reason: 'certificate is expired', subject: cert.subject.to_s)
+      end
+
+      def validate_chain_order!
+        @certificate_chain.each_cons(2) do |child, issuer|
+          next if child.issuer == issuer.subject && child.verify(issuer.public_key)
+
+          raise Errors::CertificateError.new(
+            reason: 'certificate_chain must be leaf-first and issuer-ordered',
+            subject: child.subject.to_s
+          )
+        end
+      rescue OpenSSL::X509::CertificateError, OpenSSL::PKey::PKeyError
+        raise Errors::CertificateError.new(reason: 'certificate_chain must be leaf-first and issuer-ordered')
       end
 
       def validate_key_matches_leaf!
@@ -280,15 +305,11 @@ module Safire
         @certificate_chain.first
       end
 
-      def current_timestamp
-        current_time.to_i
-      end
-
       def current_time
         time = @clock.now
-        return time if time.respond_to?(:to_i)
+        return time if time.is_a?(Time)
 
-        configuration_error!(:clock, time.class, ['object whose #now result responds to #to_i'])
+        configuration_error!(:clock, time.class, ['object whose #now result is a Time'])
       end
 
       def generate_jti
@@ -304,6 +325,10 @@ module Safire
           invalid_value:,
           valid_values:
         )
+      end
+
+      def immutable_string(value)
+        value.dup.freeze
       end
     end
   end

--- a/lib/safire/protocols/udap_software_statement.rb
+++ b/lib/safire/protocols/udap_software_statement.rb
@@ -1,0 +1,310 @@
+require 'base64'
+require 'jwt'
+require 'openssl'
+require 'securerandom'
+
+module Safire
+  module Protocols
+    # Builds X.509-backed UDAP Dynamic Client Registration software statements.
+    #
+    # The resulting compact JWS follows the software-statement requirements in
+    # HL7 UDAP Security STU2 and is intended for use by the UDAP registration
+    # protocol flow. This class performs local signing-identity checks only; the
+    # authorization server remains responsible for trusting the submitted client
+    # certificate chain.
+    #
+    # @see https://hl7.org/fhir/us/udap-security/STU2/registration.html
+    # @api private
+    class UdapSoftwareStatement
+      include URIValidation
+
+      LIFETIME_SECONDS = 300
+      SUPPORTED_ALGORITHMS = %w[RS256 RS384 ES256 ES384].freeze
+      RSA_ALGORITHMS = %w[RS256 RS384].freeze
+      EC_CURVE_ALGORITHMS = {
+        'prime256v1' => ['ES256'],
+        'secp256r1' => ['ES256'],
+        'P-256' => ['ES256'],
+        'secp384r1' => ['ES384'],
+        'P-384' => ['ES384']
+      }.freeze
+      CERTIFICATE_ENTRY_TYPES = [String, OpenSSL::X509::Certificate].freeze
+      PRIVATE_KEY_TYPES = [String, OpenSSL::PKey::RSA, OpenSSL::PKey::EC].freeze
+      DEFAULT_JTI_GENERATOR = -> { SecureRandom.uuid }
+
+      private_constant :LIFETIME_SECONDS, :SUPPORTED_ALGORITHMS, :RSA_ALGORITHMS, :EC_CURVE_ALGORITHMS,
+                       :CERTIFICATE_ENTRY_TYPES, :PRIVATE_KEY_TYPES, :DEFAULT_JTI_GENERATOR
+
+      # @param metadata [Safire::Protocols::UdapRegistrationMetadata] validated registration metadata
+      # @param client_uri [String] absolute client URI used as +iss+ and +sub+
+      # @param registration_endpoint [String] discovered registration endpoint used exactly as +aud+
+      # @param private_key [OpenSSL::PKey::RSA, OpenSSL::PKey::EC, String] signing private key or PEM
+      # @param certificate_chain [Array<String, OpenSSL::X509::Certificate>] leaf-first client certificate chain
+      # @param supported_algorithms [Array<String>] algorithms advertised by UDAP discovery
+      # @param algorithm [String, nil] optional explicit signing algorithm
+      # @param clock [#now] time source for deterministic NumericDate claims
+      # @param jti_generator [#call, nil] JTI source; defaults to +SecureRandom.uuid+
+      # @param allow_insecure_localhost [Boolean] permit HTTP localhost registration endpoint for development
+      # @raise [Safire::Errors::ValidationError] when +metadata+ is not validated registration metadata
+      # @raise [Safire::Errors::ConfigurationError] when caller-controlled signing configuration is invalid
+      # @raise [Safire::Errors::CertificateError] when the certificate chain cannot support signing
+      def initialize(metadata:, client_uri:, registration_endpoint:, private_key:, certificate_chain:,
+                     supported_algorithms:, algorithm: nil, clock: Time, jti_generator: nil,
+                     allow_insecure_localhost: false)
+        @metadata = validate_metadata(metadata)
+        @client_uri = validate_client_uri(client_uri)
+        @registration_endpoint = validate_registration_endpoint(registration_endpoint, allow_insecure_localhost)
+        @clock = validate_clock(clock)
+        @jti_generator = validate_jti_generator(jti_generator)
+        @private_key = parse_private_key(private_key)
+        @certificate_chain = parse_certificate_chain(certificate_chain)
+        @supported_algorithms = validate_supported_algorithms(supported_algorithms)
+        @algorithm = select_algorithm(algorithm)
+
+        validate_certificate_chain!
+        freeze
+      end
+
+      # Returns the signed software statement as a compact JWS string.
+      #
+      # @return [String]
+      # @raise [Safire::Errors::ConfigurationError] when the clock or JTI generator returns an invalid value
+      def to_jwt
+        JWT.encode(payload, @private_key, @algorithm, header)
+      end
+
+      private
+
+      def payload
+        now = current_timestamp
+        @metadata.to_h.merge(
+          'iss' => @client_uri,
+          'sub' => @client_uri,
+          'aud' => @registration_endpoint,
+          'iat' => now,
+          'exp' => now + LIFETIME_SECONDS,
+          'jti' => generate_jti
+        )
+      end
+
+      def header
+        {
+          'alg' => @algorithm,
+          'x5c' => @certificate_chain.map { |cert| Base64.strict_encode64(cert.to_der) }
+        }
+      end
+
+      def validate_metadata(metadata)
+        return metadata if metadata.is_a?(UdapRegistrationMetadata)
+
+        raise Errors::ValidationError.new(
+          attribute: :metadata,
+          reason: 'must be a Safire::Protocols::UdapRegistrationMetadata'
+        )
+      end
+
+      def validate_client_uri(value)
+        return value if absolute_client_uri?(value)
+
+        configuration_error!(:client_uri, value.class, ['absolute URI string'])
+      end
+
+      def absolute_client_uri?(value)
+        return false unless value.is_a?(String) && value.present?
+
+        uri = Addressable::URI.parse(value)
+        return false unless uri.scheme.present?
+        return uri.host.present? if %w[http https].include?(uri.scheme)
+
+        true
+      rescue Addressable::URI::InvalidURIError
+        false
+      end
+
+      def validate_registration_endpoint(value, allow_insecure_localhost)
+        allow_insecure_localhost = validate_localhost_policy(allow_insecure_localhost)
+        return value if strict_https_uri?(value)
+        return value if allow_insecure_localhost && localhost_http_uri?(value)
+
+        configuration_error!(:registration_endpoint, value.class, ['absolute HTTPS URI'])
+      end
+
+      def validate_clock(clock)
+        return clock if clock.respond_to?(:now)
+
+        configuration_error!(:clock, clock.class, ['object responding to #now'])
+      end
+
+      def validate_jti_generator(generator)
+        return DEFAULT_JTI_GENERATOR if generator.nil?
+        return generator if generator.respond_to?(:call)
+
+        configuration_error!(:jti_generator, generator.class, ['callable'])
+      end
+
+      def parse_private_key(key)
+        parsed = case key
+                 when OpenSSL::PKey::RSA, OpenSSL::PKey::EC
+                   key
+                 when String
+                   OpenSSL::PKey.read(key)
+                 else
+                   configuration_error!(:private_key, key.class, PRIVATE_KEY_TYPES)
+                 end
+
+        validate_private_key!(parsed)
+      rescue OpenSSL::PKey::PKeyError
+        configuration_error!(:private_key, key.class, PRIVATE_KEY_TYPES)
+      end
+
+      def validate_private_key!(key)
+        return key if supported_private_key?(key) && key.private?
+
+        configuration_error!(:private_key, key.class, PRIVATE_KEY_TYPES)
+      end
+
+      def supported_private_key?(key)
+        key.is_a?(OpenSSL::PKey::RSA) || key.is_a?(OpenSSL::PKey::EC)
+      end
+
+      def parse_certificate_chain(chain)
+        configuration_error!(:certificate_chain, chain.class, ['non-empty Array']) unless chain.is_a?(Array)
+        configuration_error!(:certificate_chain, chain.class, ['non-empty Array']) if chain.empty?
+
+        chain.map { |entry| parse_certificate_entry(entry) }.freeze
+      end
+
+      def parse_certificate_entry(entry)
+        unless CERTIFICATE_ENTRY_TYPES.any? { |type| entry.is_a?(type) }
+          configuration_error!(:certificate_chain, entry.class, CERTIFICATE_ENTRY_TYPES)
+        end
+
+        cert = entry.is_a?(String) ? OpenSSL::X509::Certificate.new(entry) : OpenSSL::X509::Certificate.new(entry.to_der)
+        cert.freeze
+      rescue OpenSSL::X509::CertificateError
+        raise Errors::CertificateError.new(reason: 'malformed certificate in certificate_chain')
+      end
+
+      def validate_supported_algorithms(values)
+        unless values.is_a?(Array) && values.all?(String)
+          configuration_error!(:supported_algorithms, values.class, ['Array<String>'])
+        end
+
+        values.dup.freeze
+      end
+
+      def select_algorithm(explicit_algorithm)
+        compatible = compatible_algorithms
+        return select_explicit_algorithm(explicit_algorithm, compatible) unless explicit_algorithm.nil?
+
+        compatible.find { |candidate| @supported_algorithms.include?(candidate) } ||
+          configuration_error!(:supported_algorithms, @supported_algorithms, compatible)
+      end
+
+      def select_explicit_algorithm(algorithm, compatible)
+        return algorithm if SUPPORTED_ALGORITHMS.include?(algorithm) &&
+                            compatible.include?(algorithm) &&
+                            @supported_algorithms.include?(algorithm)
+
+        configuration_error!(:algorithm, algorithm, compatible & @supported_algorithms)
+      end
+
+      def compatible_algorithms
+        case @private_key
+        when OpenSSL::PKey::RSA
+          RSA_ALGORITHMS
+        when OpenSSL::PKey::EC
+          EC_CURVE_ALGORITHMS.fetch(@private_key.group.curve_name) do
+            configuration_error!(:algorithm, @private_key.group.curve_name, EC_CURVE_ALGORITHMS.keys)
+          end
+        end
+      end
+
+      def validate_certificate_chain!
+        time = current_time
+        @certificate_chain.each { |cert| validate_certificate_time!(cert, time) }
+        validate_key_matches_leaf!
+        validate_leaf_uri_san!
+      end
+
+      def validate_certificate_time!(cert, time)
+        if cert.not_before > time
+          raise Errors::CertificateError.new(reason: 'certificate is not yet valid', subject: cert.subject.to_s)
+        end
+        return unless cert.not_after <= time
+
+        raise Errors::CertificateError.new(reason: 'certificate is expired', subject: cert.subject.to_s)
+      end
+
+      def validate_key_matches_leaf!
+        return if private_key_matches_leaf?
+
+        raise Errors::CertificateError.new(
+          reason: 'private key does not match the leaf certificate public key',
+          subject: leaf_certificate.subject.to_s
+        )
+      end
+
+      def private_key_matches_leaf?
+        data = 'safire-udap-key-check'
+        digest = OpenSSL::Digest.new('SHA256')
+        signature = @private_key.sign(digest, data)
+        leaf_certificate.public_key.verify(digest, signature, data)
+      rescue OpenSSL::PKey::PKeyError
+        false
+      end
+
+      def validate_leaf_uri_san!
+        return if uri_sans(leaf_certificate).include?(@client_uri)
+
+        raise Errors::CertificateError.new(
+          reason: 'client_uri does not match any URI SAN in the leaf certificate',
+          subject: leaf_certificate.subject.to_s
+        )
+      end
+
+      def uri_sans(cert)
+        san_ext = cert.extensions.find { |extension| extension.oid == 'subjectAltName' }
+        return [] unless san_ext
+
+        # OpenSSL renders SAN values as comma-separated text. That covers the
+        # simple UDAP client URI identifiers this builder supports without
+        # introducing ASN.1 parsing solely for uncommon literal comma cases.
+        san_ext.value.split(',').filter_map do |entry|
+          san = entry.strip
+          san.delete_prefix('URI:') if san.start_with?('URI:')
+        end
+      end
+
+      def leaf_certificate
+        @certificate_chain.first
+      end
+
+      def current_timestamp
+        current_time.to_i
+      end
+
+      def current_time
+        time = @clock.now
+        return time if time.respond_to?(:to_i)
+
+        configuration_error!(:clock, time.class, ['object whose #now result responds to #to_i'])
+      end
+
+      def generate_jti
+        jti = @jti_generator.call
+        return jti if jti.is_a?(String) && jti.present?
+
+        configuration_error!(:jti_generator, jti.class, ['callable returning a non-blank String'])
+      end
+
+      def configuration_error!(attribute, invalid_value, valid_values)
+        raise Errors::ConfigurationError.new(
+          invalid_attribute: attribute,
+          invalid_value:,
+          valid_values:
+        )
+      end
+    end
+  end
+end

--- a/lib/safire/protocols/udap_software_statement.rb
+++ b/lib/safire/protocols/udap_software_statement.rb
@@ -184,7 +184,11 @@ module Safire
           configuration_error!(:certificate_chain, entry.class, CERTIFICATE_ENTRY_TYPES)
         end
 
-        cert = entry.is_a?(String) ? OpenSSL::X509::Certificate.new(entry) : OpenSSL::X509::Certificate.new(entry.to_der)
+        cert = if entry.is_a?(String)
+                 OpenSSL::X509::Certificate.new(entry)
+               else
+                 OpenSSL::X509::Certificate.new(entry.to_der)
+               end
         cert.freeze
       rescue OpenSSL::X509::CertificateError
         raise Errors::CertificateError.new(reason: 'malformed certificate in certificate_chain')
@@ -243,7 +247,7 @@ module Safire
         if cert.not_before > time
           raise Errors::CertificateError.new(reason: 'certificate is not yet valid', subject: cert.subject.to_s)
         end
-        return unless cert.not_after <= time
+        return unless cert.not_after < time
 
         raise Errors::CertificateError.new(reason: 'certificate is expired', subject: cert.subject.to_s)
       end
@@ -292,13 +296,22 @@ module Safire
         san_ext = cert.extensions.find { |extension| extension.oid == 'subjectAltName' }
         return [] unless san_ext
 
-        # OpenSSL renders SAN values as comma-separated text. That covers the
-        # simple UDAP client URI identifiers this builder supports without
-        # introducing ASN.1 parsing solely for uncommon literal comma cases.
-        san_ext.value.split(',').filter_map do |entry|
-          san = entry.strip
-          san.delete_prefix('URI:') if san.start_with?('URI:')
+        subject_alt_name_entries(san_ext).filter_map do |entry|
+          entry.value if entry.tag_class == :CONTEXT_SPECIFIC && entry.tag == 6
         end
+      end
+
+      def subject_alt_name_entries(extension)
+        extension_asn1 = OpenSSL::ASN1.decode(extension.to_der)
+        extn_value = extension_asn1.value.find { |entry| entry.is_a?(OpenSSL::ASN1::OctetString) }
+        return [] unless extn_value
+
+        general_names = OpenSSL::ASN1.decode(extn_value.value)
+        return [] unless general_names.value.is_a?(Array)
+
+        general_names.value
+      rescue OpenSSL::ASN1::ASN1Error
+        []
       end
 
       def leaf_certificate

--- a/spec/safire/protocols/udap_software_statement_spec.rb
+++ b/spec/safire/protocols/udap_software_statement_spec.rb
@@ -45,6 +45,32 @@ RSpec.describe Safire::Protocols::UdapSoftwareStatement do
     JWT.decode(statement.to_jwt, cert.public_key, true, algorithms: [algorithm], verify_expiration: false)
   end
 
+  def build_issuer_spoofed_chain
+    real_issuer_key = OpenSSL::PKey::RSA.generate(2048)
+    issuer_subject = '/CN=UDAP Issuer'
+    real_issuer = build_valid_certificate(
+      key: real_issuer_key,
+      uri_san: 'https://issuer.example.com',
+      subject: issuer_subject,
+      serial: 2
+    )
+    issued_leaf = build_valid_certificate(
+      key: rsa_key,
+      uri_san: client_uri,
+      issuer_cert: real_issuer,
+      issuer_key: real_issuer_key,
+      serial: 3
+    )
+    spoofed_issuer = build_valid_certificate(
+      key: OpenSSL::PKey::RSA.generate(2048),
+      uri_san: 'https://issuer.example.com',
+      subject: issuer_subject,
+      serial: 4
+    )
+
+    [issued_leaf, spoofed_issuer]
+  end
+
   describe '#to_jwt' do
     it 'builds the minimal JOSE header with a leaf-first x5c chain' do
       issuer_key = OpenSSL::PKey::RSA.generate(2048)
@@ -140,6 +166,14 @@ RSpec.describe Safire::Protocols::UdapSoftwareStatement do
       payload, = decode_statement(build_statement(client_uri: did_uri, certificate_chain: [cert]), cert:)
 
       expect(payload['iss']).to eq(did_uri)
+    end
+
+    it 'allows URI SANs containing literal commas' do
+      comma_uri = 'https://client.example.com/app?groups=a,b'
+      cert = build_valid_certificate(key: rsa_key, uri_san: comma_uri, structural_san: true)
+      payload, = decode_statement(build_statement(client_uri: comma_uri, certificate_chain: [cert]), cert:)
+
+      expect(payload['iss']).to eq(comma_uri)
     end
 
     it 'allows HTTP localhost registration endpoints only with an explicit development opt-in' do
@@ -293,6 +327,14 @@ RSpec.describe Safire::Protocols::UdapSoftwareStatement do
         .to raise_error(Safire::Errors::CertificateError, /expired/)
     end
 
+    it 'allows a certificate whose not_after equals the signing time' do
+      boundary = build_udap_certificate(key: rsa_key, uri_san: client_uri, not_before: now - 3600, not_after: now)
+      statement = build_statement(certificate_chain: [boundary])
+      payload, = decode_statement(statement, cert: boundary)
+
+      expect(payload['iat']).to eq(now.to_i)
+    end
+
     it 'rejects a not-yet-valid chain certificate' do
       future = build_udap_certificate(key: rsa_key, uri_san: 'https://issuer.example.com', not_before: now + 60)
 
@@ -310,6 +352,11 @@ RSpec.describe Safire::Protocols::UdapSoftwareStatement do
       )
 
       expect { build_statement(certificate_chain: [leaf_cert, unrelated]) }
+        .to raise_error(Safire::Errors::CertificateError, /issuer-ordered/)
+    end
+
+    it 'rejects an issuer-spoofed certificate chain whose signature does not verify' do
+      expect { build_statement(certificate_chain: build_issuer_spoofed_chain) }
         .to raise_error(Safire::Errors::CertificateError, /issuer-ordered/)
     end
 

--- a/spec/safire/protocols/udap_software_statement_spec.rb
+++ b/spec/safire/protocols/udap_software_statement_spec.rb
@@ -1,0 +1,309 @@
+require 'spec_helper'
+require_relative '../../support/udap_certificate_helpers'
+
+RSpec.describe Safire::Protocols::UdapSoftwareStatement do
+  include UdapCertificateHelpers
+
+  let(:now) { Time.at(1_700_000_000) }
+  let(:clock) { class_double(Time, now:) }
+  let(:jti_generator) { -> { 'jti-123' } }
+  let(:client_uri) { 'https://client.example.com/app' }
+  let(:registration_endpoint) { 'https://as.example.com/register' }
+  let(:rsa_key) { OpenSSL::PKey::RSA.generate(2048) }
+  let(:leaf_cert) { build_valid_certificate(key: rsa_key, uri_san: client_uri) }
+  let(:metadata_input) do
+    {
+      client_name: 'Example Backend Service',
+      contacts: ['mailto:security@example.com'],
+      grant_types: ['client_credentials'],
+      scope: 'system/Patient.rs'
+    }
+  end
+  let(:metadata) { Safire::Protocols::UdapRegistrationMetadata.new(metadata_input) }
+  let(:base_params) do
+    {
+      metadata:,
+      client_uri:,
+      registration_endpoint:,
+      private_key: rsa_key,
+      certificate_chain: [leaf_cert],
+      supported_algorithms: %w[RS256 RS384 ES256],
+      clock:,
+      jti_generator:
+    }
+  end
+
+  def build_statement(overrides = {})
+    described_class.new(**base_params, **overrides)
+  end
+
+  def build_valid_certificate(**kwargs)
+    build_udap_certificate(not_before: now - 60, not_after: now + 3600, **kwargs)
+  end
+
+  def decode_statement(statement = build_statement, cert: leaf_cert, algorithm: 'RS256')
+    JWT.decode(statement.to_jwt, cert.public_key, true, algorithms: [algorithm], verify_expiration: false)
+  end
+
+  describe '#to_jwt' do
+    it 'builds the minimal JOSE header with a leaf-first x5c chain' do
+      intermediate = build_valid_certificate(key: rsa_key, uri_san: 'https://issuer.example.com', serial: 2)
+      statement = build_statement(certificate_chain: [leaf_cert, intermediate])
+      _payload, header = decode_statement(statement)
+
+      expect(header).to eq(
+        'alg' => 'RS256',
+        'x5c' => [leaf_cert, intermediate].map { |cert| Base64.strict_encode64(cert.to_der) }
+      )
+    end
+
+    it 'builds a complete client-credentials software statement payload' do
+      payload, = decode_statement
+
+      expect(payload).to include(
+        'iss' => client_uri,
+        'sub' => client_uri,
+        'aud' => registration_endpoint,
+        'iat' => now.to_i,
+        'exp' => now.to_i + 300,
+        'jti' => 'jti-123',
+        'client_name' => 'Example Backend Service',
+        'grant_types' => ['client_credentials'],
+        'token_endpoint_auth_method' => 'private_key_jwt',
+        'scope' => 'system/Patient.rs'
+      )
+    end
+
+    it 'builds a complete authorization-code software statement payload' do
+      metadata = Safire::Protocols::UdapRegistrationMetadata.new(
+        metadata_input.merge(
+          grant_types: %w[authorization_code refresh_token],
+          redirect_uris: ['https://client.example.com/callback'],
+          logo_uri: 'https://client.example.com/logo.png'
+        )
+      )
+      payload, = decode_statement(build_statement(metadata:))
+
+      expect(payload).to include(
+        'grant_types' => %w[authorization_code refresh_token],
+        'redirect_uris' => ['https://client.example.com/callback'],
+        'logo_uri' => 'https://client.example.com/logo.png',
+        'response_types' => ['code']
+      )
+    end
+
+    it 'uses the client URI and registration endpoint exactly as supplied' do
+      exact_client_uri = 'https://Client.example.com:443/app/'
+      exact_endpoint = 'https://as.example.com/register/'
+      cert = build_valid_certificate(key: rsa_key, uri_san: exact_client_uri)
+      payload, = decode_statement(
+        build_statement(client_uri: exact_client_uri, registration_endpoint: exact_endpoint, certificate_chain: [cert]),
+        cert:
+      )
+
+      expect(payload).to include('iss' => exact_client_uri, 'sub' => exact_client_uri, 'aud' => exact_endpoint)
+    end
+
+    it 'allows non-HTTPS absolute client URIs when the exact URI appears in the certificate SAN' do
+      did_uri = 'did:web:client.example.com:app'
+      cert = build_valid_certificate(key: rsa_key, uri_san: did_uri)
+      payload, = decode_statement(build_statement(client_uri: did_uri, certificate_chain: [cert]), cert:)
+
+      expect(payload['iss']).to eq(did_uri)
+    end
+
+    it 'allows HTTP localhost registration endpoints only with an explicit development opt-in' do
+      endpoint = 'http://localhost:4567/register'
+      statement = build_statement(registration_endpoint: endpoint, allow_insecure_localhost: true)
+      payload, = decode_statement(statement)
+
+      expect(payload['aud']).to eq(endpoint)
+    end
+
+    it 'generates a fresh random jti when no generator is injected' do
+      first_payload, = decode_statement(build_statement(jti_generator: nil))
+      second_payload, = decode_statement(build_statement(jti_generator: nil))
+
+      expect(first_payload['jti']).not_to eq(second_payload['jti'])
+    end
+  end
+
+  describe 'algorithm selection' do
+    it 'prefers RS256 for RSA keys when advertised' do
+      _payload, header = decode_statement(build_statement(supported_algorithms: %w[RS384 RS256]))
+
+      expect(header['alg']).to eq('RS256')
+    end
+
+    it 'selects RS384 for RSA keys when RS256 is not advertised' do
+      statement = build_statement(supported_algorithms: ['RS384'])
+      _payload, header = decode_statement(statement, algorithm: 'RS384')
+
+      expect(header['alg']).to eq('RS384')
+    end
+
+    it 'supports ES256 with EC P-256 keys' do
+      ec_key = OpenSSL::PKey::EC.generate('prime256v1')
+      cert = build_valid_certificate(key: ec_key, uri_san: client_uri)
+      statement = build_statement(private_key: ec_key, certificate_chain: [cert], supported_algorithms: ['ES256'])
+      _payload, header = decode_statement(statement, cert:, algorithm: 'ES256')
+
+      expect(header['alg']).to eq('ES256')
+    end
+
+    it 'supports ES384 with EC P-384 keys' do
+      ec_key = OpenSSL::PKey::EC.generate('secp384r1')
+      cert = build_valid_certificate(key: ec_key, uri_san: client_uri)
+      statement = build_statement(private_key: ec_key, certificate_chain: [cert], supported_algorithms: ['ES384'])
+      _payload, header = decode_statement(statement, cert:, algorithm: 'ES384')
+
+      expect(header['alg']).to eq('ES384')
+    end
+
+    it 'honors an explicit compatible algorithm when advertised' do
+      statement = build_statement(algorithm: 'RS384', supported_algorithms: %w[RS256 RS384])
+      _payload, header = decode_statement(statement, algorithm: 'RS384')
+
+      expect(header['alg']).to eq('RS384')
+    end
+
+    it 'rejects an explicit algorithm that is not advertised' do
+      expect { build_statement(algorithm: 'RS384', supported_algorithms: ['RS256']) }
+        .to raise_error(Safire::Errors::ConfigurationError, /algorithm/)
+    end
+
+    it 'rejects a blank explicit algorithm' do
+      expect { build_statement(algorithm: ' ') }
+        .to raise_error(Safire::Errors::ConfigurationError, /algorithm/)
+    end
+
+    it 'rejects an algorithm that is incompatible with the private key' do
+      expect { build_statement(algorithm: 'ES256', supported_algorithms: ['ES256']) }
+        .to raise_error(Safire::Errors::ConfigurationError, /algorithm/)
+    end
+
+    it 'rejects unsupported advertised algorithms when no compatible supported algorithm remains' do
+      expect { build_statement(supported_algorithms: %w[HS256 ES256]) }
+        .to raise_error(Safire::Errors::ConfigurationError, /supported_algorithms/)
+    end
+
+    it 'requires supported_algorithms to be an array of strings' do
+      expect { build_statement(supported_algorithms: ['RS256', nil]) }
+        .to raise_error(Safire::Errors::ConfigurationError, /supported_algorithms/)
+    end
+  end
+
+  describe 'configuration and certificate validation' do
+    it 'accepts PEM strings for private key and certificate chain entries' do
+      statement = build_statement(private_key: rsa_key.to_pem, certificate_chain: [leaf_cert.to_pem])
+      payload, = decode_statement(statement)
+
+      expect(payload['iss']).to eq(client_uri)
+    end
+
+    it 'requires a validated UdapRegistrationMetadata object' do
+      expect { build_statement(metadata: metadata.to_h) }
+        .to raise_error(Safire::Errors::ValidationError, /metadata/)
+    end
+
+    it 'rejects a malformed private key without leaking the value' do
+      error = capture_error(Safire::Errors::ConfigurationError) do
+        build_statement(private_key: 'not a private key')
+      end
+
+      expect(error.message).to include('private_key')
+      expect(error.message).not_to include('not a private key')
+    end
+
+    it 'rejects a public-key-only signing key' do
+      expect { build_statement(private_key: rsa_key.public_key) }
+        .to raise_error(Safire::Errors::ConfigurationError, /private_key/)
+    end
+
+    it 'rejects an empty certificate chain' do
+      expect { build_statement(certificate_chain: []) }
+        .to raise_error(Safire::Errors::ConfigurationError, /certificate_chain/)
+    end
+
+    it 'rejects malformed certificate PEM as a certificate error' do
+      expect { build_statement(certificate_chain: ['not a certificate']) }
+        .to raise_error(Safire::Errors::CertificateError, /malformed/)
+    end
+
+    it 'rejects an expired leaf certificate' do
+      expired = build_udap_certificate(key: rsa_key, uri_san: client_uri, not_before: now - 3600, not_after: now - 1)
+
+      expect { build_statement(certificate_chain: [expired]) }
+        .to raise_error(Safire::Errors::CertificateError, /expired/)
+    end
+
+    it 'rejects a not-yet-valid chain certificate' do
+      future = build_udap_certificate(key: rsa_key, uri_san: 'https://issuer.example.com', not_before: now + 60)
+
+      expect { build_statement(certificate_chain: [leaf_cert, future]) }
+        .to raise_error(Safire::Errors::CertificateError, /not yet valid/)
+    end
+
+    it 'rejects a leaf certificate whose public key does not match the private key' do
+      other_key = OpenSSL::PKey::RSA.generate(2048)
+      mismatched = build_valid_certificate(key: other_key, uri_san: client_uri)
+
+      expect { build_statement(certificate_chain: [mismatched]) }
+        .to raise_error(Safire::Errors::CertificateError, /private key/)
+    end
+
+    it 'rejects a leaf certificate without a URI SAN' do
+      cert = build_valid_certificate(key: rsa_key, uri_san: nil)
+
+      expect { build_statement(certificate_chain: [cert]) }
+        .to raise_error(Safire::Errors::CertificateError, /URI SAN/)
+    end
+
+    it 'rejects a leaf certificate whose URI SAN does not exactly match client_uri' do
+      cert = build_valid_certificate(key: rsa_key, uri_san: "#{client_uri}/")
+
+      expect { build_statement(certificate_chain: [cert]) }
+        .to raise_error(Safire::Errors::CertificateError, /URI SAN/)
+    end
+
+    it 'rejects HTTP registration endpoints by default' do
+      expect { build_statement(registration_endpoint: 'http://localhost:4567/register') }
+        .to raise_error(Safire::Errors::ConfigurationError, /registration_endpoint/)
+    end
+
+    it 'rejects a non-boolean localhost HTTP opt-in' do
+      expect { build_statement(allow_insecure_localhost: 'true') }
+        .to raise_error(Safire::Errors::ConfigurationError, /allow_insecure_localhost/)
+    end
+
+    it 'rejects remote HTTP registration endpoints even with the localhost opt-in' do
+      expect do
+        build_statement(registration_endpoint: 'http://as.example.com/register', allow_insecure_localhost: true)
+      end.to raise_error(Safire::Errors::ConfigurationError, /registration_endpoint/)
+    end
+
+    it 'rejects invalid client URIs' do
+      expect { build_statement(client_uri: '/relative-client') }
+        .to raise_error(Safire::Errors::ConfigurationError, /client_uri/)
+    end
+
+    it 'requires the JTI generator to be callable when provided' do
+      expect { build_statement(jti_generator: 'jti') }
+        .to raise_error(Safire::Errors::ConfigurationError, /jti_generator/)
+    end
+
+    it 'requires the JTI generator to return a non-blank string' do
+      statement = build_statement(jti_generator: -> { ' ' })
+
+      expect { statement.to_jwt }
+        .to raise_error(Safire::Errors::ConfigurationError, /jti_generator/)
+    end
+
+    it 'requires the clock to return a time-like object' do
+      bad_clock = class_double(Time, now: Object.new)
+
+      expect { build_statement(clock: bad_clock) }
+        .to raise_error(Safire::Errors::ConfigurationError, /clock/)
+    end
+  end
+end

--- a/spec/safire/protocols/udap_software_statement_spec.rb
+++ b/spec/safire/protocols/udap_software_statement_spec.rb
@@ -47,13 +47,26 @@ RSpec.describe Safire::Protocols::UdapSoftwareStatement do
 
   describe '#to_jwt' do
     it 'builds the minimal JOSE header with a leaf-first x5c chain' do
-      intermediate = build_valid_certificate(key: rsa_key, uri_san: 'https://issuer.example.com', serial: 2)
-      statement = build_statement(certificate_chain: [leaf_cert, intermediate])
-      _payload, header = decode_statement(statement)
+      issuer_key = OpenSSL::PKey::RSA.generate(2048)
+      issuer_cert = build_valid_certificate(
+        key: issuer_key,
+        uri_san: 'https://issuer.example.com',
+        subject: '/CN=UDAP Issuer',
+        serial: 2
+      )
+      issued_leaf = build_valid_certificate(
+        key: rsa_key,
+        uri_san: client_uri,
+        issuer_cert:,
+        issuer_key:,
+        serial: 3
+      )
+      statement = build_statement(certificate_chain: [issued_leaf, issuer_cert])
+      _payload, header = decode_statement(statement, cert: issued_leaf)
 
       expect(header).to eq(
         'alg' => 'RS256',
-        'x5c' => [leaf_cert, intermediate].map { |cert| Base64.strict_encode64(cert.to_der) }
+        'x5c' => [issued_leaf, issuer_cert].map { |cert| Base64.strict_encode64(cert.to_der) }
       )
     end
 
@@ -104,6 +117,23 @@ RSpec.describe Safire::Protocols::UdapSoftwareStatement do
       expect(payload).to include('iss' => exact_client_uri, 'sub' => exact_client_uri, 'aud' => exact_endpoint)
     end
 
+    it 'snapshots validated URI inputs before signing' do
+      mutable_client_uri = client_uri.dup
+      mutable_endpoint = registration_endpoint.dup
+      cert = build_valid_certificate(key: rsa_key, uri_san: mutable_client_uri)
+      statement = build_statement(
+        client_uri: mutable_client_uri,
+        registration_endpoint: mutable_endpoint,
+        certificate_chain: [cert]
+      )
+
+      mutable_client_uri.replace('https://attacker.example.com/app')
+      mutable_endpoint.replace('https://attacker.example.com/register')
+      payload, = decode_statement(statement, cert:)
+
+      expect(payload).to include('iss' => client_uri, 'sub' => client_uri, 'aud' => registration_endpoint)
+    end
+
     it 'allows non-HTTPS absolute client URIs when the exact URI appears in the certificate SAN' do
       did_uri = 'did:web:client.example.com:app'
       cert = build_valid_certificate(key: rsa_key, uri_san: did_uri)
@@ -125,6 +155,22 @@ RSpec.describe Safire::Protocols::UdapSoftwareStatement do
       second_payload, = decode_statement(build_statement(jti_generator: nil))
 
       expect(first_payload['jti']).not_to eq(second_payload['jti'])
+    end
+
+    it 'revalidates certificate validity at signing time' do
+      signing_clock = Struct.new(:now).new(now)
+      expiring_cert = build_udap_certificate(
+        key: rsa_key,
+        uri_san: client_uri,
+        not_before: now - 60,
+        not_after: now + 60
+      )
+      statement = build_statement(clock: signing_clock, certificate_chain: [expiring_cert])
+
+      signing_clock.now = now + 61
+
+      expect { statement.to_jwt }
+        .to raise_error(Safire::Errors::CertificateError, /expired/)
     end
   end
 
@@ -162,6 +208,16 @@ RSpec.describe Safire::Protocols::UdapSoftwareStatement do
 
     it 'honors an explicit compatible algorithm when advertised' do
       statement = build_statement(algorithm: 'RS384', supported_algorithms: %w[RS256 RS384])
+      _payload, header = decode_statement(statement, algorithm: 'RS384')
+
+      expect(header['alg']).to eq('RS384')
+    end
+
+    it 'snapshots an explicit algorithm before signing' do
+      algorithm = 'RS384'.dup
+      statement = build_statement(algorithm:, supported_algorithms: ['RS384'])
+
+      algorithm.replace('RS256')
       _payload, header = decode_statement(statement, algorithm: 'RS384')
 
       expect(header['alg']).to eq('RS384')
@@ -244,6 +300,19 @@ RSpec.describe Safire::Protocols::UdapSoftwareStatement do
         .to raise_error(Safire::Errors::CertificateError, /not yet valid/)
     end
 
+    it 'rejects a certificate chain that is not issuer-ordered' do
+      unrelated_key = OpenSSL::PKey::RSA.generate(2048)
+      unrelated = build_valid_certificate(
+        key: unrelated_key,
+        uri_san: 'https://unrelated.example.com',
+        subject: '/CN=Unrelated Issuer',
+        serial: 2
+      )
+
+      expect { build_statement(certificate_chain: [leaf_cert, unrelated]) }
+        .to raise_error(Safire::Errors::CertificateError, /issuer-ordered/)
+    end
+
     it 'rejects a leaf certificate whose public key does not match the private key' do
       other_key = OpenSSL::PKey::RSA.generate(2048)
       mismatched = build_valid_certificate(key: other_key, uri_san: client_uri)
@@ -299,10 +368,17 @@ RSpec.describe Safire::Protocols::UdapSoftwareStatement do
         .to raise_error(Safire::Errors::ConfigurationError, /jti_generator/)
     end
 
-    it 'requires the clock to return a time-like object' do
+    it 'requires the clock to return Time' do
       bad_clock = class_double(Time, now: Object.new)
 
       expect { build_statement(clock: bad_clock) }
+        .to raise_error(Safire::Errors::ConfigurationError, /clock/)
+    end
+
+    it 'rejects NumericDate clock values before certificate comparisons' do
+      numeric_clock = class_double(Time, now: now.to_i)
+
+      expect { build_statement(clock: numeric_clock) }
         .to raise_error(Safire::Errors::ConfigurationError, /clock/)
     end
   end

--- a/spec/support/udap_certificate_helpers.rb
+++ b/spec/support/udap_certificate_helpers.rb
@@ -1,0 +1,19 @@
+module UdapCertificateHelpers
+  def build_udap_certificate(key:, uri_san:, subject: '/CN=UDAP Client', issuer_cert: nil, issuer_key: nil,
+                             not_before: Time.now - 60, not_after: Time.now + 3600, serial: 1)
+    cert = OpenSSL::X509::Certificate.new
+    cert.version = 2
+    cert.serial = serial
+    cert.subject = OpenSSL::X509::Name.parse(subject)
+    cert.issuer = issuer_cert&.subject || cert.subject
+    cert.public_key = key
+    cert.not_before = not_before
+    cert.not_after = not_after
+
+    extension_factory = OpenSSL::X509::ExtensionFactory.new(issuer_cert || cert, cert)
+    cert.add_extension(extension_factory.create_extension('subjectAltName', "URI:#{uri_san}", false)) if uri_san
+
+    cert.sign(issuer_key || key, OpenSSL::Digest.new('SHA256'))
+    cert
+  end
+end

--- a/spec/support/udap_certificate_helpers.rb
+++ b/spec/support/udap_certificate_helpers.rb
@@ -1,6 +1,7 @@
 module UdapCertificateHelpers
   def build_udap_certificate(key:, uri_san:, subject: '/CN=UDAP Client', issuer_cert: nil, issuer_key: nil,
-                             not_before: Time.now - 60, not_after: Time.now + 3600, serial: 1)
+                             not_before: Time.now - 60, not_after: Time.now + 3600, serial: 1,
+                             structural_san: false)
     cert = OpenSSL::X509::Certificate.new
     cert.version = 2
     cert.serial = serial
@@ -11,9 +12,26 @@ module UdapCertificateHelpers
     cert.not_after = not_after
 
     extension_factory = OpenSSL::X509::ExtensionFactory.new(issuer_cert || cert, cert)
-    cert.add_extension(extension_factory.create_extension('subjectAltName', "URI:#{uri_san}", false)) if uri_san
+    if uri_san
+      cert.add_extension(
+        subject_alt_name_extension(extension_factory, uri_san, structural: structural_san)
+      )
+    end
 
     cert.sign(issuer_key || key, OpenSSL::Digest.new('SHA256'))
     cert
+  end
+
+  def uri_san_extension(uri)
+    general_name = OpenSSL::ASN1::ASN1Data.new(uri, 6, :CONTEXT_SPECIFIC)
+    general_names = OpenSSL::ASN1::Sequence([general_name])
+
+    OpenSSL::X509::Extension.new('subjectAltName', general_names.to_der, false)
+  end
+
+  def subject_alt_name_extension(extension_factory, uri, structural:)
+    return uri_san_extension(uri) if structural
+
+    extension_factory.create_extension('subjectAltName', "URI:#{uri}", false)
   end
 end


### PR DESCRIPTION
## Summary

Adds the UDAP Security STU2 software-statement signing foundation for Dynamic Client Registration. The new builder produces compact JWS software statements with exact `iss`/`sub`/`aud` claims, five-minute lifetime, fresh `jti`, leaf-first `x5c`, and RSA/EC algorithm selection constrained by the server-advertised signing algorithms and the configured private key.

The implementation validates local signing identity inputs before a token is emitted: metadata type, client URI, registration endpoint policy, private key material, certificate chain shape, certificate validity windows, private-key/leaf-certificate match, and exact URI SAN match. Documentation, ADRs, YARD text, README, and changelog entries now describe the implemented signing foundation while keeping end-to-end registration submission marked as planned.

## Validation

- `bundle exec rspec`
- `RUBOCOP_CACHE_ROOT=tmp/rubocop_cache bundle exec rubocop`
- `bin/docs`
- `bundle exec jekyll build` from `docs/`
