### PR TITLE
Add UDAP registration cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `Safire::Client#register_client` now supports UDAP Security STU2 Dynamic
-  Client Registration when initialized with `protocol: :udap`. Safire performs
-  discovery-bound registration, validates `signed_metadata`, checks
-  `UdapMetadata#valid?`, signs a fresh X.509-backed `software_statement`, posts
-  the fixed UDAP envelope with optional `certifications`, accepts new-registration
-  `201` and update-style `200` responses with a valid `client_id`, and preserves
-  UDAP registration error codes such as `invalid_software_statement` and
+- `Safire::Client#register_client` and `Safire::Client#cancel_registration` now
+  support the UDAP Security STU2 Dynamic Client Registration lifecycle when
+  initialized with `protocol: :udap`. Safire performs discovery-bound
+  registration, validates `signed_metadata`, checks `UdapMetadata#valid?`, signs
+  a fresh X.509-backed `software_statement`, posts the fixed UDAP envelope with
+  optional `certifications`, accepts new-registration `201` and update-style
+  `200` registration responses with a valid `client_id`, confirms cancellation
+  responses through an empty `grant_types` array, and preserves UDAP
+  registration error codes such as `invalid_software_statement` and
   `unapproved_software_statement`.
 - `Safire::Protocols::UdapRegistrationMetadata` validates and normalizes
   caller-controlled UDAP Security STU2 registration and cancellation metadata

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ metadata = client.server_metadata(community: 'https://udap.example.org/community
 Production UDAP discovery requires trust anchors plus an explicit certificate revocation policy
 (`crls:` or `revocation_checker:`). Use `verify_chain: false` only for development or tests.
 
-Dynamic Client Registration is also implemented for certificate-backed UDAP clients:
+Dynamic Client Registration is implemented for certificate-backed UDAP clients:
 
 ```ruby
 udap_client = Safire::Client.new(
@@ -64,9 +64,20 @@ registration = udap_client.register_client(
   trusted_anchors: [ca_cert],
   crls:            [ca_crl]
 )
+
+cancellation = udap_client.cancel_registration(
+  {
+    client_name: 'Example Backend Service',
+    contacts: ['mailto:security@example.com'],
+    scope: 'system/Patient.rs'
+  },
+  client_uri:      'https://client.example.com',
+  trusted_anchors: [ca_cert],
+  crls:            [ca_crl]
+)
 ```
 
-UDAP registration cancellation, JWT client authentication, and Tiered OAuth are planned. See [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md) for details.
+UDAP JWT client authentication and Tiered OAuth are planned. See [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md) for details.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,9 +38,11 @@ Feedback, bug reports, and pull requests are welcome via the [issue tracker](htt
 - **Demo Workflow** — Sinatra demo supports protocol-aware server setup and a
   UDAP Discovery screen with signed metadata trust status
 - **UDAP Dynamic Client Registration** — certificate-backed STU2 new
-  registration and modification via signed software statements; includes
-  metadata validation, signed endpoint precedence, community-scoped discovery,
-  certification envelope handling, and RFC 7591-shaped response parsing
+  registration, modification, and cancellation via signed software statements;
+  includes metadata validation, signed endpoint precedence, community-scoped
+  discovery, certification envelope handling, RFC 7591-shaped registration
+  response parsing, and cancellation confirmation through an empty
+  `grant_types` response
 
 ---
 
@@ -48,8 +50,6 @@ Feedback, bug reports, and pull requests are welcome via the [issue tracker](htt
 
 ### UDAP Security
 
-- **UDAP Registration Cancellation** — signed cancellation request with an empty
-  `grant_types` array and response confirmation
 - **UDAP JWT Client Auth** — B2B and consumer-facing authorization flows
 - **Tiered OAuth** — identity chaining for multi-system access
 
@@ -94,5 +94,5 @@ Feedback, bug reports, and pull requests are welcome via the [issue tracker](htt
 | ActiveSupport | ≥ 7.1, < 9 |
 | Rails (optional) | ≥ 7.1 |
 | SMART App Launch | 2.2.0 (STU2) |
-| UDAP Security | 2.0.0 (STU2 discovery and Dynamic Client Registration implemented; cancellation/auth flows planned) |
+| UDAP Security | 2.0.0 (STU2 discovery and Dynamic Client Registration lifecycle implemented; auth flows planned) |
 | FHIR | R4, R4B |

--- a/docs/adr/ADR-002-facade-and-forwardable.md
+++ b/docs/adr/ADR-002-facade-and-forwardable.md
@@ -43,7 +43,8 @@ class Client
                  :server_metadata, :authorization_url,
                  :request_access_token, :refresh_token,
                  :request_backend_token,
-                 :token_response_valid?, :register_client
+                 :token_response_valid?, :register_client,
+                 :cancel_registration
 
   private
 

--- a/docs/adr/ADR-012-udap-signed-metadata-validation.md
+++ b/docs/adr/ADR-012-udap-signed-metadata-validation.md
@@ -81,9 +81,10 @@ anchor set). Instances returned by `Udap#server_metadata` are already pre-valida
 
 UDAP Dynamic Client Registration is the first Safire flow that acts on
 discovered UDAP endpoints after discovery. `Protocols::Udap#register_client`
-uses the `registration_endpoint` from the `UdapMetadata` instance returned by
-`server_metadata`. Because `server_metadata` merges signed endpoint claims over
-unsigned JSON before constructing the entity, registration posts to the
+and `Protocols::Udap#cancel_registration` use the `registration_endpoint` from
+the `UdapMetadata` instance returned by `server_metadata`. Because
+`server_metadata` merges signed endpoint claims over unsigned JSON before
+constructing the entity, registration lifecycle requests post to the
 authoritative signed endpoint when signed and unsigned values differ.
 
 ---

--- a/docs/adr/ADR-013-udap-registration-request-model.md
+++ b/docs/adr/ADR-013-udap-registration-request-model.md
@@ -101,5 +101,6 @@ regular expression.
 - Extension metadata remains forward-compatible without permitting arbitrary
   Ruby objects into a JWT payload.
 - Metadata validation remains independent of software-statement signing and the
-  network registration flow. `Protocols::Udap#register_client` consumes this
-  value object when performing end-to-end UDAP registration.
+  network registration lifecycle. `Protocols::Udap#register_client` and
+  `Protocols::Udap#cancel_registration` consume this value object when
+  performing end-to-end UDAP registration operations.

--- a/docs/adr/ADR-014-udap-software-statement-signing.md
+++ b/docs/adr/ADR-014-udap-software-statement-signing.md
@@ -111,6 +111,7 @@ stubbing global randomness.
 - The generated JWT is short-lived: `exp` is always `iat + 300`.
 - Private keys, compact JWTs, and certificate contents are not included in
   validation error messages.
-- End-to-end UDAP registration uses this builder through
-  `Protocols::Udap#register_client`; applications should prefer the facade
-  method over direct software-statement construction.
+- End-to-end UDAP registration lifecycle operations use this builder through
+  `Protocols::Udap#register_client` and `Protocols::Udap#cancel_registration`;
+  applications should prefer the facade methods over direct software-statement
+  construction.

--- a/docs/configuration/client-setup.md
+++ b/docs/configuration/client-setup.md
@@ -65,7 +65,7 @@ Selects the authorization protocol. Defaults to `:smart`.
 | Value | Status | Description |
 |-------|--------|-------------|
 | `:smart` | Implemented | SMART App Launch 2.2.0 |
-| `:udap` | Partial | UDAP Security STU2 discovery and Dynamic Client Registration — `server_metadata` validates `signed_metadata`, supports optional `community:`, and accepts trust policy keywords (`trusted_anchors:`, `crls:`, `revocation_checker:`, `verify_chain:`); `register_client` submits certificate-backed UDAP registration requests; auth/token flows raise `NotImplementedError` |
+| `:udap` | Partial | UDAP Security STU2 discovery and Dynamic Client Registration — `server_metadata` validates `signed_metadata`, supports optional `community:`, and accepts trust policy keywords (`trusted_anchors:`, `crls:`, `revocation_checker:`, `verify_chain:`); `register_client` and `cancel_registration` submit certificate-backed UDAP registration lifecycle requests; auth/token flows raise `NotImplementedError` |
 
 For UDAP, `client_type:` is not applicable. Passing any explicit value, either at initialization or through `client.client_type=`, raises `Safire::Errors::ConfigurationError`. Future UDAP authentication flows will use signed JWT assertions rather than SMART client types.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,11 +41,11 @@ A lean Ruby gem implementing **[SMART App Launch](https://hl7.org/fhir/smart-app
 
 - Discovery (`/.well-known/udap`) with optional community scoping
 - Dynamic Client Registration metadata validation and normalization
-- X.509-backed software-statement signing and registration submission
+- X.509-backed software-statement signing for registration, modification, and cancellation
 
-Registration cancellation, JWT assertion authentication, and Tiered OAuth remain
-planned. See [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md)
-for details.
+JWT assertion authentication and Tiered OAuth remain planned. See
+[ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md) for
+details.
 
 ## Demo Application
 

--- a/docs/troubleshooting/client-errors.md
+++ b/docs/troubleshooting/client-errors.md
@@ -130,6 +130,31 @@ end
 Either response is a server-side protocol error and should not be treated as a
 successful registration.
 
+### `RegistrationError`: UDAP cancellation response does not confirm cancellation
+
+```
+Safire::Errors::RegistrationError: Client registration failed — HTTP 202 — cancellation response must include an empty grant_types array
+```
+
+UDAP registration cancellation is confirmed by the response body, not by a
+specific 2xx status code. Safire accepts a cancellation response only when it
+contains a non-blank string `client_id` and an empty `grant_types` array:
+
+```ruby
+cancellation = udap_client.cancel_registration(
+  metadata,
+  client_uri:      'https://client.example.com',
+  trusted_anchors: [ca_cert],
+  crls:            [ca_crl]
+)
+
+cancellation['grant_types'] # => []
+```
+
+If the response omits `grant_types`, returns a non-array value, or returns a
+non-empty array, treat it as a failed cancellation and investigate the
+authorization server response.
+
 ---
 
 ## Confidential Symmetric Client Errors

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -32,7 +32,7 @@ Safire raises typed errors so you can handle each failure category separately:
 | `Safire::Errors::DiscoveryError` | SMART or UDAP metadata discovery failed (HTTP error, invalid JSON, missing SMART `token_endpoint` when required, or UDAP `signed_metadata` validation failure) |
 | `Safire::Errors::ValidationError` | Caller-controlled input is invalid before a request is sent, such as UDAP registration metadata or certification JWT shape |
 | `Safire::Errors::CertificateError` | UDAP `x5c` certificate data could not be parsed or the configured UDAP client certificate chain cannot support signing |
-| `Safire::Errors::RegistrationError` | Dynamic Client Registration failed (server error, or 2xx response with a missing or invalid `client_id`) |
+| `Safire::Errors::RegistrationError` | Dynamic Client Registration failed (server error, 2xx response with a missing or invalid `client_id`, or UDAP cancellation response without an empty `grant_types` array) |
 | `Safire::Errors::TokenError` | Token exchange or refresh failed (OAuth error, missing fields) |
 | `Safire::Errors::NetworkError` | Transport-level failure (connection refused, timeout, blocked redirect) |
 

--- a/docs/udap.md
+++ b/docs/udap.md
@@ -14,9 +14,8 @@ has_children: true
 <div class="code-example" markdown="1">
 **Implemented now:** UDAP Security STU2 discovery (`/.well-known/udap`)
 including signed metadata validation and optional community scoping, plus
-certificate-backed Dynamic Client Registration for new registrations and
-modifications. Registration cancellation, JWT client authentication, and
-Tiered OAuth remain planned. See
+certificate-backed Dynamic Client Registration for registration, modification,
+and cancellation. JWT client authentication and Tiered OAuth remain planned. See
 [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md).
 </div>
 
@@ -164,7 +163,8 @@ UDAP Dynamic Client Registration is available through the same facade method as
 SMART registration, selected by `protocol: :udap`. Safire discovers and
 validates UDAP metadata, signs your registration metadata into a
 `software_statement`, posts the fixed UDAP request envelope, and returns the
-server's registration response.
+server's registration response. Use `register_client` for new registration and
+modification, and `cancel_registration` for cancellation.
 
 ```ruby
 client = Safire::Client.new(
@@ -194,7 +194,25 @@ registration = client.register_client(
 registration['client_id']
 ```
 
-Pass `community:` when registering within a specific UDAP trust community.
+Cancel an existing registration with the same discovery and trust policy:
+
+```ruby
+cancellation = client.cancel_registration(
+  {
+    client_name: 'Example Backend Service',
+    contacts: ['mailto:security@example.com'],
+    scope: 'system/Patient.rs system/Observation.rs'
+  },
+  client_uri:      'https://client.example.com',
+  trusted_anchors: [ca_cert],
+  crls:            [ca_crl]
+)
+
+cancellation['grant_types'] # => []
+```
+
+Pass `community:` when registering, modifying, or cancelling within a specific
+UDAP trust community.
 Pass `certifications:` when the community requires third-party certification
 JWTs. Safire shape-checks those JWT strings and sends them to the authorization
 server; it does not create, verify, or interpret certification contents.
@@ -221,8 +239,6 @@ certification handling, and error boundaries.
 
 ### Client Flows
 
-- **Registration cancellation** — cancel an existing UDAP registration by
-  submitting a signed cancellation request with an empty `grant_types` array
 - **JWT Client Authentication** — authenticate on every request using a signed JWT assertion (Authentication Token, AnT) with an X.509 certificate chain in the `x5c` header; the registered `client_id` is reused as `iss` and `sub` in each assertion
 - **Tiered OAuth** — delegated authorization for multi-system access per the UDAP Security IG
 - **Pushed Authorization Requests (RFC 9126)** — PAR support for pre-registering authorization requests

--- a/docs/udap/dynamic-client-registration/index.md
+++ b/docs/udap/dynamic-client-registration/index.md
@@ -14,8 +14,8 @@ has_children: true
 
 <div class="code-example" markdown="1">
 **Current status:** Safire implements UDAP Security STU2 new registration and
-registration modification through `Safire::Client#register_client`.
-Registration cancellation is planned separately.
+registration modification through `Safire::Client#register_client`, and
+registration cancellation through `Safire::Client#cancel_registration`.
 </div>
 
 ## Register a Client
@@ -70,6 +70,29 @@ Safire performs these steps:
 Calling `register_client` again with the same `client_uri` and community
 requests modification of the existing registration. Safire returns the server
 response without assuming the `client_id` is unchanged.
+
+Use `cancel_registration` to cancel an existing registration. Cancellation
+uses the same discovery, trust policy, certifications, and signing identity as
+registration, but Safire signs the metadata in cancellation mode and injects an
+empty `grant_types` array:
+
+```ruby
+cancellation = client.cancel_registration(
+  {
+    client_name: 'Example Backend Service',
+    contacts: ['mailto:security@example.com'],
+    scope: 'system/Patient.rs system/Observation.rs'
+  },
+  client_uri:      'https://client.example.com',
+  trusted_anchors: [ca_cert],
+  crls:            [ca_crl]
+)
+
+cancellation['grant_types'] # => []
+```
+
+See [Registration Lifecycle]({% link udap/dynamic-client-registration/lifecycle.md %})
+for modification and cancellation behavior.
 
 ### Authorization-code registration
 
@@ -139,7 +162,7 @@ contents.
 | `Safire::Errors::ValidationError` | Caller metadata or the `certifications:` collection is invalid before signing |
 | `Safire::Errors::ConfigurationError` | Signing configuration is missing or incompatible, such as an unsupported explicit `jwt_algorithm` |
 | `Safire::Errors::CertificateError` | The configured client certificate chain cannot support signing or does not match `client_uri:` |
-| `Safire::Errors::RegistrationError` | The registration server returns an OAuth error response, a response status other than `200` or `201`, or a successful response without a non-blank string `client_id` |
+| `Safire::Errors::RegistrationError` | The registration server returns an OAuth error response, a registration response status other than `200` or `201`, any successful response lacks a non-blank string `client_id`, or a cancellation response does not confirm cancellation with an empty `grant_types` array |
 | `Safire::Errors::NetworkError` | Connection failure, timeout, SSL error, or blocked non-HTTPS redirect |
 
 ## Validate Metadata
@@ -234,10 +257,9 @@ Exactly one primary grant is allowed. Unknown grant types, duplicate values,
 `refresh_token` without `authorization_code`, and combining
 `authorization_code` with `client_credentials` raise `ValidationError`.
 
-The metadata value object also has `operation: :cancel` as a foundation for the
-future cancellation workflow. Omit `grant_types`; Safire injects an empty array
-and excludes authorization-only metadata. The public `cancel_registration`
-method is not implemented yet.
+Cancellation uses the same value object with `operation: :cancel`. Omit
+`grant_types`; Safire injects an empty array and excludes authorization-only
+metadata.
 
 ```ruby
 cancellation = Safire::Protocols::UdapRegistrationMetadata.new(

--- a/docs/udap/dynamic-client-registration/lifecycle.md
+++ b/docs/udap/dynamic-client-registration/lifecycle.md
@@ -1,0 +1,91 @@
+---
+layout: default
+title: Registration Lifecycle
+parent: Dynamic Client Registration
+grand_parent: UDAP
+nav_order: 3
+permalink: /udap/dynamic-client-registration/lifecycle/
+description: "How Safire handles UDAP registration creation, modification, and cancellation."
+---
+
+# Registration Lifecycle
+
+{: .no_toc }
+
+UDAP Dynamic Client Registration uses one registration endpoint for new
+registration, modification, and cancellation. Safire keeps those lifecycle
+operations on the `Safire::Client` facade while preserving their different
+response rules.
+
+## Create or Modify
+
+Call `register_client` for both new registration and modification. A repeated
+call with the same `client_uri` and community requests modification of the
+existing registration.
+
+```ruby
+registration = client.register_client(
+  {
+    client_name: 'Example Backend Service',
+    contacts: ['mailto:security@example.com'],
+    grant_types: ['client_credentials'],
+    scope: 'system/Patient.rs'
+  },
+  client_uri:      'https://client.example.com',
+  trusted_anchors: [ca_cert],
+  crls:            [ca_crl]
+)
+```
+
+Safire accepts new-registration `201 Created` responses and update-style `200`
+responses. Either response must be a JSON object with a non-blank string
+`client_id`.
+
+## Cancel
+
+Call `cancel_registration` to cancel an existing registration. Provide the
+metadata that identifies the registration, but omit `grant_types`; Safire signs
+a cancellation software statement that contains `grant_types: []`.
+
+```ruby
+cancellation = client.cancel_registration(
+  {
+    client_name: 'Example Backend Service',
+    contacts: ['mailto:security@example.com'],
+    scope: 'system/Patient.rs'
+  },
+  client_uri:      'https://client.example.com',
+  trusted_anchors: [ca_cert],
+  crls:            [ca_crl]
+)
+
+cancellation['client_id']
+cancellation['grant_types'] # => []
+```
+
+Cancellation uses the same discovery-bound registration endpoint, community
+scoping, trust policy, `certifications:`, and X.509 signing configuration as
+`register_client`.
+
+Unlike registration, Safire does not require a specific 2xx status code for
+cancellation. UDAP Security STU2 confirms cancellation through the response
+body: the response must contain a non-blank string `client_id` and an empty
+`grant_types` array. A non-empty, missing, or non-array `grant_types` value
+raises `Safire::Errors::RegistrationError`.
+
+## Error Boundaries
+
+Both lifecycle methods raise the same Safire error families:
+
+| Error | Meaning |
+|-------|---------|
+| `Safire::Errors::DiscoveryError` | UDAP discovery failed, signed metadata was not trusted, metadata was structurally non-conformant for DCR, or the server did not advertise usable UDAP DCR capability |
+| `Safire::Errors::ValidationError` | Caller metadata or `certifications:` failed local validation before signing |
+| `Safire::Errors::ConfigurationError` | Signing configuration is missing or incompatible |
+| `Safire::Errors::CertificateError` | The private key, certificate chain, validity period, or `client_uri` SAN check failed |
+| `Safire::Errors::RegistrationError` | The registration endpoint returned an OAuth error response or a malformed success response |
+| `Safire::Errors::NetworkError` | The request failed at the transport layer |
+
+OAuth-style server errors preserve the server's `error` and
+`error_description`, including UDAP-specific codes such as
+`invalid_software_statement` and `unapproved_software_statement`.

--- a/docs/udap/dynamic-client-registration/software-statement.md
+++ b/docs/udap/dynamic-client-registration/software-statement.md
@@ -14,16 +14,17 @@ description: "How Safire builds UDAP Security STU2 X.509-backed software stateme
 
 <div class="code-example" markdown="1">
 **Current status:** Safire uses this signing layer internally when
-`Safire::Client#register_client` submits UDAP Security STU2 registration
-requests. Most applications should use `register_client` rather than construct
-software statements directly.
+`Safire::Client#register_client` and `Safire::Client#cancel_registration`
+submit UDAP Security STU2 registration lifecycle requests. Most applications
+should use those facade methods rather than construct software statements
+directly.
 </div>
 
 ## What Safire Builds
 
 UDAP registration metadata is signed into a compact JWS software statement
-inside `register_client`. The software statement carries the client
-registration parameters plus the required security claims:
+inside `register_client` and `cancel_registration`. The software statement
+carries the client registration parameters plus the required security claims:
 
 | Claim | Safire behavior |
 |-------|-----------------|

--- a/lib/safire/client.rb
+++ b/lib/safire/client.rb
@@ -162,6 +162,19 @@ module Safire
   #     trusted_anchors: [udap_ca],
   #     crls: [udap_crl]
   #   )
+  #
+  # @example UDAP registration cancellation – signed STU2 cancellation
+  #   cancellation = temp_client.cancel_registration(
+  #     {
+  #       client_name: 'Example Backend Service',
+  #       contacts: ['mailto:security@example.com'],
+  #       scope: 'system/Patient.rs system/Observation.rs'
+  #     },
+  #     client_uri: 'https://client.example.com',
+  #     trusted_anchors: [udap_ca],
+  #     crls: [udap_crl]
+  #   )
+  #   cancellation['grant_types'] # => []
   class Client
     extend Forwardable
 
@@ -178,7 +191,8 @@ module Safire
                    :server_metadata, :authorization_url,
                    :request_access_token, :refresh_token,
                    :request_backend_token,
-                   :token_response_valid?, :register_client
+                   :token_response_valid?, :register_client,
+                   :cancel_registration
 
     attr_reader :config, :protocol, :client_type
 

--- a/lib/safire/protocols/behaviours.rb
+++ b/lib/safire/protocols/behaviours.rb
@@ -55,6 +55,16 @@ module Safire
       def register_client(...)
         raise NotImplementedError, "#{self.class}#register_client is not implemented"
       end
+
+      # Cancels an existing dynamic client registration.
+      #
+      # Implementations should override this method when the protocol supports a
+      # cancellation lifecycle operation.
+      #
+      # @abstract
+      def cancel_registration(...)
+        raise NotImplementedError, "#{self.class}#cancel_registration is not implemented"
+      end
     end
   end
 end

--- a/lib/safire/protocols/udap.rb
+++ b/lib/safire/protocols/udap.rb
@@ -9,8 +9,8 @@ module Safire
     # Discovery results are cached per community within each instance.
     #
     # Other UDAP flows (B2B client credentials token acquisition, B2C authorization
-    # code, Tiered OAuth, and registration cancellation) raise +NotImplementedError+
-    # and are planned for future PRs.
+    # code, and Tiered OAuth) raise +NotImplementedError+ and are planned for
+    # future PRs.
     #
     # This is an internal class used exclusively by {Safire::Client}. Do not
     # instantiate it directly — use {Safire::Client} instead.
@@ -25,7 +25,10 @@ module Safire
       REGISTRATION_HEADERS = { content_type: 'application/json' }.freeze
       SUCCESSFUL_REGISTRATION_STATUSES = [200, 201].freeze
       MANDATORY_REGISTRATION_ALGORITHM = 'RS256'.freeze
-      private_constant :REGISTRATION_HEADERS, :SUCCESSFUL_REGISTRATION_STATUSES, :MANDATORY_REGISTRATION_ALGORITHM
+      REGISTER_ACTION = 'Registering client via UDAP Dynamic Client Registration...'.freeze
+      CANCEL_ACTION = 'Cancelling client registration via UDAP Dynamic Client Registration...'.freeze
+      private_constant :REGISTRATION_HEADERS, :SUCCESSFUL_REGISTRATION_STATUSES,
+                       :MANDATORY_REGISTRATION_ALGORITHM, :REGISTER_ACTION, :CANCEL_ACTION
 
       def initialize(config)
         @base_url = config.base_url
@@ -126,6 +129,102 @@ module Safire
                           crls: [], revocation_checker: nil, verify_chain: true,
                           private_key: @private_key, certificate_chain: @certificate_chain,
                           jwt_algorithm: @jwt_algorithm)
+        response = submit_registration_request(
+          metadata,
+          operation: :register,
+          action: REGISTER_ACTION,
+          client_uri:,
+          community:,
+          trusted_anchors:,
+          crls:,
+          revocation_checker:,
+          verify_chain:,
+          certifications:,
+          private_key:,
+          certificate_chain:,
+          jwt_algorithm:
+        )
+        validate_registration_response_status!(response)
+        parse_registration_response(response.body)
+      rescue Faraday::Error => e
+        raise registration_error_from(e)
+      end
+
+      # Cancels an existing UDAP Dynamic Client Registration.
+      #
+      # Cancellation uses the same discovery-bound endpoint, trust policy,
+      # certifications, and X.509-backed software-statement signing as
+      # {#register_client}. Safire builds the software statement in cancellation
+      # mode, which injects an empty +grant_types+ array and rejects any
+      # caller-supplied +grant_types+ value.
+      #
+      # STU2 defines cancellation confirmation by the successful response body:
+      # +client_id+ must be present and +grant_types+ must be an empty array.
+      #
+      # @param metadata [Hash] identifying UDAP client metadata; omit +grant_types+
+      # @param client_uri [String] exact URI used as +iss+ and +sub+ and required
+      #   to appear as a URI SAN in the leaf certificate
+      # @param community [String, nil] optional UDAP community URI for discovery
+      # @param certifications [Array<String>, nil] optional third-party certification
+      #   JWTs; +nil+ omits the field and +[]+ sends an explicit empty collection
+      # @param trusted_anchors [Array<OpenSSL::X509::Certificate>] server trust anchors
+      #   for signed metadata validation
+      # @param crls [Array<OpenSSL::X509::CRL>] revocation lists for signed metadata validation
+      # @param revocation_checker [#call, nil] custom server certificate revocation policy
+      # @param verify_chain [Boolean] whether discovery signed_metadata chain validation is required
+      # @param private_key [OpenSSL::PKey::RSA, OpenSSL::PKey::EC, String, nil]
+      #   client signing private key; defaults to configuration
+      # @param certificate_chain [Array<String, OpenSSL::X509::Certificate>, nil]
+      #   leaf-first client signing certificate chain; defaults to configuration
+      # @param jwt_algorithm [String, nil] optional explicit registration signing algorithm
+      # @return [Hash] cancellation response from the authorization server
+      # @raise [Safire::Errors::DiscoveryError] when UDAP discovery is unavailable,
+      #   structurally non-conformant for registration, or does not advertise UDAP DCR
+      # @raise [Safire::Errors::ValidationError] when caller metadata or certifications are invalid
+      # @raise [Safire::Errors::ConfigurationError] when signing configuration is missing or incompatible
+      # @raise [Safire::Errors::CertificateError] when the client certificate chain cannot support signing
+      # @raise [Safire::Errors::RegistrationError] when the server rejects cancellation or fails to confirm it
+      # @raise [Safire::Errors::NetworkError] on connection failure, timeout, SSL error,
+      #   or a redirect to a non-HTTPS URL
+      def cancel_registration(metadata, client_uri:, community: nil, certifications: nil, trusted_anchors: [],
+                              crls: [], revocation_checker: nil, verify_chain: true,
+                              private_key: @private_key, certificate_chain: @certificate_chain,
+                              jwt_algorithm: @jwt_algorithm)
+        response = submit_registration_request(
+          metadata,
+          operation: :cancel,
+          action: CANCEL_ACTION,
+          client_uri:,
+          community:,
+          trusted_anchors:,
+          crls:,
+          revocation_checker:,
+          verify_chain:,
+          certifications:,
+          private_key:,
+          certificate_chain:,
+          jwt_algorithm:
+        )
+        parse_cancellation_response(response)
+      rescue Faraday::Error => e
+        raise registration_error_from(e)
+      end
+
+      private
+
+      # Shared request preparation and POST for both :register and :cancel operations.
+      def submit_registration_request(metadata, operation:, action:, **)
+        endpoint, software_statement, certifications = prepare_registration_request(
+          metadata,
+          operation:,
+          **
+        )
+        post_registration_request(endpoint, software_statement, certifications, action:)
+      end
+
+      def prepare_registration_request(metadata, operation:, client_uri:, community:, trusted_anchors:, crls:,
+                                       revocation_checker:, verify_chain:, certifications:, private_key:,
+                                       certificate_chain:, jwt_algorithm:)
         community = normalize_community(community)
         discovered = registration_server_metadata(
           community:,
@@ -138,17 +237,14 @@ module Safire
         software_statement = registration_software_statement(
           metadata,
           discovered,
+          operation:,
           client_uri:,
           private_key:,
           certificate_chain:,
           jwt_algorithm:
         )
-        post_registration(discovered.registration_endpoint, software_statement, certifications)
-      rescue Faraday::Error => e
-        raise registration_error_from(e)
+        [discovered.registration_endpoint, software_statement, certifications]
       end
-
-      private
 
       def registration_server_metadata(community:, trusted_anchors:, crls:, revocation_checker:, verify_chain:)
         discovered = server_metadata(community:, trusted_anchors:, crls:, revocation_checker:, verify_chain:)
@@ -222,10 +318,11 @@ module Safire
         parts.length == 3 && parts.all? { |part| Safire::Protocols::COMPACT_JWS_SEGMENT.match?(part) }
       end
 
-      def registration_software_statement(metadata, discovered, client_uri:, private_key:, certificate_chain:,
-                                          jwt_algorithm:)
+      def registration_software_statement(metadata, discovered, operation:, client_uri:,
+                                          private_key:, certificate_chain:, jwt_algorithm:)
         registration_metadata = UdapRegistrationMetadata.new(
           metadata,
+          operation:,
           allow_insecure_localhost: @allow_insecure_localhost
         )
         build_software_statement(
@@ -251,16 +348,14 @@ module Safire
         )
       end
 
-      def post_registration(endpoint, software_statement, certifications)
-        Safire.logger.info('Registering client via UDAP Dynamic Client Registration...')
+      def post_registration_request(endpoint, software_statement, certifications, action:)
+        Safire.logger.info(action)
 
-        response = @http_client.post(
+        @http_client.post(
           endpoint,
           body: registration_request_body(software_statement.to_jwt, certifications),
           headers: REGISTRATION_HEADERS
         )
-        validate_registration_response_status!(response)
-        parse_registration_response(response.body)
       end
 
       def validate_registration_response_status!(response)
@@ -269,6 +364,16 @@ module Safire
         raise Errors::RegistrationError.new(
           status: response.status,
           error_description: 'unexpected registration response status'
+        )
+      end
+
+      def parse_cancellation_response(response)
+        parsed = parse_registration_response(response.body)
+        return parsed if parsed['grant_types'].is_a?(Array) && parsed['grant_types'].empty?
+
+        raise Errors::RegistrationError.new(
+          status: response.status,
+          error_description: 'cancellation response must include an empty grant_types array'
         )
       end
 

--- a/lib/safire/protocols/udap.rb
+++ b/lib/safire/protocols/udap.rb
@@ -24,10 +24,11 @@ module Safire
       WELL_KNOWN_PATH = '/.well-known/udap'.freeze
       REGISTRATION_HEADERS = { content_type: 'application/json' }.freeze
       SUCCESSFUL_REGISTRATION_STATUSES = [200, 201].freeze
+      SUCCESSFUL_CANCELLATION_STATUSES = 200..299
       MANDATORY_REGISTRATION_ALGORITHM = 'RS256'.freeze
       REGISTER_ACTION = 'Registering client via UDAP Dynamic Client Registration...'.freeze
       CANCEL_ACTION = 'Cancelling client registration via UDAP Dynamic Client Registration...'.freeze
-      private_constant :REGISTRATION_HEADERS, :SUCCESSFUL_REGISTRATION_STATUSES,
+      private_constant :REGISTRATION_HEADERS, :SUCCESSFUL_REGISTRATION_STATUSES, :SUCCESSFUL_CANCELLATION_STATUSES,
                        :MANDATORY_REGISTRATION_ALGORITHM, :REGISTER_ACTION, :CANCEL_ACTION
 
       def initialize(config)
@@ -368,12 +369,22 @@ module Safire
       end
 
       def parse_cancellation_response(response)
+        validate_cancellation_response_status!(response)
         parsed = parse_registration_response(response.body)
         return parsed if parsed['grant_types'].is_a?(Array) && parsed['grant_types'].empty?
 
         raise Errors::RegistrationError.new(
           status: response.status,
           error_description: 'cancellation response must include an empty grant_types array'
+        )
+      end
+
+      def validate_cancellation_response_status!(response)
+        return if SUCCESSFUL_CANCELLATION_STATUSES.cover?(response.status)
+
+        raise Errors::RegistrationError.new(
+          status: response.status,
+          error_description: 'unexpected cancellation response status'
         )
       end
 

--- a/spec/integration/udap_dcr_flow_spec.rb
+++ b/spec/integration/udap_dcr_flow_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe 'UDAP Dynamic Client Registration Flow', type: :integration do
       scope: 'system/Patient.rs'
     }
   end
+  let(:cancellation_metadata) { registration_metadata.except(:grant_types) }
   let(:udap_metadata) do
     {
       'udap_versions_supported' => ['1'],
@@ -126,6 +127,54 @@ RSpec.describe 'UDAP Dynamic Client Registration Flow', type: :integration do
     stub_registration_response(status: 200)
 
     expect(client.register_client(registration_metadata, client_uri:)['client_id']).to eq('udap-client-123')
+  end
+
+  it 'cancels registration with a signed empty grant_types claim' do
+    stub_udap_discovery
+    stub_registration_response(
+      status: 202,
+      body: { 'client_id' => 'udap-client-123', 'grant_types' => [] }
+    )
+
+    result = client.cancel_registration(cancellation_metadata, client_uri:)
+
+    expect(result).to include('client_id' => 'udap-client-123', 'grant_types' => [])
+    expect(decoded_software_statement).to include(
+      'iss' => client_uri,
+      'sub' => client_uri,
+      'aud' => registration_endpoint,
+      'grant_types' => []
+    )
+  end
+
+  it 'uses a fresh software statement for each cancellation request' do
+    stub_udap_discovery
+    stub_registration_response(body: { 'client_id' => 'udap-client-123', 'grant_types' => [] })
+
+    2.times { client.cancel_registration(cancellation_metadata, client_uri:) }
+
+    payloads = registration_requests.map do |body|
+      jwt = JSON.parse(body)['software_statement']
+      JWT.decode(jwt, certificate.public_key, true, algorithms: ['RS256'], verify_expiration: false).first
+    end
+    expect(payloads.map { |payload| payload['jti'] }.uniq.length).to eq(2)
+    expect(payloads).to all(satisfy { |payload| payload['exp'] == payload['iat'] + 300 })
+  end
+
+  it 'rejects caller-supplied cancellation grant_types before POSTing' do
+    stub_udap_discovery
+
+    expect { client.cancel_registration(registration_metadata, client_uri:) }
+      .to raise_error(Safire::Errors::ValidationError, /grant_types/)
+    expect(WebMock).not_to have_requested(:post, registration_endpoint)
+  end
+
+  it 'raises RegistrationError when cancellation response leaves grants active' do
+    stub_udap_discovery
+    stub_registration_response(body: { 'client_id' => 'udap-client-123', 'grant_types' => ['client_credentials'] })
+
+    expect { client.cancel_registration(cancellation_metadata, client_uri:) }
+      .to raise_error(Safire::Errors::RegistrationError, /empty grant_types/)
   end
 
   it 'raises DiscoveryError before POST when the server does not advertise UDAP DCR' do

--- a/spec/safire/client_spec.rb
+++ b/spec/safire/client_spec.rb
@@ -194,6 +194,27 @@ RSpec.describe Safire::Client do
     it 'raises NotImplementedError for unimplemented UDAP flows' do
       expect { udap_client.authorization_url }.to raise_error(NotImplementedError)
     end
+
+    it 'delegates cancel_registration to Protocols::Udap' do
+      response = { 'client_id' => 'udap-client-123', 'grant_types' => [] }
+      protocol_client = instance_double(Safire::Protocols::Udap, cancel_registration: response)
+      metadata = { client_name: 'Example', contacts: ['mailto:security@example.com'], scope: 'system/*.rs' }
+
+      allow(Safire::Protocols::Udap).to receive(:new).and_return(protocol_client)
+
+      result = described_class.new(config, protocol: :udap)
+                              .cancel_registration(metadata, client_uri: 'https://client.example.com')
+
+      expect(result).to eq(response)
+      expect(protocol_client).to have_received(:cancel_registration)
+        .with(metadata, client_uri: 'https://client.example.com')
+    end
+  end
+
+  describe '#cancel_registration' do
+    it 'raises NotImplementedError for SMART clients' do
+      expect { described_class.new(config).cancel_registration({}) }.to raise_error(NotImplementedError)
+    end
   end
 
   # ---------- Authorization URL ----------

--- a/spec/safire/protocols/behaviours_spec.rb
+++ b/spec/safire/protocols/behaviours_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Safire::Protocols::Behaviours do
   %i[
     server_metadata authorization_url request_access_token
     refresh_token token_response_valid? register_client request_backend_token
+    cancel_registration
   ].each do |method|
     it "##{method} raises NotImplementedError by default" do
       expect { instance.public_send(method) }.to raise_error(NotImplementedError)

--- a/spec/safire/protocols/smart_spec.rb
+++ b/spec/safire/protocols/smart_spec.rb
@@ -1270,4 +1270,10 @@ RSpec.describe Safire::Protocols::Smart do
       end
     end
   end
+
+  describe '#cancel_registration' do
+    it 'raises NotImplementedError' do
+      expect { described_class.new(config).cancel_registration }.to raise_error(NotImplementedError)
+    end
+  end
 end

--- a/spec/safire/protocols/udap_spec.rb
+++ b/spec/safire/protocols/udap_spec.rb
@@ -970,6 +970,22 @@ RSpec.describe Safire::Protocols::Udap do
       end
     end
 
+    context 'when the cancellation response has a final non-2xx status' do
+      before do
+        stub_request(:post, registration_endpoint)
+          .to_return(
+            status: 304,
+            body: cancellation_response.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+      end
+
+      it 'raises RegistrationError even when the body confirms cancellation' do
+        expect { udap.cancel_registration(client_metadata, client_uri:) }
+          .to raise_error(Safire::Errors::RegistrationError, /unexpected cancellation response status/)
+      end
+    end
+
     context 'when the server rejects the cancellation request' do
       before do
         stub_request(:post, registration_endpoint).to_return(

--- a/spec/safire/protocols/udap_spec.rb
+++ b/spec/safire/protocols/udap_spec.rb
@@ -553,6 +553,7 @@ RSpec.describe Safire::Protocols::Udap do
 
       expect(Safire::Protocols::UdapRegistrationMetadata).to have_received(:new).with(
         client_metadata,
+        operation: :register,
         allow_insecure_localhost: false
       )
     end
@@ -565,6 +566,7 @@ RSpec.describe Safire::Protocols::Udap do
 
         expect(Safire::Protocols::UdapRegistrationMetadata).to have_received(:new).with(
           client_metadata,
+          operation: :register,
           allow_insecure_localhost: true
         )
       end
@@ -803,6 +805,192 @@ RSpec.describe Safire::Protocols::Udap do
 
     it 'does not accept a client_type keyword' do
       expect { described_class.new(config, client_type: nil) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#cancel_registration' do
+    let(:registration_endpoint) { 'https://fhir.example.com/signed-register' }
+    let(:client_uri) { 'https://client.example.com/app' }
+    let(:client_metadata) do
+      {
+        client_name: 'Example Backend Service',
+        contacts: ['mailto:security@example.com'],
+        scope: 'system/Patient.rs'
+      }
+    end
+    let(:cancellation_response) do
+      {
+        'client_id' => 'udap-client-123',
+        'grant_types' => []
+      }
+    end
+    let(:registration_discovery_body) do
+      valid_metadata.merge(
+        'udap_profiles_supported' => %w[udap_dcr udap_authn udap_authz],
+        'registration_endpoint' => 'https://fhir.example.com/unsigned-register',
+        'registration_endpoint_jwt_signing_alg_values_supported' => %w[RS256 RS384]
+      )
+    end
+    let(:registration_signed_claims) do
+      {
+        'token_endpoint' => valid_metadata['token_endpoint'],
+        'registration_endpoint' => registration_endpoint
+      }
+    end
+    let(:registration_validator) do
+      instance_double(
+        Safire::Protocols::UdapSignedMetadataValidator,
+        signed_endpoint_claims: registration_signed_claims
+      )
+    end
+    let(:registration_metadata) { instance_double(Safire::Protocols::UdapRegistrationMetadata) }
+    let(:software_statement) { instance_double(Safire::Protocols::UdapSoftwareStatement, to_jwt: 'header.payload.sig') }
+
+    before do
+      stub_udap(body: registration_discovery_body)
+      allow(Safire::Protocols::UdapSignedMetadataValidator).to receive(:new).and_return(registration_validator)
+      allow(Safire::Protocols::UdapRegistrationMetadata).to receive(:new).and_return(registration_metadata)
+      allow(Safire::Protocols::UdapSoftwareStatement).to receive(:new).and_return(software_statement)
+      stub_request(:post, registration_endpoint)
+        .to_return(status: 202, body: cancellation_response.to_json, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns a body-confirmed cancellation response without requiring status 200' do
+      expect(udap.cancel_registration(client_metadata, client_uri:)).to eq(cancellation_response)
+    end
+
+    it 'builds cancellation metadata with an empty grant set' do
+      udap.cancel_registration(client_metadata, client_uri:)
+
+      expect(Safire::Protocols::UdapRegistrationMetadata).to have_received(:new).with(
+        client_metadata,
+        operation: :cancel,
+        allow_insecure_localhost: false
+      )
+    end
+
+    it 'uses the same discovered registration endpoint and UDAP request envelope' do
+      udap.cancel_registration(client_metadata, client_uri:)
+
+      expect(WebMock).to(have_requested(:post, registration_endpoint).with do |request|
+        body = JSON.parse(request.body)
+        request.headers['Content-Type'].start_with?('application/json') &&
+          body == {
+            'software_statement' => 'header.payload.sig',
+            'udap' => '1'
+          }
+      end)
+    end
+
+    it 'scopes cancellation discovery by community' do
+      community = 'https://community.example.com/udap'
+      stub_request(:get, well_known_url)
+        .with(query: { 'community' => community })
+        .to_return(
+          status: 200,
+          body: registration_discovery_body.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      udap.cancel_registration(
+        client_metadata,
+        client_uri:,
+        community:
+      )
+
+      expect(WebMock).to have_requested(:get, well_known_url).with(query: { 'community' => community })
+    end
+
+    it 'passes trust policy through discovery' do
+      anchor = instance_double(OpenSSL::X509::Certificate, to_der: 'anchor')
+      crl = instance_double(OpenSSL::X509::CRL, to_der: 'crl')
+      checker = ->(**_kwargs) { true }
+
+      udap.cancel_registration(
+        client_metadata,
+        client_uri:,
+        trusted_anchors: [anchor],
+        crls: [crl],
+        revocation_checker: checker,
+        verify_chain: false
+      )
+
+      expect(registration_validator).to have_received(:signed_endpoint_claims).with(
+        base_url: base_url,
+        trusted_anchors: [anchor],
+        crls: [crl],
+        revocation_checker: checker,
+        verify_chain: false,
+        allow_insecure_localhost: false
+      )
+    end
+
+    it 'preserves cancellation certifications in the UDAP request envelope' do
+      certifications = ['eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJjZXJ0In0.c2ln']
+
+      udap.cancel_registration(client_metadata, client_uri:, certifications:)
+
+      expect(WebMock).to(have_requested(:post, registration_endpoint).with do |request|
+        JSON.parse(request.body)['certifications'] == certifications
+      end)
+    end
+
+    [
+      ['missing grant_types', { 'client_id' => 'udap-client-123' }],
+      ['non-array grant_types', { 'client_id' => 'udap-client-123', 'grant_types' => 'client_credentials' }],
+      ['non-empty grant_types', { 'client_id' => 'udap-client-123', 'grant_types' => ['client_credentials'] }]
+    ].each do |description, response_body|
+      context "when the cancellation response has #{description}" do
+        before do
+          stub_request(:post, registration_endpoint)
+            .to_return(
+              status: 200,
+              body: response_body.to_json,
+              headers: { 'Content-Type' => 'application/json' }
+            )
+        end
+
+        it 'raises RegistrationError' do
+          expect { udap.cancel_registration(client_metadata, client_uri:) }
+            .to raise_error(Safire::Errors::RegistrationError, /empty grant_types/)
+        end
+      end
+    end
+
+    context 'when the cancellation response is missing client_id' do
+      before do
+        stub_request(:post, registration_endpoint)
+          .to_return(status: 200, body: { 'grant_types' => [] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'raises RegistrationError through the RFC 7591 response parser' do
+        expect { udap.cancel_registration(client_metadata, client_uri:) }
+          .to raise_error(Safire::Errors::RegistrationError, /missing client_id/)
+      end
+    end
+
+    context 'when the server rejects the cancellation request' do
+      before do
+        stub_request(:post, registration_endpoint).to_return(
+          status: 400,
+          body: {
+            'error' => 'invalid_software_statement',
+            'error_description' => 'signature failed'
+          }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+
+      it 'raises RegistrationError with the server error code' do
+        error = capture_error(Safire::Errors::RegistrationError) do
+          udap.cancel_registration(client_metadata, client_uri:)
+        end
+
+        expect(error.status).to eq(400)
+        expect(error.error_code).to eq('invalid_software_statement')
+        expect(error.error_description).to eq('signature failed')
+      end
     end
   end
 end


### PR DESCRIPTION
Summary

Adds UDAP Security STU2 registration cancellation through Safire::Client#cancel_registration. The flow reuses the existing discovery-bound UDAP DCR request preparation, signs cancellation metadata with operation: :cancel, posts the standard UDAP envelope, and validates cancellation by response body confirmation with client_id plus an empty grant_types array. The PR also updates the UDAP lifecycle docs, troubleshooting, ADR references, README, changelog, and roadmap so cancellation is represented as implemented rather than planned.

Validation

- bundle exec rspec
- RUBOCOP_CACHE_ROOT=/tmp/rubocop-cache bundle exec rubocop
- bin/docs
- bundle exec jekyll build (from docs/)