### PR TITLE
Implement UDAP Dynamic Client Registration flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Safire::Client#register_client` now supports UDAP Security STU2 Dynamic
+  Client Registration when initialized with `protocol: :udap`. Safire performs
+  discovery-bound registration, validates `signed_metadata`, checks
+  `UdapMetadata#valid?`, signs a fresh X.509-backed `software_statement`, posts
+  the fixed UDAP envelope with optional `certifications`, accepts new-registration
+  `201` and update-style `200` responses with a valid `client_id`, and preserves
+  UDAP registration error codes such as `invalid_software_statement` and
+  `unapproved_software_statement`.
 - `Safire::Protocols::UdapRegistrationMetadata` validates and normalizes
   caller-controlled UDAP Security STU2 registration and cancellation metadata
   before software-statement signing. It enforces exact grant shapes, HTTPS
@@ -21,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   values with minimal `alg`/`x5c` headers, exact `iss`/`sub`/`aud` claims, a
   five-minute lifetime, fresh `jti`, RSA/EC algorithm negotiation constrained
   by discovery and key type, and local certificate/key/SAN consistency checks.
-  End-to-end UDAP registration remains planned.
+  The UDAP registration protocol flow now uses this signing foundation internally.
 - `Safire::ClientConfig` accepts a leaf-first, issuer-ordered
   `certificate_chain` of PEM strings or `OpenSSL::X509::Certificate` instances
   as the client signing identity foundation for UDAP Dynamic Client

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Coverage](https://codecov.io/gh/vanessuniq/safire/branch/main/graph/badge.svg)](https://codecov.io/gh/vanessuniq/safire)
 [![Documentation](https://img.shields.io/badge/docs-yard-blue.svg)](https://vanessuniq.github.io/safire)
 
-Safire is a Ruby gem for healthcare client applications that implements [SMART App Launch 2.2.0](https://hl7.org/fhir/smart-app-launch/) and [UDAP Security STU2 / v2.0.0](https://hl7.org/fhir/us/udap-security/STU2/index.html) server metadata discovery plus UDAP registration metadata and software-statement foundations. It handles SMART OAuth 2.0 authorization against HL7 FHIR servers, covering PKCE, private key JWT assertions, and the Backend Services system-to-system flow, so you can focus on your application rather than protocol plumbing.
+Safire is a Ruby gem for healthcare client applications that implements [SMART App Launch 2.2.0](https://hl7.org/fhir/smart-app-launch/) and [UDAP Security STU2 / v2.0.0](https://hl7.org/fhir/us/udap-security/STU2/index.html) discovery plus certificate-backed Dynamic Client Registration. It handles SMART OAuth 2.0 authorization against HL7 FHIR servers, covering PKCE, private key JWT assertions, and the Backend Services system-to-system flow, so you can focus on your application rather than protocol plumbing.
 
 ---
 
@@ -41,24 +41,32 @@ metadata = client.server_metadata(community: 'https://udap.example.org/community
 Production UDAP discovery requires trust anchors plus an explicit certificate revocation policy
 (`crls:` or `revocation_checker:`). Use `verify_chain: false` only for development or tests.
 
-Dynamic Client Registration metadata validation is also implemented:
+Dynamic Client Registration is also implemented for certificate-backed UDAP clients:
 
 ```ruby
-registration_metadata = Safire::Protocols::UdapRegistrationMetadata.new(
+udap_client = Safire::Client.new(
   {
-    client_name: 'Example Health App',
-    contacts: ['mailto:security@example.com'],
-    grant_types: %w[authorization_code refresh_token],
-    scope: 'openid system/Patient.rs',
-    redirect_uris: ['https://app.example.com/callback'],
-    logo_uri: 'https://app.example.com/logo.png'
-  }
+    base_url: 'https://fhir.example.com',
+    private_key: File.read('client-key.pem'),
+    certificate_chain: [File.read('client-cert.pem')]
+  },
+  protocol: :udap
 )
 
-registration_metadata.to_h
+registration = udap_client.register_client(
+  {
+    client_name: 'Example Backend Service',
+    contacts: ['mailto:security@example.com'],
+    grant_types: ['client_credentials'],
+    scope: 'system/Patient.rs'
+  },
+  client_uri:      'https://client.example.com',
+  trusted_anchors: [ca_cert],
+  crls:            [ca_crl]
+)
 ```
 
-UDAP registration submission, JWT client authentication, and Tiered OAuth are planned. See [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md) for details.
+UDAP registration cancellation, JWT client authentication, and Tiered OAuth are planned. See [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md) for details.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,8 +37,10 @@ Feedback, bug reports, and pull requests are welcome via the [issue tracker](htt
   exposes UDAP discovery while rejecting SMART-only `client_type:` values
 - **Demo Workflow** — Sinatra demo supports protocol-aware server setup and a
   UDAP Discovery screen with signed metadata trust status
-- **UDAP DCR Foundations** — registration metadata validation and internal
-  X.509-backed software statement signing
+- **UDAP Dynamic Client Registration** — certificate-backed STU2 new
+  registration and modification via signed software statements; includes
+  metadata validation, signed endpoint precedence, community-scoped discovery,
+  certification envelope handling, and RFC 7591-shaped response parsing
 
 ---
 
@@ -46,8 +48,8 @@ Feedback, bug reports, and pull requests are welcome via the [issue tracker](htt
 
 ### UDAP Security
 
-- **UDAP Dynamic Client Registration Submission** — signed registration request
-  envelope POST and response handling
+- **UDAP Registration Cancellation** — signed cancellation request with an empty
+  `grant_types` array and response confirmation
 - **UDAP JWT Client Auth** — B2B and consumer-facing authorization flows
 - **Tiered OAuth** — identity chaining for multi-system access
 
@@ -92,5 +94,5 @@ Feedback, bug reports, and pull requests are welcome via the [issue tracker](htt
 | ActiveSupport | ≥ 7.1, < 9 |
 | Rails (optional) | ≥ 7.1 |
 | SMART App Launch | 2.2.0 (STU2) |
-| UDAP Security | 2.0.0 (STU2 discovery and DCR signing foundations implemented; registration submission/auth flows planned) |
+| UDAP Security | 2.0.0 (STU2 discovery and Dynamic Client Registration implemented; cancellation/auth flows planned) |
 | FHIR | R4, R4B |

--- a/docs/adr/ADR-010-optional-client-id-dcr-temp-client.md
+++ b/docs/adr/ADR-010-optional-client-id-dcr-temp-client.md
@@ -46,6 +46,34 @@ client = Safire::Client.new({
 
 Flow methods that require `client_id` (`authorization_url`, `request_access_token`, `request_backend_token`) validate its presence at call time and raise `ConfigurationError` if absent.
 
+### 2026-07-04 amendment: UDAP certificate-backed temp clients
+
+UDAP Dynamic Client Registration uses the same temp-client pattern, but the
+temporary client is identified by a private key and X.509 certificate chain
+rather than by SMART client type credentials:
+
+```ruby
+temp_client = Safire::Client.new(
+  {
+    base_url: 'https://fhir.example.com',
+    private_key: File.read('client-key.pem'),
+    certificate_chain: [File.read('client-cert.pem')]
+  },
+  protocol: :udap
+)
+
+registration = temp_client.register_client(
+  metadata,
+  client_uri: 'https://client.example.com',
+  trusted_anchors: [udap_ca],
+  crls: [udap_crl]
+)
+```
+
+`client_id` remains optional at construction. UDAP `register_client` discovers
+the registration endpoint, signs a software statement using the configured or
+per-call signing identity, and returns the server-assigned `client_id`.
+
 ---
 
 ## Consequences

--- a/docs/adr/ADR-012-udap-signed-metadata-validation.md
+++ b/docs/adr/ADR-012-udap-signed-metadata-validation.md
@@ -77,6 +77,15 @@ discovery is fetched again.
 hold a metadata object and want to explicitly re-validate (for example, with a different trust
 anchor set). Instances returned by `Udap#server_metadata` are already pre-validated.
 
+### DCR consumes authoritative signed endpoint claims
+
+UDAP Dynamic Client Registration is the first Safire flow that acts on
+discovered UDAP endpoints after discovery. `Protocols::Udap#register_client`
+uses the `registration_endpoint` from the `UdapMetadata` instance returned by
+`server_metadata`. Because `server_metadata` merges signed endpoint claims over
+unsigned JSON before constructing the entity, registration posts to the
+authoritative signed endpoint when signed and unsigned values differ.
+
 ---
 
 ## Consequences
@@ -88,3 +97,5 @@ anchor set). Instances returned by `Udap#server_metadata` are already pre-valida
 - `CertificateError` is reserved for unrecoverable DER parse failures. All other validation
   decisions use the warn-and-return-nil pattern.
 - `UdapMetadata#valid?` remains a structural check only; it does not invoke the JWT validator.
+- Downstream UDAP flows must consume endpoints from `UdapMetadata` returned by
+  `server_metadata`; they must not read unsigned discovery JSON directly.

--- a/docs/adr/ADR-013-udap-registration-request-model.md
+++ b/docs/adr/ADR-013-udap-registration-request-model.md
@@ -101,5 +101,5 @@ regular expression.
 - Extension metadata remains forward-compatible without permitting arbitrary
   Ruby objects into a JWT payload.
 - Metadata validation remains independent of software-statement signing and the
-  network registration flow; this ADR by itself does not make UDAP DCR end to
-  end available.
+  network registration flow. `Protocols::Udap#register_client` consumes this
+  value object when performing end-to-end UDAP registration.

--- a/docs/adr/ADR-014-udap-software-statement-signing.md
+++ b/docs/adr/ADR-014-udap-software-statement-signing.md
@@ -37,8 +37,8 @@ discovered registration endpoint, a private key, a leaf-first certificate
 chain, and the server-advertised registration signing algorithms.
 
 The builder has no HTTP behavior and does not perform discovery. UDAP protocol
-orchestration will remain responsible for fetching metadata, checking DCR
-capability, and POSTing the request envelope in a later PR.
+orchestration is responsible for fetching metadata, checking DCR capability,
+POSTing the request envelope, and parsing the response.
 
 ### Keep URI comparison exact
 
@@ -111,6 +111,6 @@ stubbing global randomness.
 - The generated JWT is short-lived: `exp` is always `iat + 300`.
 - Private keys, compact JWTs, and certificate contents are not included in
   validation error messages.
-- End-to-end UDAP registration still requires the protocol orchestration PR
-  that discovers metadata, builds the request envelope, POSTs to the
-  registration endpoint, and parses the response.
+- End-to-end UDAP registration uses this builder through
+  `Protocols::Udap#register_client`; applications should prefer the facade
+  method over direct software-statement construction.

--- a/docs/configuration/client-setup.md
+++ b/docs/configuration/client-setup.md
@@ -46,7 +46,7 @@ client = Safire::Client.new(config)
 ```
 
 {: .note }
-> `client_id` is the only authorization parameter validated at call time rather than at construction. `authorization_url`, `request_access_token`, `refresh_token`, and `request_backend_token` each raise `Safire::Errors::ConfigurationError` if `client_id` is absent when called. This means you can build a client without a `client_id` and call `register_client` to obtain one at runtime. See [Dynamic Client Registration]({{ site.baseurl }}/smart-on-fhir/dynamic-client-registration/) for details.
+> `client_id` is the only authorization parameter validated at call time rather than at construction. `authorization_url`, `request_access_token`, `refresh_token`, and `request_backend_token` each raise `Safire::Errors::ConfigurationError` if `client_id` is absent when called. This means you can build a client without a `client_id` and call `register_client` to obtain one at runtime. See [SMART Dynamic Client Registration]({{ site.baseurl }}/smart-on-fhir/dynamic-client-registration/) or [UDAP Dynamic Client Registration]({{ site.baseurl }}/udap/dynamic-client-registration/) for details.
 
 ---
 
@@ -65,7 +65,7 @@ Selects the authorization protocol. Defaults to `:smart`.
 | Value | Status | Description |
 |-------|--------|-------------|
 | `:smart` | Implemented | SMART App Launch 2.2.0 |
-| `:udap` | Partial | UDAP Security STU2 discovery — `server_metadata` validates `signed_metadata`, supports optional `community:`, and accepts trust policy keywords (`trusted_anchors:`, `crls:`, `revocation_checker:`, `verify_chain:`); auth flows raise `NotImplementedError` |
+| `:udap` | Partial | UDAP Security STU2 discovery and Dynamic Client Registration — `server_metadata` validates `signed_metadata`, supports optional `community:`, and accepts trust policy keywords (`trusted_anchors:`, `crls:`, `revocation_checker:`, `verify_chain:`); `register_client` submits certificate-backed UDAP registration requests; auth/token flows raise `NotImplementedError` |
 
 For UDAP, `client_type:` is not applicable. Passing any explicit value, either at initialization or through `client.client_type=`, raises `Safire::Errors::ConfigurationError`. Future UDAP authentication flows will use signed JWT assertions rather than SMART client types.
 
@@ -132,11 +132,24 @@ certificate objects, so subsequent caller mutations cannot alter the configured
 identity. Safire performs PEM parsing, private-key matching, validity checks,
 and URI SAN checks when a software statement is built.
 
-Configured credentials are intended to serve as defaults, with per-call
-overrides for applications that select signing identities dynamically. Safire
-can build the software statement foundation now; the end-to-end UDAP Dynamic
-Client Registration API is not available yet. UDAP discovery does not access
-these signing credentials.
+Configured credentials are intended to serve as defaults for UDAP Dynamic
+Client Registration, with per-call overrides for applications that select
+signing identities dynamically. UDAP discovery does not access these signing
+credentials.
+
+```ruby
+registration = client.register_client(
+  {
+    client_name: 'Example Backend Service',
+    contacts: ['mailto:security@example.com'],
+    grant_types: ['client_credentials'],
+    scope: 'system/Patient.rs'
+  },
+  client_uri:      'https://client.example.com',
+  trusted_anchors: [udap_ca],
+  crls:            [udap_crl]
+)
+```
 
 ### Client Type
 
@@ -249,6 +262,6 @@ config.inspect
 ## Next Steps
 
 - [Logging]({{ site.baseurl }}/configuration/logging/) — configure Safire's logger and HTTP request logging
-- [UDAP Discovery]({{ site.baseurl }}/udap/) — discover and validate UDAP Security STU2 server metadata
-- [Dynamic Client Registration]({{ site.baseurl }}/smart-on-fhir/dynamic-client-registration/) — obtain a `client_id` at runtime using RFC 7591
+- [UDAP]({{ site.baseurl }}/udap/) — discover UDAP metadata and register certificate-backed clients
+- [SMART Dynamic Client Registration]({{ site.baseurl }}/smart-on-fhir/dynamic-client-registration/) — obtain a `client_id` at runtime using RFC 7591
 - [SMART App Launch Workflows]({{ site.baseurl }}/smart-on-fhir/) — step-by-step authorization flow guides

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -29,7 +29,7 @@ flowchart TD
     A -->|"resolves config"| B
     A -->|"validates protocol + client_type"| C
     C -->|":smart (default)"| D
-    C -->|":udap"| G["Protocols::Udap\n— discovery implemented\n— DCR foundations implemented\n— auth flows planned"]
+    C -->|":udap"| G["Protocols::Udap\n— discovery implemented\n— DCR implemented\n— auth flows planned"]
     D -->|"lazily fetches"| E
     E -->|"HTTP"| F
 ```
@@ -55,9 +55,8 @@ flowchart TD
 | `authorization_endpoint` | String | No | — | Override the discovered authorization endpoint |
 | `token_endpoint` | String | No | — | Override the discovered token endpoint |
 
-`certificate_chain` and the UDAP algorithm values are used by Safire's UDAP
-software-statement signing foundation. Network registration is not available
-yet.
+`certificate_chain` and the UDAP algorithm values are used by
+`Safire::Client#register_client` when `protocol: :udap`.
 
 ## In This Section
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ description: "Safire is a Ruby gem implementing SMART App Launch 2.2.0 and UDAP 
 [![Gem Version](https://badge.fury.io/rb/safire.svg)](https://badge.fury.io/rb/safire)
 [![CI](https://github.com/vanessuniq/safire/workflows/CI/badge.svg)](https://github.com/vanessuniq/safire/actions)
 
-A lean Ruby gem implementing **[SMART App Launch](https://hl7.org/fhir/smart-app-launch/)** flows and **[UDAP Security STU2 / v2.0.0](https://hl7.org/fhir/us/udap-security/STU2/index.html)** discovery and registration foundations for clients.
+A lean Ruby gem implementing **[SMART App Launch](https://hl7.org/fhir/smart-app-launch/)** flows and **[UDAP Security STU2 / v2.0.0](https://hl7.org/fhir/us/udap-security/STU2/index.html)** discovery and Dynamic Client Registration for clients.
 
 ## Quick Navigation
 
@@ -20,7 +20,7 @@ A lean Ruby gem implementing **[SMART App Launch](https://hl7.org/fhir/smart-app
 | [Getting Started]({{ site.baseurl }}/installation/) | Install Safire and quick start guide |
 | [Configuration]({{ site.baseurl }}/configuration/) | All configuration options and parameters |
 | [SMART]({{ site.baseurl }}/smart-on-fhir/) | App Launch (Public, Confidential Symmetric, Confidential Asymmetric) and Backend Services |
-| [UDAP]({{ site.baseurl }}/udap/) | UDAP Security discovery plus registration metadata and software-statement foundations |
+| [UDAP]({{ site.baseurl }}/udap/) | UDAP Security discovery plus certificate-backed Dynamic Client Registration |
 | [Security Guide]({{ site.baseurl }}/security/) | HTTPS, credential protection, token storage, key rotation |
 | [Advanced Examples]({{ site.baseurl }}/advanced/) | Caching, multi-server, token management, complete Rails integration |
 | [Troubleshooting]({{ site.baseurl }}/troubleshooting/) | Common issues and solutions |
@@ -41,9 +41,9 @@ A lean Ruby gem implementing **[SMART App Launch](https://hl7.org/fhir/smart-app
 
 - Discovery (`/.well-known/udap`) with optional community scoping
 - Dynamic Client Registration metadata validation and normalization
-- X.509-backed software-statement signing foundation
+- X.509-backed software-statement signing and registration submission
 
-Registration submission, JWT assertion authentication, and Tiered OAuth are
+Registration cancellation, JWT assertion authentication, and Tiered OAuth remain
 planned. See [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md)
 for details.
 

--- a/docs/troubleshooting/client-errors.md
+++ b/docs/troubleshooting/client-errors.md
@@ -34,6 +34,52 @@ registration = client.register_client(
 )
 ```
 
+For UDAP, the registration endpoint is always discovery-bound. Safire raises
+`DiscoveryError` before POSTing when discovery fails, `signed_metadata` cannot
+be validated, `UdapMetadata#valid?` reports structural non-conformance, the
+server does not advertise `udap_dcr`, or the server does not publish
+registration signing algorithms:
+
+```ruby
+registration = udap_client.register_client(
+  metadata,
+  client_uri:      'https://client.example.com',
+  trusted_anchors: [ca_cert],
+  crls:            [ca_crl]
+)
+```
+
+### `ValidationError`: UDAP registration metadata or certifications are invalid
+
+```
+Safire::Errors::ValidationError: Validation failed for certifications: must be nil or an array of compact JWS strings
+```
+
+UDAP registration signs caller-controlled metadata before sending it. Safire
+therefore validates the metadata and certification collection locally and raises
+`ValidationError` before building a software statement when input is malformed.
+
+Common causes:
+
+- missing required metadata such as `client_name`, `contacts`, `grant_types`, or `scope`
+- unsupported grant combinations
+- non-HTTPS redirect or logo URIs, except HTTP localhost when explicitly enabled for development
+- reserved claims such as `iss`, `sub`, `aud`, `exp`, `jti`, `software_statement`, `certifications`, or `udap`
+- `certifications:` is not `nil` or an array of compact JWS strings
+- discovery declares required certifications, but `certifications:` is omitted or empty
+
+### `CertificateError`: UDAP client signing identity cannot support registration
+
+```
+Safire::Errors::CertificateError: Certificate error — client_uri does not match any URI SAN in the leaf certificate
+```
+
+UDAP registration requires a private key and leaf-first certificate chain. The
+private key must match the leaf certificate, every certificate must be currently
+valid, and the `client_uri:` must exactly match a URI Subject Alternative Name
+in the leaf certificate. Case, port, and trailing slash differences are
+significant.
+
 ### `RegistrationError`: Server rejected the registration request
 
 ```
@@ -48,6 +94,10 @@ rescue Safire::Errors::RegistrationError => e
   puts e.error_code        # "invalid_redirect_uri"
   puts e.error_description # "Redirect URI must use HTTPS"
 ```
+
+UDAP servers may return UDAP-specific error codes such as
+`invalid_software_statement` or `unapproved_software_statement`; Safire
+preserves them in `e.error_code`.
 
 ### `RegistrationError`: 2xx response has a missing or invalid `client_id`
 

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -30,7 +30,8 @@ Safire raises typed errors so you can handle each failure category separately:
 |-------------|-------------|
 | `Safire::Errors::ConfigurationError` | Missing or invalid client configuration — caught at construction time |
 | `Safire::Errors::DiscoveryError` | SMART or UDAP metadata discovery failed (HTTP error, invalid JSON, missing SMART `token_endpoint` when required, or UDAP `signed_metadata` validation failure) |
-| `Safire::Errors::CertificateError` | UDAP `x5c` certificate data could not be parsed during `signed_metadata` validation |
+| `Safire::Errors::ValidationError` | Caller-controlled input is invalid before a request is sent, such as UDAP registration metadata or certification JWT shape |
+| `Safire::Errors::CertificateError` | UDAP `x5c` certificate data could not be parsed or the configured UDAP client certificate chain cannot support signing |
 | `Safire::Errors::RegistrationError` | Dynamic Client Registration failed (server error, or 2xx response with a missing or invalid `client_id`) |
 | `Safire::Errors::TokenError` | Token exchange or refresh failed (OAuth error, missing fields) |
 | `Safire::Errors::NetworkError` | Transport-level failure (connection refused, timeout, blocked redirect) |

--- a/docs/udap.md
+++ b/docs/udap.md
@@ -3,7 +3,7 @@ layout: default
 title: UDAP
 nav_order: 5
 permalink: /udap/
-description: "UDAP Security STU2 discovery, registration metadata validation, and software-statement signing foundations in Safire."
+description: "UDAP Security STU2 discovery and Dynamic Client Registration in Safire."
 has_children: true
 ---
 
@@ -12,11 +12,10 @@ has_children: true
 {: .no_toc }
 
 <div class="code-example" markdown="1">
-**Implemented now:** UDAP Security STU2 discovery (`/.well-known/udap`),
-including signed metadata validation and optional community scoping. The
-[Dynamic Client Registration guide]({% link udap/dynamic-client-registration/index.md %})
-also covers implemented registration metadata validation and software-statement
-signing foundations. Registration submission, JWT client authentication, and
+**Implemented now:** UDAP Security STU2 discovery (`/.well-known/udap`)
+including signed metadata validation and optional community scoping, plus
+certificate-backed Dynamic Client Registration for new registrations and
+modifications. Registration cancellation, JWT client authentication, and
 Tiered OAuth remain planned. See
 [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md).
 </div>
@@ -125,9 +124,8 @@ metadata.signed_metadata_valid?(
 Support helpers expose advertised profiles and usable discovery capabilities.
 Capability helpers combine profile or grant signals with the endpoint
 preconditions Safire can verify during discovery. These describe what the
-server advertises; Safire's DCR metadata validator and software-statement
-signing foundation are available, while DCR submission, JWT client
-authentication, and Tiered OAuth remain planned.
+server advertises; `register_client` performs its own discovery-bound checks
+before submitting a UDAP registration request.
 
 | Helper | Checks |
 |--------|--------|
@@ -158,6 +156,53 @@ metadata.client_authorization_profile?
 metadata.tiered_oauth_profile?
 ```
 
+---
+
+## Dynamic Client Registration
+
+UDAP Dynamic Client Registration is available through the same facade method as
+SMART registration, selected by `protocol: :udap`. Safire discovers and
+validates UDAP metadata, signs your registration metadata into a
+`software_statement`, posts the fixed UDAP request envelope, and returns the
+server's registration response.
+
+```ruby
+client = Safire::Client.new(
+  {
+    base_url: 'https://fhir.example.com',
+    private_key: File.read('client-key.pem'),
+    certificate_chain: [
+      File.read('client-cert.pem'),
+      File.read('issuing-ca.pem')
+    ]
+  },
+  protocol: :udap
+)
+
+registration = client.register_client(
+  {
+    client_name: 'Example Backend Service',
+    contacts: ['mailto:security@example.com'],
+    grant_types: ['client_credentials'],
+    scope: 'system/Patient.rs system/Observation.rs'
+  },
+  client_uri:      'https://client.example.com',
+  trusted_anchors: [ca_cert],
+  crls:            [ca_crl]
+)
+
+registration['client_id']
+```
+
+Pass `community:` when registering within a specific UDAP trust community.
+Pass `certifications:` when the community requires third-party certification
+JWTs. Safire shape-checks those JWT strings and sends them to the authorization
+server; it does not create, verify, or interpret certification contents.
+
+See [Dynamic Client Registration]({% link udap/dynamic-client-registration/index.md %})
+for metadata rules, software-statement behavior, trust-policy keywords,
+certification handling, and error boundaries.
+
 ### Error handling
 
 | Condition | Error raised |
@@ -176,18 +221,18 @@ metadata.tiered_oauth_profile?
 
 ### Client Flows
 
-- **Dynamic Client Registration (DCR)** — metadata validation and
-  software-statement signing foundations are implemented; registration
-  submission remains planned for the one-time registration that obtains a
-  `client_id`
+- **Registration cancellation** — cancel an existing UDAP registration by
+  submitting a signed cancellation request with an empty `grant_types` array
 - **JWT Client Authentication** — authenticate on every request using a signed JWT assertion (Authentication Token, AnT) with an X.509 certificate chain in the `x5c` header; the registered `client_id` is reused as `iss` and `sub` in each assertion
 - **Tiered OAuth** — delegated authorization for multi-system access per the UDAP Security IG
 - **Pushed Authorization Requests (RFC 9126)** — PAR support for pre-registering authorization requests
 
 ### Trust Framework
 
-- **Client certificate trust management** — apply trust anchors and community policy to future
-  UDAP client authentication and registration flows
+- **Client certificate trust management for auth flows** — apply trust anchors
+  and community policy to future UDAP client authentication flows; registration
+  server acceptance of the submitted client certificate remains the
+  authorization server's trust decision
 - **Trust Community Support** — integration with UDAP trust communities (e.g. Carequality, CommonWell)
 
 ---

--- a/docs/udap/dynamic-client-registration/index.md
+++ b/docs/udap/dynamic-client-registration/index.md
@@ -139,7 +139,7 @@ contents.
 | `Safire::Errors::ValidationError` | Caller metadata or the `certifications:` collection is invalid before signing |
 | `Safire::Errors::ConfigurationError` | Signing configuration is missing or incompatible, such as an unsupported explicit `jwt_algorithm` |
 | `Safire::Errors::CertificateError` | The configured client certificate chain cannot support signing or does not match `client_uri:` |
-| `Safire::Errors::RegistrationError` | The registration server returns an OAuth error response or a 2xx response without a non-blank string `client_id` |
+| `Safire::Errors::RegistrationError` | The registration server returns an OAuth error response, a response status other than `200` or `201`, or a successful response without a non-blank string `client_id` |
 | `Safire::Errors::NetworkError` | Connection failure, timeout, SSL error, or blocked non-HTTPS redirect |
 
 ## Validate Metadata

--- a/docs/udap/dynamic-client-registration/index.md
+++ b/docs/udap/dynamic-client-registration/index.md
@@ -4,7 +4,7 @@ title: Dynamic Client Registration
 parent: UDAP
 nav_order: 1
 permalink: /udap/dynamic-client-registration/
-description: "Validate UDAP Security STU2 registration metadata and prepare X.509-backed software statements."
+description: "Register UDAP Security STU2 clients with certificate-backed software statements."
 has_children: true
 ---
 
@@ -13,16 +13,140 @@ has_children: true
 {: .no_toc }
 
 <div class="code-example" markdown="1">
-**Current status:** Safire can validate and normalize UDAP Security STU2
-registration metadata and construct X.509-backed software statements.
-Submission to the registration endpoint is not implemented yet, so this remains
-a foundation API rather than an end-to-end registration workflow.
+**Current status:** Safire implements UDAP Security STU2 new registration and
+registration modification through `Safire::Client#register_client`.
+Registration cancellation is planned separately.
 </div>
+
+## Register a Client
+
+Create a temporary UDAP client with the FHIR server base URL plus the client
+signing identity. Then call `register_client` with registration metadata and
+the exact `client_uri` that appears as a URI Subject Alternative Name in the
+leaf certificate.
+
+```ruby
+client = Safire::Client.new(
+  {
+    base_url: 'https://fhir.example.com',
+    private_key: File.read('client-key.pem'),
+    certificate_chain: [
+      File.read('client-cert.pem'),
+      File.read('issuing-ca.pem')
+    ]
+  },
+  protocol: :udap
+)
+
+registration = client.register_client(
+  {
+    client_name: 'Example Backend Service',
+    contacts: ['mailto:security@example.com'],
+    grant_types: ['client_credentials'],
+    scope: 'system/Patient.rs system/Observation.rs'
+  },
+  client_uri:      'https://client.example.com',
+  trusted_anchors: [ca_cert],
+  crls:            [ca_crl]
+)
+
+client_id = registration['client_id']
+```
+
+Safire performs these steps:
+
+1. Discovers UDAP metadata from `/.well-known/udap`, optionally scoped by
+   `community:`.
+2. Validates `signed_metadata` using the supplied server trust policy.
+3. Runs `UdapMetadata#valid?` because registration is about to trust and act on
+   the discovered registration endpoint.
+4. Verifies that the server advertises the `udap_dcr` profile and a usable
+   `registration_endpoint`.
+5. Validates caller registration metadata.
+6. Signs a fresh `software_statement` JWT using the configured or per-call
+   client signing identity.
+7. POSTs the UDAP request envelope and returns the parsed registration response.
+
+Calling `register_client` again with the same `client_uri` and community
+requests modification of the existing registration. Safire returns the server
+response without assuming the `client_id` is unchanged.
+
+### Authorization-code registration
+
+Authorization-code clients include redirect and logo metadata. Safire generates
+`response_types: ["code"]` and `token_endpoint_auth_method: "private_key_jwt"`
+inside the signed software statement.
+
+```ruby
+registration = client.register_client(
+  {
+    client_name: 'Example Provider App',
+    contacts: ['mailto:security@example.com'],
+    grant_types: %w[authorization_code refresh_token],
+    scope: 'openid fhirUser patient/*.rs',
+    redirect_uris: ['https://client.example.com/callback'],
+    logo_uri: 'https://client.example.com/logo.png'
+  },
+  client_uri:      'https://client.example.com',
+  trusted_anchors: [ca_cert],
+  crls:            [ca_crl]
+)
+```
+
+### Community, trust policy, and certifications
+
+Use `community:` when registering against a specific UDAP trust community:
+
+```ruby
+registration = client.register_client(
+  metadata,
+  client_uri:      'https://client.example.com',
+  community:       'https://udap.example.org/community1',
+  trusted_anchors: [ca_cert],
+  crls:            [ca_crl]
+)
+```
+
+`trusted_anchors:`, `crls:`, `revocation_checker:`, and `verify_chain:` apply
+to server `signed_metadata` validation during discovery. They are not the
+client signing certificate chain.
+
+Pass `certifications:` when the discovered community requires or accepts
+third-party certification JWTs:
+
+```ruby
+registration = client.register_client(
+  metadata,
+  client_uri:      'https://client.example.com',
+  certifications: [certification_jwt],
+  trusted_anchors: [ca_cert],
+  crls:            [ca_crl]
+)
+```
+
+`certifications: nil` omits the envelope field. `certifications: []` sends an
+explicit empty array, which is useful for modification requests that clear
+optional certifications. If discovery advertises required certifications,
+Safire rejects `nil` and `[]` locally. Safire shape-checks certification values
+as compact JWS strings but does not create, decode, verify, or interpret their
+contents.
+
+### Errors
+
+| Error | When raised |
+|-------|-------------|
+| `Safire::Errors::DiscoveryError` | Discovery fails, `signed_metadata` cannot be validated, discovered metadata is structurally non-conformant, or the server does not advertise usable UDAP DCR capability |
+| `Safire::Errors::ValidationError` | Caller metadata or the `certifications:` collection is invalid before signing |
+| `Safire::Errors::ConfigurationError` | Signing configuration is missing or incompatible, such as an unsupported explicit `jwt_algorithm` |
+| `Safire::Errors::CertificateError` | The configured client certificate chain cannot support signing or does not match `client_uri:` |
+| `Safire::Errors::RegistrationError` | The registration server returns an OAuth error response or a 2xx response without a non-blank string `client_id` |
+| `Safire::Errors::NetworkError` | Connection failure, timeout, SSL error, or blocked non-HTTPS redirect |
 
 ## Validate Metadata
 
-Build a `UdapRegistrationMetadata` value object before signing registration
-metadata:
+`register_client` builds `UdapRegistrationMetadata` internally. You can also
+construct it directly when you want to validate metadata before invoking the
+network flow:
 
 ```ruby
 metadata = Safire::Protocols::UdapRegistrationMetadata.new(
@@ -110,8 +234,10 @@ Exactly one primary grant is allowed. Unknown grant types, duplicate values,
 `refresh_token` without `authorization_code`, and combining
 `authorization_code` with `client_credentials` raise `ValidationError`.
 
-Cancellation uses `operation: :cancel`. Omit `grant_types`; Safire injects an
-empty array and excludes authorization-only metadata:
+The metadata value object also has `operation: :cancel` as a foundation for the
+future cancellation workflow. Omit `grant_types`; Safire injects an empty array
+and excludes authorization-only metadata. The public `cancel_registration`
+method is not implemented yet.
 
 ```ruby
 cancellation = Safire::Protocols::UdapRegistrationMetadata.new(
@@ -139,5 +265,4 @@ algorithm selection, and certificate/key checks.
 
 See the
 [UDAP Security STU2 registration profile](https://hl7.org/fhir/us/udap-security/STU2/registration.html)
-for the normative requirements. End-to-end registration will become available
-after Safire adds registration submission.
+for the normative requirements.

--- a/docs/udap/dynamic-client-registration/software-statement.md
+++ b/docs/udap/dynamic-client-registration/software-statement.md
@@ -81,7 +81,9 @@ that list with the configured private key:
 
 When `jwt_algorithm` is omitted, Safire selects the first compatible advertised
 algorithm. RSA keys prefer `RS256` because it is the STU2 baseline. An explicit
-algorithm must be advertised by the server and compatible with the key.
+algorithm must be advertised by the server and compatible with the key. Safire
+raises `DiscoveryError` before signing if the server metadata omits mandatory
+`RS256` registration signing support.
 
 ## Validation Boundaries
 

--- a/docs/udap/dynamic-client-registration/software-statement.md
+++ b/docs/udap/dynamic-client-registration/software-statement.md
@@ -13,17 +13,17 @@ description: "How Safire builds UDAP Security STU2 X.509-backed software stateme
 {: .no_toc }
 
 <div class="code-example" markdown="1">
-**Current status:** Safire can validate registration metadata and has the
-internal signing foundation needed to construct conformant X.509-backed UDAP
-Security STU2 software statements. A supported public registration API that
-submits the request to the server is not implemented yet.
+**Current status:** Safire uses this signing layer internally when
+`Safire::Client#register_client` submits UDAP Security STU2 registration
+requests. Most applications should use `register_client` rather than construct
+software statements directly.
 </div>
 
 ## What Safire Builds
 
-UDAP registration metadata is signed into a compact JWS software statement. The
-software statement carries the client registration parameters plus the required
-security claims:
+UDAP registration metadata is signed into a compact JWS software statement
+inside `register_client`. The software statement carries the client
+registration parameters plus the required security claims:
 
 | Claim | Safire behavior |
 |-------|-----------------|

--- a/lib/safire.rb
+++ b/lib/safire.rb
@@ -11,6 +11,7 @@ require_relative 'safire/entity'
 require_relative 'safire/pkce'
 require_relative 'safire/jwt_assertion'
 require_relative 'safire/uri_validation'
+require_relative 'safire/protocols'
 
 root = File.expand_path '.', File.dirname(File.absolute_path(__FILE__))
 Dir.glob(File.join(root, 'safire', 'protocols', '**', '*.rb')).each do |file|

--- a/lib/safire/client.rb
+++ b/lib/safire/client.rb
@@ -1,10 +1,11 @@
 module Safire
   # Unified facade client for SMART and UDAP protocol support.
   #
-  # This class is the main entry point for integrating SMART authorization via Safire.
-  # It supports discovery of server metadata and provides a unified interface for building
-  # authorization URLs, exchanging authorization codes, refreshing tokens, and requesting
-  # backend services access tokens (client_credentials grant).
+  # This class is the main entry point for integrating SMART authorization and UDAP discovery
+  # or registration via Safire. It supports discovery of server metadata and provides a unified
+  # interface for building authorization URLs, exchanging authorization codes, refreshing tokens,
+  # requesting backend services access tokens, and registering clients when the selected protocol
+  # implements Dynamic Client Registration.
   #
   # Configuration is provided via {Safire::ClientConfig} or a Hash. Key attributes:
   #
@@ -109,7 +110,7 @@ module Safire
   #   client = Safire::Client.new(config, client_type: :confidential_asymmetric)
   #   token_data = client.request_backend_token
   #
-  # @example Dynamic Client Registration – obtain a client_id before authorization flows
+  # @example SMART Dynamic Client Registration – obtain a client_id before authorization flows
   #   # Step 1 – create a temporary client (no client_id required)
   #   temp_client = Safire::Client.new({ base_url: 'https://fhir.example.com' })
   #
@@ -135,6 +136,31 @@ module Safire
   #       redirect_uri: 'https://myapp.example.com/callback',
   #       scopes:       ['openid', 'profile', 'patient/*.read']
   #     }
+  #   )
+  #
+  # @example UDAP Dynamic Client Registration – signed STU2 registration
+  #   temp_client = Safire::Client.new(
+  #     {
+  #       base_url: 'https://fhir.example.com',
+  #       private_key: File.read('client-key.pem'),
+  #       certificate_chain: [
+  #         File.read('client-cert.pem'),
+  #         File.read('issuing-ca.pem')
+  #       ]
+  #     },
+  #     protocol: :udap
+  #   )
+  #
+  #   registration = temp_client.register_client(
+  #     {
+  #       client_name: 'Example Backend Service',
+  #       contacts: ['mailto:security@example.com'],
+  #       grant_types: ['client_credentials'],
+  #       scope: 'system/Patient.rs system/Observation.rs'
+  #     },
+  #     client_uri: 'https://client.example.com',
+  #     trusted_anchors: [udap_ca],
+  #     crls: [udap_crl]
   #   )
   class Client
     extend Forwardable

--- a/lib/safire/protocols.rb
+++ b/lib/safire/protocols.rb
@@ -1,0 +1,6 @@
+module Safire
+  # Shared protocol namespace for protocol-level constants.
+  module Protocols
+    COMPACT_JWS_SEGMENT = /\A[A-Za-z0-9\-_]+\z/
+  end
+end

--- a/lib/safire/protocols/udap.rb
+++ b/lib/safire/protocols/udap.rb
@@ -3,11 +3,13 @@ module Safire
     # UDAP Security STU2 protocol implementation.
     #
     # Handles server metadata discovery from the UDAP well-known endpoint
-    # (per {https://hl7.org/fhir/us/udap-security/STU2/discovery.html STU2 §2}).
-    # Results are cached per community within each instance.
+    # (per {https://hl7.org/fhir/us/udap-security/STU2/discovery.html STU2 §2})
+    # and Dynamic Client Registration (per
+    # {https://hl7.org/fhir/us/udap-security/STU2/registration.html STU2 §3}).
+    # Discovery results are cached per community within each instance.
     #
-    # All other UDAP flows (B2B client credentials, B2C authorization code,
-    # Tiered OAuth, Dynamic Client Registration) raise {NotImplementedError}
+    # Other UDAP flows (B2B client credentials token acquisition, B2C authorization
+    # code, Tiered OAuth, and registration cancellation) raise +NotImplementedError+
     # and are planned for future PRs.
     #
     # This is an internal class used exclusively by {Safire::Client}. Do not
@@ -17,12 +19,18 @@ module Safire
     # @api private
     class Udap
       include Behaviours
+      include OAuthResponseHandling
 
       WELL_KNOWN_PATH = '/.well-known/udap'.freeze
+      REGISTRATION_HEADERS = { content_type: 'application/json' }.freeze
+      private_constant :REGISTRATION_HEADERS
 
       def initialize(config)
         @base_url = config.base_url
         @allow_insecure_localhost = config.allow_insecure_localhost
+        @private_key = config.private_key
+        @certificate_chain = config.certificate_chain
+        @jwt_algorithm = config.jwt_algorithm
         @http_client = Safire::HTTPClient.new(allow_insecure_localhost: @allow_insecure_localhost)
         @metadata_cache = {}
       end
@@ -75,7 +83,184 @@ module Safire
         entry.fetch(:metadata)
       end
 
+      # Dynamically registers or modifies a UDAP client using STU2 Dynamic Client Registration.
+      #
+      # UDAP registration is discovery-bound: Safire first discovers and validates
+      # UDAP metadata, then posts a fixed request envelope to the discovered
+      # +registration_endpoint+. The caller-provided metadata is validated and signed
+      # into the +software_statement+ JWT; it is not duplicated at the top level.
+      #
+      # Calling this method again with the same +client_uri+ and community requests
+      # modification of the existing registration. Safire accepts both 201 Created
+      # and update-style 200 responses as long as the response is a JSON object with
+      # a non-blank string +client_id+.
+      #
+      # @param metadata [Hash] caller-controlled UDAP registration metadata
+      # @param client_uri [String] exact URI used as +iss+ and +sub+ and required
+      #   to appear as a URI SAN in the leaf certificate
+      # @param community [String, nil] optional UDAP community URI for discovery
+      # @param certifications [Array<String>, nil] optional third-party certification
+      #   JWTs; +nil+ omits the field and +[]+ sends an explicit empty collection
+      # @param trusted_anchors [Array<OpenSSL::X509::Certificate>] server trust anchors
+      #   for signed metadata validation
+      # @param crls [Array<OpenSSL::X509::CRL>] revocation lists for signed metadata validation
+      # @param revocation_checker [#call, nil] custom server certificate revocation policy
+      # @param verify_chain [Boolean] whether discovery signed_metadata chain validation is required
+      # @param private_key [OpenSSL::PKey::RSA, OpenSSL::PKey::EC, String, nil]
+      #   client signing private key; defaults to configuration
+      # @param certificate_chain [Array<String, OpenSSL::X509::Certificate>, nil]
+      #   leaf-first client signing certificate chain; defaults to configuration
+      # @param jwt_algorithm [String, nil] optional explicit registration signing algorithm
+      # @return [Hash] registration response from the authorization server
+      # @raise [Safire::Errors::DiscoveryError] when UDAP discovery is unavailable,
+      #   structurally non-conformant for registration, or does not advertise UDAP DCR
+      # @raise [Safire::Errors::ValidationError] when caller metadata or certifications are invalid
+      # @raise [Safire::Errors::ConfigurationError] when signing configuration is missing or incompatible
+      # @raise [Safire::Errors::CertificateError] when the client certificate chain cannot support signing
+      # @raise [Safire::Errors::RegistrationError] when the server rejects registration or returns malformed success
+      # @raise [Safire::Errors::NetworkError] on connection failure, timeout, SSL error,
+      #   or a redirect to a non-HTTPS URL
+      def register_client(metadata, client_uri:, community: nil, certifications: nil, trusted_anchors: [],
+                          crls: [], revocation_checker: nil, verify_chain: true,
+                          private_key: @private_key, certificate_chain: @certificate_chain,
+                          jwt_algorithm: @jwt_algorithm)
+        community = normalize_community(community)
+        discovered = registration_server_metadata(
+          community:,
+          trusted_anchors:,
+          crls:,
+          revocation_checker:,
+          verify_chain:
+        )
+        certifications = validate_certifications!(certifications, discovered)
+        software_statement = registration_software_statement(
+          metadata,
+          discovered,
+          client_uri:,
+          private_key:,
+          certificate_chain:,
+          jwt_algorithm:
+        )
+        post_registration(discovered.registration_endpoint, software_statement, certifications)
+      rescue Faraday::Error => e
+        raise registration_error_from(e)
+      end
+
       private
+
+      def registration_server_metadata(community:, trusted_anchors:, crls:, revocation_checker:, verify_chain:)
+        discovered = server_metadata(community:, trusted_anchors:, crls:, revocation_checker:, verify_chain:)
+        validate_registration_discovery!(discovered, community:)
+        discovered
+      end
+
+      def validate_registration_discovery!(metadata, community:)
+        unless metadata.valid?
+          registration_discovery_error!(
+            'UDAP metadata is not structurally conformant for Dynamic Client Registration',
+            community
+          )
+        end
+
+        return if metadata.supports_dynamic_registration?
+
+        registration_discovery_error!(
+          'server does not advertise UDAP Dynamic Client Registration support',
+          community
+        )
+      end
+
+      def registration_discovery_error!(description, community)
+        raise Errors::DiscoveryError.new(
+          endpoint: well_known_endpoint(community:),
+          error_description: description,
+          label: 'UDAP metadata'
+        )
+      end
+
+      def validate_certifications!(certifications, metadata)
+        normalized = normalize_certifications!(certifications)
+        required = Array(metadata.udap_certifications_required)
+        return normalized if required.empty? || normalized.present?
+
+        raise Errors::ValidationError.new(
+          attribute: :certifications,
+          reason: 'must include certifications required by the UDAP community'
+        )
+      end
+
+      def normalize_certifications!(certifications)
+        return if certifications.nil?
+
+        unless certifications.is_a?(Array) && certifications.all? { |entry| compact_jws?(entry) }
+          raise Errors::ValidationError.new(
+            attribute: :certifications,
+            reason: 'must be nil or an array of compact JWS strings'
+          )
+        end
+
+        certifications.map { |entry| entry.dup.freeze }.freeze
+      end
+
+      def compact_jws?(value)
+        return false unless value.is_a?(String) && value.present?
+
+        parts = value.split('.', -1)
+        parts.length == 3 && parts.all? { |part| Safire::Protocols::COMPACT_JWS_SEGMENT.match?(part) }
+      end
+
+      def registration_software_statement(metadata, discovered, client_uri:, private_key:, certificate_chain:,
+                                          jwt_algorithm:)
+        registration_metadata = UdapRegistrationMetadata.new(
+          metadata,
+          allow_insecure_localhost: @allow_insecure_localhost
+        )
+        build_software_statement(
+          registration_metadata,
+          discovered,
+          client_uri:,
+          private_key:,
+          certificate_chain:,
+          jwt_algorithm:
+        )
+      end
+
+      def build_software_statement(metadata, discovered, client_uri:, private_key:, certificate_chain:, jwt_algorithm:)
+        UdapSoftwareStatement.new(
+          metadata:,
+          client_uri:,
+          registration_endpoint: discovered.registration_endpoint,
+          private_key:,
+          certificate_chain:,
+          supported_algorithms: discovered.registration_endpoint_jwt_signing_alg_values_supported,
+          algorithm: jwt_algorithm,
+          allow_insecure_localhost: @allow_insecure_localhost
+        )
+      end
+
+      def post_registration(endpoint, software_statement, certifications)
+        Safire.logger.info('Registering client via UDAP Dynamic Client Registration...')
+
+        response = @http_client.post(
+          endpoint,
+          body: registration_request_body(software_statement.to_jwt, certifications),
+          headers: REGISTRATION_HEADERS
+        )
+        parse_registration_response(response.body)
+      end
+
+      def registration_request_body(software_statement, certifications)
+        body = {
+          software_statement:,
+          udap: '1'
+        }
+        body[:certifications] = certifications unless certifications.nil?
+        body.to_json
+      end
+
+      def registration_error_from(faraday_error)
+        oauth_error_from(faraday_error, Errors::RegistrationError)
+      end
 
       def fetch_metadata(community:, trust_policy:)
         endpoint = well_known_endpoint(community:)

--- a/lib/safire/protocols/udap.rb
+++ b/lib/safire/protocols/udap.rb
@@ -23,7 +23,9 @@ module Safire
 
       WELL_KNOWN_PATH = '/.well-known/udap'.freeze
       REGISTRATION_HEADERS = { content_type: 'application/json' }.freeze
-      private_constant :REGISTRATION_HEADERS
+      SUCCESSFUL_REGISTRATION_STATUSES = [200, 201].freeze
+      MANDATORY_REGISTRATION_ALGORITHM = 'RS256'.freeze
+      private_constant :REGISTRATION_HEADERS, :SUCCESSFUL_REGISTRATION_STATUSES, :MANDATORY_REGISTRATION_ALGORITHM
 
       def initialize(config)
         @base_url = config.base_url
@@ -151,6 +153,7 @@ module Safire
       def registration_server_metadata(community:, trusted_anchors:, crls:, revocation_checker:, verify_chain:)
         discovered = server_metadata(community:, trusted_anchors:, crls:, revocation_checker:, verify_chain:)
         validate_registration_discovery!(discovered, community:)
+        validate_registration_signing_algorithms!(discovered, community:)
         discovered
       end
 
@@ -166,6 +169,16 @@ module Safire
 
         registration_discovery_error!(
           'server does not advertise UDAP Dynamic Client Registration support',
+          community
+        )
+      end
+
+      def validate_registration_signing_algorithms!(metadata, community:)
+        algorithms = metadata.registration_endpoint_jwt_signing_alg_values_supported
+        return if algorithms.include?(MANDATORY_REGISTRATION_ALGORITHM)
+
+        registration_discovery_error!(
+          "server does not advertise mandatory #{MANDATORY_REGISTRATION_ALGORITHM} registration signing support",
           community
         )
       end
@@ -246,7 +259,17 @@ module Safire
           body: registration_request_body(software_statement.to_jwt, certifications),
           headers: REGISTRATION_HEADERS
         )
+        validate_registration_response_status!(response)
         parse_registration_response(response.body)
+      end
+
+      def validate_registration_response_status!(response)
+        return if SUCCESSFUL_REGISTRATION_STATUSES.include?(response.status)
+
+        raise Errors::RegistrationError.new(
+          status: response.status,
+          error_description: 'unexpected registration response status'
+        )
       end
 
       def registration_request_body(software_statement, certifications)

--- a/lib/safire/protocols/udap_metadata.rb
+++ b/lib/safire/protocols/udap_metadata.rb
@@ -70,7 +70,6 @@ module Safire
 
       ATTRIBUTES = (REQUIRED_ATTRIBUTES | OPTIONAL_ATTRIBUTES).freeze
       STRING_URL_ATTRIBUTES = %i[token_endpoint registration_endpoint].freeze
-      BASE64URL_SEGMENT = /\A[A-Za-z0-9\-_]+\z/
       ARRAY_ATTRIBUTES = %i[
         udap_versions_supported
         udap_profiles_supported
@@ -328,7 +327,7 @@ module Safire
 
       def compact_jws_format?(value)
         parts = value.split('.', -1)
-        parts.length == 3 && parts.all? { |p| BASE64URL_SEGMENT.match?(p) }
+        parts.length == 3 && parts.all? { |part| Safire::Protocols::COMPACT_JWS_SEGMENT.match?(part) }
       end
 
       def valid_endpoint_url?(value)

--- a/spec/integration/udap_dcr_flow_spec.rb
+++ b/spec/integration/udap_dcr_flow_spec.rb
@@ -1,0 +1,150 @@
+require 'spec_helper'
+require_relative '../support/udap_certificate_helpers'
+
+RSpec.describe 'UDAP Dynamic Client Registration Flow', type: :integration do
+  include UdapCertificateHelpers
+
+  let(:base_url) { 'https://fhir.example.com' }
+  let(:well_known_url) { "#{base_url}/.well-known/udap" }
+  let(:registration_endpoint) { "#{base_url}/register" }
+  let(:token_endpoint) { "#{base_url}/token" }
+  let(:client_uri) { 'https://client.example.com/app' }
+  let(:private_key) { OpenSSL::PKey::RSA.generate(2048) }
+  let(:certificate) { build_udap_certificate(key: private_key, uri_san: client_uri) }
+  let(:client) do
+    Safire::Client.new(
+      {
+        base_url:,
+        private_key:,
+        certificate_chain: [certificate]
+      },
+      protocol: :udap
+    )
+  end
+  let(:registration_metadata) do
+    {
+      client_name: 'Example Backend Service',
+      contacts: ['mailto:security@example.com'],
+      grant_types: ['client_credentials'],
+      scope: 'system/Patient.rs'
+    }
+  end
+  let(:udap_metadata) do
+    {
+      'udap_versions_supported' => ['1'],
+      'udap_profiles_supported' => %w[udap_dcr udap_authn udap_authz],
+      'udap_authorization_extensions_supported' => [],
+      'udap_certifications_supported' => [],
+      'grant_types_supported' => ['client_credentials'],
+      'scopes_supported' => ['system/*.rs'],
+      'token_endpoint' => token_endpoint,
+      'token_endpoint_auth_methods_supported' => ['private_key_jwt'],
+      'token_endpoint_auth_signing_alg_values_supported' => ['RS256'],
+      'registration_endpoint' => "#{base_url}/unsigned-register",
+      'registration_endpoint_jwt_signing_alg_values_supported' => ['RS256'],
+      'signed_metadata' => 'eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwcyJ9.c2ln'
+    }
+  end
+  let(:registration_response) do
+    {
+      'client_id' => 'udap-client-123',
+      'client_name' => 'Example Backend Service'
+    }
+  end
+  let(:registration_requests) { [] }
+
+  def stub_udap_discovery(community: nil, body: udap_metadata)
+    request = stub_request(:get, well_known_url)
+    request = request.with(query: { 'community' => community }) if community
+    request.to_return(status: 200, body: body.to_json, headers: { 'Content-Type' => 'application/json' })
+  end
+
+  def stub_signed_metadata_validation
+    validator = instance_double(
+      Safire::Protocols::UdapSignedMetadataValidator,
+      signed_endpoint_claims: {
+        'token_endpoint' => token_endpoint,
+        'registration_endpoint' => registration_endpoint
+      }
+    )
+    allow(Safire::Protocols::UdapSignedMetadataValidator).to receive(:new).and_return(validator)
+  end
+
+  def stub_registration_response(status: 201, body: registration_response)
+    stub_request(:post, registration_endpoint)
+      .with { |request| registration_requests << request.body }
+      .to_return(status:, body: body.to_json, headers: { 'Content-Type' => 'application/json' })
+  end
+
+  def decoded_software_statement
+    jwt = JSON.parse(registration_requests.last)['software_statement']
+    JWT.decode(jwt, certificate.public_key, true, algorithms: ['RS256'], verify_expiration: false).first
+  end
+
+  before do
+    stub_signed_metadata_validation
+  end
+
+  it 'discovers UDAP metadata, posts a signed registration envelope, and returns client_id' do
+    stub_udap_discovery
+    stub_registration_response
+
+    result = client.register_client(registration_metadata, client_uri:)
+
+    expect(result['client_id']).to eq('udap-client-123')
+    expect(WebMock).to have_requested(:post, registration_endpoint)
+  end
+
+  it 'uses the signed registration endpoint claim as the software statement audience' do
+    stub_udap_discovery
+    stub_registration_response
+
+    client.register_client(registration_metadata, client_uri:)
+
+    payload = decoded_software_statement
+    expect(payload).to include(
+      'iss' => client_uri,
+      'sub' => client_uri,
+      'aud' => registration_endpoint,
+      'client_name' => 'Example Backend Service',
+      'token_endpoint_auth_method' => 'private_key_jwt'
+    )
+  end
+
+  it 'scopes discovery by community when provided' do
+    community = 'https://community.example.com/udap'
+    stub_udap_discovery(community:)
+    stub_registration_response
+
+    client.register_client(registration_metadata, client_uri:, community:)
+
+    expect(WebMock).to have_requested(:get, well_known_url).with(query: { 'community' => community })
+  end
+
+  it 'accepts update-style 200 registration responses when client_id is present' do
+    stub_udap_discovery
+    stub_registration_response(status: 200)
+
+    expect(client.register_client(registration_metadata, client_uri:)['client_id']).to eq('udap-client-123')
+  end
+
+  it 'raises DiscoveryError before POST when the server does not advertise UDAP DCR' do
+    stub_udap_discovery(body: udap_metadata.merge('udap_profiles_supported' => %w[udap_authn udap_authz]))
+
+    expect { client.register_client(registration_metadata, client_uri:) }
+      .to raise_error(Safire::Errors::DiscoveryError, /Dynamic Client Registration/)
+    expect(WebMock).not_to have_requested(:post, registration_endpoint)
+  end
+
+  it 'raises RegistrationError for a UDAP registration error response' do
+    stub_udap_discovery
+    stub_request(:post, registration_endpoint).to_return(
+      status: 400,
+      body: { 'error' => 'invalid_software_statement' }.to_json,
+      headers: { 'Content-Type' => 'application/json' }
+    )
+
+    expect { client.register_client(registration_metadata, client_uri:) }
+      .to raise_error(Safire::Errors::RegistrationError, /invalid_software_statement/)
+  end
+end

--- a/spec/safire/protocols/udap_spec.rb
+++ b/spec/safire/protocols/udap_spec.rb
@@ -9,9 +9,15 @@ RSpec.describe Safire::Protocols::Udap do
     instance_double(
       Safire::ClientConfig,
       base_url:,
-      allow_insecure_localhost:
+      allow_insecure_localhost:,
+      private_key: configured_private_key,
+      certificate_chain: configured_certificate_chain,
+      jwt_algorithm: configured_jwt_algorithm
     )
   end
+  let(:configured_private_key) { 'configured-private-key' }
+  let(:configured_certificate_chain) { ['configured-certificate'] }
+  let(:configured_jwt_algorithm) { nil }
   let(:well_known_url) { "#{base_url}/.well-known/udap" }
 
   let(:valid_metadata) do
@@ -448,8 +454,326 @@ RSpec.describe Safire::Protocols::Udap do
   end
 
   describe '#register_client' do
-    it 'raises NotImplementedError' do
-      expect { udap.register_client({}) }.to raise_error(NotImplementedError)
+    let(:registration_endpoint) { 'https://fhir.example.com/signed-register' }
+    let(:client_uri) { 'https://client.example.com/app' }
+    let(:client_metadata) do
+      {
+        client_name: 'Example Backend Service',
+        contacts: ['mailto:security@example.com'],
+        grant_types: ['client_credentials'],
+        scope: 'system/Patient.rs'
+      }
+    end
+    let(:registration_response) do
+      {
+        'client_id' => 'udap-client-123',
+        'client_name' => 'Example Backend Service'
+      }
+    end
+    let(:registration_discovery_body) do
+      valid_metadata.merge(
+        'udap_profiles_supported' => %w[udap_dcr udap_authn udap_authz],
+        'registration_endpoint' => 'https://fhir.example.com/unsigned-register',
+        'registration_endpoint_jwt_signing_alg_values_supported' => %w[RS256 RS384]
+      )
+    end
+    let(:registration_signed_claims) do
+      {
+        'token_endpoint' => valid_metadata['token_endpoint'],
+        'registration_endpoint' => registration_endpoint
+      }
+    end
+    let(:registration_validator) do
+      instance_double(
+        Safire::Protocols::UdapSignedMetadataValidator,
+        signed_endpoint_claims: registration_signed_claims
+      )
+    end
+    let(:registration_metadata) { instance_double(Safire::Protocols::UdapRegistrationMetadata) }
+    let(:software_statement) { instance_double(Safire::Protocols::UdapSoftwareStatement, to_jwt: 'header.payload.sig') }
+
+    def stub_registration_discovery_for_community(community)
+      stub_request(:get, well_known_url)
+        .with(query: { 'community' => community })
+        .to_return(
+          status: 200,
+          body: registration_discovery_body.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+    end
+
+    before do
+      stub_udap(body: registration_discovery_body)
+      allow(Safire::Protocols::UdapSignedMetadataValidator).to receive(:new).and_return(registration_validator)
+      allow(Safire::Protocols::UdapRegistrationMetadata).to receive(:new).and_return(registration_metadata)
+      allow(Safire::Protocols::UdapSoftwareStatement).to receive(:new).and_return(software_statement)
+      stub_request(:post, registration_endpoint)
+        .to_return(status: 201, body: registration_response.to_json, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns the parsed registration response' do
+      expect(udap.register_client(client_metadata, client_uri:)).to eq(registration_response)
+    end
+
+    it 'scopes discovery by community' do
+      community = 'https://community.example.com/udap'
+
+      stub_registration_discovery_for_community(community)
+      udap.register_client(client_metadata, client_uri:, community:)
+
+      expect(WebMock).to have_requested(:get, well_known_url).with(query: { 'community' => community })
+    end
+
+    it 'passes the server trust policy to signed metadata validation' do
+      anchor = instance_double(OpenSSL::X509::Certificate, to_der: 'anchor')
+      crl = instance_double(OpenSSL::X509::CRL, to_der: 'crl')
+      checker = ->(**_kwargs) { true }
+
+      udap.register_client(
+        client_metadata,
+        client_uri:,
+        trusted_anchors: [anchor],
+        crls: [crl],
+        revocation_checker: checker,
+        verify_chain: false
+      )
+
+      expect(registration_validator).to have_received(:signed_endpoint_claims).with(
+        base_url: base_url,
+        trusted_anchors: [anchor],
+        crls: [crl],
+        revocation_checker: checker,
+        verify_chain: false,
+        allow_insecure_localhost: false
+      )
+    end
+
+    it 'builds validated registration metadata with the configured localhost policy' do
+      udap.register_client(client_metadata, client_uri:)
+
+      expect(Safire::Protocols::UdapRegistrationMetadata).to have_received(:new).with(
+        client_metadata,
+        allow_insecure_localhost: false
+      )
+    end
+
+    context 'when insecure localhost is enabled in config' do
+      let(:allow_insecure_localhost) { true }
+
+      it 'passes the development policy to the registration metadata builder' do
+        udap.register_client(client_metadata, client_uri:)
+
+        expect(Safire::Protocols::UdapRegistrationMetadata).to have_received(:new).with(
+          client_metadata,
+          allow_insecure_localhost: true
+        )
+      end
+    end
+
+    it 'builds a software statement from configured signing defaults and discovered algorithms' do
+      udap.register_client(client_metadata, client_uri:)
+
+      expect(Safire::Protocols::UdapSoftwareStatement).to have_received(:new).with(
+        metadata: registration_metadata,
+        client_uri:,
+        registration_endpoint:,
+        private_key: configured_private_key,
+        certificate_chain: configured_certificate_chain,
+        supported_algorithms: %w[RS256 RS384],
+        algorithm: nil,
+        allow_insecure_localhost: false
+      )
+    end
+
+    it 'allows per-call signing credential overrides' do
+      udap.register_client(
+        client_metadata,
+        client_uri:,
+        private_key: 'override-key',
+        certificate_chain: ['override-cert'],
+        jwt_algorithm: 'RS384'
+      )
+
+      expect(Safire::Protocols::UdapSoftwareStatement).to have_received(:new).with(
+        hash_including(
+          private_key: 'override-key',
+          certificate_chain: ['override-cert'],
+          algorithm: 'RS384'
+        )
+      )
+    end
+
+    it 'POSTs the UDAP registration envelope as JSON without certifications when omitted' do
+      udap.register_client(client_metadata, client_uri:)
+
+      expect(WebMock).to(have_requested(:post, registration_endpoint).with do |request|
+        body = JSON.parse(request.body)
+        request.headers['Content-Type'].start_with?('application/json') &&
+          body == {
+            'software_statement' => 'header.payload.sig',
+            'udap' => '1'
+          }
+      end)
+    end
+
+    it 'preserves an explicit empty certifications array in the request envelope' do
+      udap.register_client(client_metadata, client_uri:, certifications: [])
+
+      expect(WebMock).to(have_requested(:post, registration_endpoint).with do |request|
+        JSON.parse(request.body)['certifications'] == []
+      end)
+    end
+
+    it 'includes caller-supplied certification JWTs without decoding or verifying them' do
+      certifications = ['eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJjZXJ0In0.c2ln']
+
+      udap.register_client(client_metadata, client_uri:, certifications:)
+
+      expect(WebMock).to(have_requested(:post, registration_endpoint).with do |request|
+        JSON.parse(request.body)['certifications'] == certifications
+      end)
+    end
+
+    it 'raises DiscoveryError when discovered metadata is structurally non-conformant' do
+      stub_udap(
+        body: registration_discovery_body.merge(
+          'registration_endpoint_jwt_signing_alg_values_supported' => []
+        )
+      )
+
+      expect { udap.register_client(client_metadata, client_uri:) }
+        .to raise_error(Safire::Errors::DiscoveryError, /structurally conformant/)
+      expect(WebMock).not_to have_requested(:post, registration_endpoint)
+    end
+
+    it 'raises DiscoveryError when the server does not advertise UDAP DCR capability' do
+      stub_udap(
+        body: registration_discovery_body.merge(
+          'udap_profiles_supported' => %w[udap_authn udap_authz]
+        )
+      )
+
+      expect { udap.register_client(client_metadata, client_uri:) }
+        .to raise_error(Safire::Errors::DiscoveryError, /Dynamic Client Registration/)
+      expect(WebMock).not_to have_requested(:post, registration_endpoint)
+    end
+
+    context 'when the community requires certifications' do
+      let(:registration_discovery_body) do
+        super().merge(
+          'udap_certifications_supported' => ['https://policy.example/cert'],
+          'udap_certifications_required' => ['https://policy.example/cert']
+        )
+      end
+
+      it 'raises ValidationError when certifications are omitted' do
+        expect { udap.register_client(client_metadata, client_uri:) }
+          .to raise_error(Safire::Errors::ValidationError, /certifications/)
+        expect(Safire::Protocols::UdapSoftwareStatement).not_to have_received(:new)
+      end
+
+      it 'raises ValidationError when certifications are explicitly empty' do
+        expect { udap.register_client(client_metadata, client_uri:, certifications: []) }
+          .to raise_error(Safire::Errors::ValidationError, /certifications/)
+        expect(Safire::Protocols::UdapSoftwareStatement).not_to have_received(:new)
+      end
+
+      it 'accepts a compact-JWS certification value' do
+        udap.register_client(
+          client_metadata,
+          client_uri:,
+          certifications: ['eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJjZXJ0In0.c2ln']
+        )
+
+        expect(Safire::Protocols::UdapSoftwareStatement).to have_received(:new)
+      end
+    end
+
+    it 'raises ValidationError for malformed certification collections' do
+      expect { udap.register_client(client_metadata, client_uri:, certifications: ['not-a-jwt']) }
+        .to raise_error(Safire::Errors::ValidationError, /compact JWS/)
+      expect(Safire::Protocols::UdapSoftwareStatement).not_to have_received(:new)
+    end
+
+    context 'when the server returns an update-style 200 response' do
+      before do
+        stub_request(:post, registration_endpoint)
+          .to_return(
+            status: 200,
+            body: registration_response.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+      end
+
+      it 'accepts the response when client_id is present' do
+        expect(udap.register_client(client_metadata, client_uri:)).to eq(registration_response)
+      end
+    end
+
+    context 'when the server returns a UDAP registration error' do
+      before do
+        stub_request(:post, registration_endpoint).to_return(
+          status: 400,
+          body: {
+            'error' => 'invalid_software_statement',
+            'error_description' => 'signature failed'
+          }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+
+      it 'raises RegistrationError with the UDAP error code' do
+        error = capture_error(Safire::Errors::RegistrationError) do
+          udap.register_client(client_metadata, client_uri:)
+        end
+
+        expect(error.error_code).to eq('invalid_software_statement')
+        expect(error.error_description).to eq('signature failed')
+      end
+    end
+
+    context 'when the server returns unapproved_software_statement' do
+      before do
+        stub_request(:post, registration_endpoint).to_return(
+          status: 401,
+          body: { 'error' => 'unapproved_software_statement' }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+
+      it 'preserves the UDAP error code' do
+        error = capture_error(Safire::Errors::RegistrationError) do
+          udap.register_client(client_metadata, client_uri:)
+        end
+
+        expect(error.error_code).to eq('unapproved_software_statement')
+      end
+    end
+
+    context 'when the success response is malformed' do
+      before do
+        stub_request(:post, registration_endpoint)
+          .to_return(status: 201, body: { 'client_name' => 'Example' }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'raises RegistrationError before returning the response' do
+        expect { udap.register_client(client_metadata, client_uri:) }
+          .to raise_error(Safire::Errors::RegistrationError, /missing client_id/)
+      end
+    end
+
+    context 'when a network error occurs during registration' do
+      before { stub_request(:post, registration_endpoint).to_raise(Faraday::ConnectionFailed) }
+
+      it 'raises NetworkError' do
+        expect { udap.register_client(client_metadata, client_uri:) }
+          .to raise_error(Safire::Errors::NetworkError)
+      end
+    end
+
+    it 'does not accept a client_type keyword' do
+      expect { described_class.new(config, client_type: nil) }.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/safire/protocols/udap_spec.rb
+++ b/spec/safire/protocols/udap_spec.rb
@@ -658,6 +658,19 @@ RSpec.describe Safire::Protocols::Udap do
       expect(WebMock).not_to have_requested(:post, registration_endpoint)
     end
 
+    it 'raises DiscoveryError when the server omits mandatory RS256 registration signing support' do
+      stub_udap(
+        body: registration_discovery_body.merge(
+          'registration_endpoint_jwt_signing_alg_values_supported' => ['ES384']
+        )
+      )
+
+      expect { udap.register_client(client_metadata, client_uri:) }
+        .to raise_error(Safire::Errors::DiscoveryError, /RS256/)
+      expect(Safire::Protocols::UdapSoftwareStatement).not_to have_received(:new)
+      expect(WebMock).not_to have_requested(:post, registration_endpoint)
+    end
+
     context 'when the community requires certifications' do
       let(:registration_discovery_body) do
         super().merge(
@@ -707,6 +720,22 @@ RSpec.describe Safire::Protocols::Udap do
 
       it 'accepts the response when client_id is present' do
         expect(udap.register_client(client_metadata, client_uri:)).to eq(registration_response)
+      end
+    end
+
+    context 'when the server returns an unsupported 2xx response' do
+      before do
+        stub_request(:post, registration_endpoint)
+          .to_return(
+            status: 202,
+            body: registration_response.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+      end
+
+      it 'raises RegistrationError before parsing the body as a successful registration' do
+        expect { udap.register_client(client_metadata, client_uri:) }
+          .to raise_error(Safire::Errors::RegistrationError, /unexpected registration response status/)
       end
     end
 


### PR DESCRIPTION
Implements the UDAP Security STU2 Dynamic Client Registration protocol flow for `Safire::Client#register_client` when the client is initialized with `protocol: :udap`. The flow now discovers and validates UDAP metadata, honors signed endpoint precedence, validates registration capability before signing, builds a fresh X.509-backed software statement, posts the fixed UDAP registration envelope with optional certifications, and parses RFC 7591-shaped success and error responses.

This also updates the public UDAP DCR documentation, facade YARD examples, ADR notes, README, roadmap, troubleshooting guidance, and changelog so the implemented behavior is described consistently while registration cancellation and UDAP auth/token flows remain planned.

Validation performed:

- `bundle exec rspec`
- `bundle exec rspec spec/safire/protocols/udap_metadata_spec.rb spec/safire/protocols/udap_spec.rb spec/integration/udap_dcr_flow_spec.rb`
- `bundle exec rspec --tag live` (0 failures; external live examples pending because the sandbox cannot resolve the SMART reference server)
- `RUBOCOP_CACHE_ROOT=/tmp/rubocop-cache bundle exec rubocop`
- `bundle audit`
- `bundle exec ruby -e "require 'safire'"`
- `git diff --check`
- `bin/docs`
- `cd docs && bundle exec jekyll build`
