### PR TITLE
Add UDAP demo credential foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Sinatra demo includes a protocol-aware UDAP Discovery workflow with
   community-scoped discovery, signed metadata validation status, and configurable
   UDAP trust material.
+- The Sinatra demo now separates UDAP server trust policy from UDAP client
+  signing credential configuration, documents the signing environment variables
+  needed for upcoming UDAP registration workflows, stores SMART and UDAP client
+  identifiers separately, and opts local SMART demo callbacks into Safire's
+  loopback-only HTTP development policy.
 - `Safire::Errors::DiscoveryError` accepts a `label:` keyword argument (default:
   `'SMART configuration'`) and exposes it as a readable attribute so callers can
   identify which protocol's discovery failed.

--- a/docs/troubleshooting/client-errors.md
+++ b/docs/troubleshooting/client-errors.md
@@ -137,8 +137,9 @@ Safire::Errors::RegistrationError: Client registration failed — HTTP 202 — c
 ```
 
 UDAP registration cancellation is confirmed by the response body, not by a
-specific 2xx status code. Safire accepts a cancellation response only when it
-contains a non-blank string `client_id` and an empty `grant_types` array:
+specific success status such as `200` or `201`. Safire accepts a cancellation
+response only when the final status is `2xx` and the body contains a non-blank
+string `client_id` plus an empty `grant_types` array:
 
 ```ruby
 cancellation = udap_client.cancel_registration(
@@ -151,9 +152,9 @@ cancellation = udap_client.cancel_registration(
 cancellation['grant_types'] # => []
 ```
 
-If the response omits `grant_types`, returns a non-array value, or returns a
-non-empty array, treat it as a failed cancellation and investigate the
-authorization server response.
+If the response status is not `2xx`, or if the body omits `grant_types`, returns
+a non-array value, or returns a non-empty array, treat it as a failed
+cancellation and investigate the authorization server response.
 
 ---
 

--- a/docs/udap/dynamic-client-registration/lifecycle.md
+++ b/docs/udap/dynamic-client-registration/lifecycle.md
@@ -67,11 +67,12 @@ Cancellation uses the same discovery-bound registration endpoint, community
 scoping, trust policy, `certifications:`, and X.509 signing configuration as
 `register_client`.
 
-Unlike registration, Safire does not require a specific 2xx status code for
-cancellation. UDAP Security STU2 confirms cancellation through the response
+Unlike registration, Safire does not require a specific success status such as
+`200` or `201` for cancellation, but the final HTTP response must still be a
+successful `2xx`. UDAP Security STU2 confirms cancellation through the response
 body: the response must contain a non-blank string `client_id` and an empty
-`grant_types` array. A non-empty, missing, or non-array `grant_types` value
-raises `Safire::Errors::RegistrationError`.
+`grant_types` array. A final non-`2xx` status, or a non-empty, missing, or
+non-array `grant_types` value, raises `Safire::Errors::RegistrationError`.
 
 ## Error Boundaries
 

--- a/examples/sinatra_app/.env.example
+++ b/examples/sinatra_app/.env.example
@@ -46,6 +46,36 @@ UDAP_CRLS_PEM=""
 UDAP_VERIFY_CHAIN=""
 
 # ============================================
+# UDAP Client Signing Credentials (optional)
+# ============================================
+# These are CLIENT-level credentials used to sign UDAP Dynamic Client
+# Registration software statements. They are separate from the server trust
+# anchors above.
+
+# Private key in PEM format. The public key must match the leaf certificate in
+# UDAP_CLIENT_CERTIFICATE_CHAIN_PEM.
+# Example value:
+# UDAP_CLIENT_PRIVATE_KEY_PEM="-----BEGIN PRIVATE KEY-----
+# ...your UDAP client private key content here...
+# -----END PRIVATE KEY-----"
+UDAP_CLIENT_PRIVATE_KEY_PEM=""
+
+# Leaf-first, issuer-ordered certificate chain in PEM format.
+# Example value:
+# UDAP_CLIENT_CERTIFICATE_CHAIN_PEM="-----BEGIN CERTIFICATE-----
+# ...your UDAP client leaf certificate...
+# -----END CERTIFICATE-----
+# -----BEGIN CERTIFICATE-----
+# ...optional issuing certificate...
+# -----END CERTIFICATE-----"
+UDAP_CLIENT_CERTIFICATE_CHAIN_PEM=""
+
+# Optional explicit software-statement signing algorithm.
+# Supported values: RS256, RS384, ES256, ES384.
+# Leave blank to let Safire select a compatible algorithm from UDAP discovery.
+UDAP_REGISTRATION_SIGNING_ALGORITHM=""
+
+# ============================================
 # Notes on Asymmetric Authentication
 # ============================================
 #

--- a/examples/sinatra_app/README.md
+++ b/examples/sinatra_app/README.md
@@ -41,6 +41,11 @@ bundle exec puma config.ru -p 4567
 
 Then visit http://localhost:4567
 
+When the demo runs on local HTTP loopback, it opts Safire clients into
+`allow_insecure_localhost: true` only for localhost/127.0.0.1 URLs. This keeps
+the local SMART callback and local test servers usable while preserving
+Safire's HTTPS-only default for remote hosts.
+
 ## Configuration
 
 ### Environment Variables
@@ -53,9 +58,12 @@ Copy `.env.example` to `.env` and configure:
 | `SESSION_SECRET` | No | Session encryption key (auto-generated if not set) |
 | `ASYMMETRIC_PRIVATE_KEY_PEM` | No | Private key in PEM format for asymmetric auth |
 | `ASYMMETRIC_KID` | No | Key ID matching your registered JWKS |
-| `UDAP_TRUST_ANCHORS_PEM` | No | PEM-encoded UDAP signing certificate trust anchors |
-| `UDAP_CRLS_PEM` | No | PEM-encoded CRLs for UDAP signing certificate revocation checks |
+| `UDAP_TRUST_ANCHORS_PEM` | No | PEM-encoded UDAP server signing certificate trust anchors |
+| `UDAP_CRLS_PEM` | No | PEM-encoded CRLs for UDAP server signing certificate revocation checks |
 | `UDAP_VERIFY_CHAIN` | No | Optional override for UDAP signed metadata chain validation (`1/true/yes/on` or `0/false/no/off`; unknown values raise a configuration error) |
+| `UDAP_CLIENT_PRIVATE_KEY_PEM` | No | PEM-encoded client private key for UDAP software-statement signing |
+| `UDAP_CLIENT_CERTIFICATE_CHAIN_PEM` | No | Leaf-first PEM certificate chain for UDAP software-statement signing |
+| `UDAP_REGISTRATION_SIGNING_ALGORITHM` | No | Optional explicit UDAP registration signing algorithm (`RS256`, `RS384`, `ES256`, or `ES384`) |
 
 ### Setting Up Asymmetric Authentication
 
@@ -109,6 +117,36 @@ UDAP_CRLS_PEM="-----BEGIN X509 CRL-----
 ```
 
 When both values are present, the demo enables chain and revocation validation by default. Set `UDAP_VERIFY_CHAIN=false` only for local development or test scenarios. Unknown `UDAP_VERIFY_CHAIN` values raise a configuration error instead of silently disabling validation.
+
+### Setting Up UDAP Client Signing Credentials
+
+UDAP Dynamic Client Registration uses a client signing identity in the
+`software_statement` JWT. This is the opposite trust direction from
+`UDAP_TRUST_ANCHORS_PEM`: trust anchors validate the **server** metadata JWT,
+while the client private key and certificate chain identify **this demo app**
+to a UDAP registration endpoint.
+
+Configure the signing credentials when testing UDAP registration:
+
+```bash
+UDAP_CLIENT_PRIVATE_KEY_PEM="-----BEGIN PRIVATE KEY-----
+...client private key...
+-----END PRIVATE KEY-----"
+
+UDAP_CLIENT_CERTIFICATE_CHAIN_PEM="-----BEGIN CERTIFICATE-----
+...leaf certificate whose URI SAN matches the client URI...
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+...optional issuing certificate...
+-----END CERTIFICATE-----"
+
+UDAP_REGISTRATION_SIGNING_ALGORITHM="RS256"
+```
+
+Leave `UDAP_REGISTRATION_SIGNING_ALGORITHM` blank to let Safire select a
+compatible algorithm from UDAP discovery and the configured key type. The
+registration UI workflow will use this foundation in the next UDAP DCR demo
+PR; the current UDAP screen remains discovery-focused.
 
 ### Adding a FHIR Server
 
@@ -217,7 +255,10 @@ examples/sinatra_app/
 │   └── servers.yml     # Server configurations (YAML storage)
 ├── models/
 │   ├── fhir_server.rb                # Server model with YAML persistence
-│   └── udap_discovery_presenter.rb   # UDAP demo presentation and trust policy
+│   ├── udap_client_credentials.rb    # UDAP demo client signing credential loader
+│   ├── udap_discovery_presenter.rb   # UDAP discovery presentation model
+│   ├── udap_pem_parsing.rb           # Shared UDAP demo PEM parsing helper
+│   └── udap_trust_policy.rb          # UDAP signed_metadata server trust policy
 ├── public/
 │   ├── css/
 │   │   └── style.css   # Application styles

--- a/examples/sinatra_app/app.rb
+++ b/examples/sinatra_app/app.rb
@@ -7,8 +7,10 @@ require 'securerandom'
 require 'openssl'
 require 'json'
 require 'base64'
+require 'uri'
 require 'safire'
 require_relative 'models/fhir_server'
+require_relative 'models/udap_trust_policy'
 require_relative 'models/udap_discovery_presenter'
 
 # Sinatra demo application for Safire gem
@@ -81,6 +83,17 @@ class SafireDemo < Sinatra::Base
 
     def jwks_uri
       "#{request.scheme}://#{request.host_with_port}/.well-known/jwks.json"
+    end
+
+    def localhost_policy_for(*urls)
+      urls.any? { |url| http_loopback_url?(url) } ? { allow_insecure_localhost: true } : {}
+    end
+
+    def http_loopback_url?(value)
+      uri = URI.parse(value.to_s)
+      uri.scheme == 'http' && %w[localhost 127.0.0.1].include?(uri.host)
+    rescue URI::InvalidURIError
+      false
     end
   end
 
@@ -245,7 +258,7 @@ class SafireDemo < Sinatra::Base
   # UDAP Discovery
   get '/demo/:server_id/udap-discovery' do
     @community = normalize_optional_param(params[:community])
-    @udap_trust_policy = UdapDiscoveryPresenter::TrustPolicy.new
+    @udap_trust_policy = UdapTrustPolicy.new
     @udap_metadata = discover_udap_metadata(@server, community: @community, trust_policy: @udap_trust_policy)
     @udap_metadata_valid = @udap_metadata.valid?
     @udap_presenter = UdapDiscoveryPresenter.new(
@@ -503,7 +516,8 @@ class SafireDemo < Sinatra::Base
   end
 
   def perform_registration
-    temp_client   = Safire::Client.new({ base_url: params[:base_url].strip })
+    base_url = params[:base_url].strip
+    temp_client   = Safire::Client.new({ base_url:, **localhost_policy_for(base_url) })
     endpoint      = params[:registration_endpoint].presence
     authorization = build_authorization_header(params[:initial_access_token], params[:token_type])
     temp_client.register_client(
@@ -576,7 +590,9 @@ class SafireDemo < Sinatra::Base
   end
 
   def fetch_and_cache_metadata(server, client)
-    client ||= Safire::Client.new({ base_url: server.base_url, client_id: server.client_id })
+    client ||= Safire::Client.new(
+      { base_url: server.base_url, client_id: server.client_id, **localhost_policy_for(server.base_url) }
+    )
     metadata = client.server_metadata
     SafireDemo.metadata_cache[server.base_url] = { metadata: metadata, fetched_at: Time.now.to_i }
     metadata
@@ -609,18 +625,31 @@ class SafireDemo < Sinatra::Base
   end
 
   def discover_udap_metadata(server, community:, trust_policy:)
-    client = Safire::Client.new({ base_url: server.base_url }, protocol: :udap)
+    client = Safire::Client.new(
+      { base_url: server.base_url, **localhost_policy_for(server.base_url) },
+      protocol: :udap
+    )
     client.server_metadata(community: community, **trust_policy.server_metadata_kwargs)
   end
 
   def build_safire_client(server, client_type: :public)
-    config = {
+    config = base_safire_client_config(server)
+    add_client_type_credentials!(config, server, client_type)
+
+    Safire::Client.new(config, client_type: client_type)
+  end
+
+  def base_safire_client_config(server)
+    {
       base_url: server.base_url,
       client_id: server.client_id,
       redirect_uri: redirect_uri,
-      scopes: server.scopes
+      scopes: server.scopes,
+      **localhost_policy_for(server.base_url, redirect_uri)
     }
+  end
 
+  def add_client_type_credentials!(config, server, client_type)
     case client_type
     when :confidential_symmetric
       config[:client_secret] = server.client_secret
@@ -629,8 +658,6 @@ class SafireDemo < Sinatra::Base
       config[:kid] = ENV.fetch('ASYMMETRIC_KID', nil)
       config[:jwks_uri] = jwks_uri unless ENV['RACK_ENV'] == 'development'
     end
-
-    Safire::Client.new(config, client_type: client_type)
   end
 
   # Build a JWK from an OpenSSL key for the JWKS endpoint

--- a/examples/sinatra_app/models/fhir_server.rb
+++ b/examples/sinatra_app/models/fhir_server.rb
@@ -15,7 +15,7 @@ class FhirServer
     'udap' => 'UDAP Security'
   }.freeze
 
-  ATTRIBUTES = %i[id name base_url client_id client_secret scopes protocols].freeze
+  ATTRIBUTES = %i[id name base_url client_id udap_client_id client_secret scopes protocols].freeze
 
   attr_accessor(*(ATTRIBUTES - %i[protocols]))
   attr_reader :errors, :protocols

--- a/examples/sinatra_app/models/udap_client_credentials.rb
+++ b/examples/sinatra_app/models/udap_client_credentials.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'openssl'
+require_relative 'udap_pem_parsing'
+
+# Client signing credentials for UDAP Dynamic Client Registration in the demo app.
+class UdapClientCredentials
+  include UdapPemParsing
+
+  PRIVATE_KEY_ENV = 'UDAP_CLIENT_PRIVATE_KEY_PEM'
+  CERTIFICATE_CHAIN_ENV = 'UDAP_CLIENT_CERTIFICATE_CHAIN_PEM'
+  SIGNING_ALGORITHM_ENV = 'UDAP_REGISTRATION_SIGNING_ALGORITHM'
+  SUPPORTED_ALGORITHMS = %w[RS256 RS384 ES256 ES384].freeze
+  private_constant :PRIVATE_KEY_ENV, :CERTIFICATE_CHAIN_ENV, :SIGNING_ALGORITHM_ENV, :SUPPORTED_ALGORITHMS
+
+  def initialize(env = ENV)
+    @env = env
+  end
+
+  def configured?
+    env_value?(PRIVATE_KEY_ENV) && env_value?(CERTIFICATE_CHAIN_ENV)
+  end
+
+  def client_config_kwargs
+    @client_config_kwargs ||= begin
+      validate_required_credentials!
+      {
+        private_key: private_key,
+        certificate_chain: certificate_chain
+      }.tap do |kwargs|
+        kwargs[:jwt_algorithm] = signing_algorithm if signing_algorithm
+      end.freeze
+    end
+  end
+
+  private
+
+  attr_reader :env
+
+  def validate_required_credentials!
+    missing = []
+    missing << PRIVATE_KEY_ENV.to_sym unless env_value?(PRIVATE_KEY_ENV)
+    missing << CERTIFICATE_CHAIN_ENV.to_sym unless env_value?(CERTIFICATE_CHAIN_ENV)
+    return if missing.empty?
+
+    raise Safire::Errors::ConfigurationError.new(missing_attributes: missing)
+  end
+
+  def private_key
+    @private_key ||= begin
+      key = OpenSSL::PKey.read(env.fetch(PRIVATE_KEY_ENV).to_s)
+      raise_invalid_private_key! unless key.private?
+
+      key
+    end
+  rescue OpenSSL::PKey::PKeyError
+    raise_invalid_private_key!
+  end
+
+  def raise_invalid_private_key!
+    raise Safire::Errors::ConfigurationError.new(
+      invalid_attribute: PRIVATE_KEY_ENV.to_sym,
+      invalid_value: 'configured value',
+      valid_values: ['PEM private key']
+    )
+  end
+
+  def certificate_chain
+    @certificate_chain ||= parse_pem_collection(
+      env,
+      env_key: CERTIFICATE_CHAIN_ENV,
+      pattern: UdapPemParsing::CERTIFICATE_PATTERN,
+      parser: OpenSSL::X509::Certificate
+    )
+  end
+
+  def signing_algorithm
+    return @signing_algorithm if defined?(@signing_algorithm)
+
+    value = env.fetch(SIGNING_ALGORITHM_ENV, nil).to_s.strip
+    return @signing_algorithm = nil if value.empty?
+    return @signing_algorithm = value.freeze if SUPPORTED_ALGORITHMS.include?(value)
+
+    raise Safire::Errors::ConfigurationError.new(
+      invalid_attribute: SIGNING_ALGORITHM_ENV.to_sym,
+      invalid_value: value,
+      valid_values: SUPPORTED_ALGORITHMS
+    )
+  end
+
+  def env_value?(key)
+    env.fetch(key, nil).to_s.strip.present?
+  end
+end

--- a/examples/sinatra_app/models/udap_discovery_presenter.rb
+++ b/examples/sinatra_app/models/udap_discovery_presenter.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'openssl'
-
 # Presentation model for the UDAP discovery demo view.
 class UdapDiscoveryPresenter
   PROFILE_CHECKS = [
@@ -91,97 +89,6 @@ class UdapDiscoveryPresenter
 
   def badge_class(value)
     value ? 'badge-added' : 'badge-info'
-  end
-
-  # Trust policy for the UDAP discovery demo.
-  class TrustPolicy
-    CERTIFICATE_PATTERN = /-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/m
-    CRL_PATTERN = /-----BEGIN X509 CRL-----.*?-----END X509 CRL-----/m
-    TRUTHY_VALUES = %w[1 true yes on].freeze
-    FALSEY_VALUES = %w[0 false no off].freeze
-    BOOLEAN_VALUES = (TRUTHY_VALUES + FALSEY_VALUES).freeze
-
-    def initialize(env = ENV)
-      @env = env
-    end
-
-    def server_metadata_kwargs
-      {
-        trusted_anchors: trusted_anchors,
-        crls: crls,
-        verify_chain: verify_chain?
-      }
-    end
-
-    def development_mode?
-      !verify_chain?
-    end
-
-    def chain_verification_disabled_reason
-      return nil if verify_chain?
-
-      explicit_verify_chain == false ? :explicit_override : :missing_trust_material
-    end
-
-    def verify_chain?
-      explicit = explicit_verify_chain
-      return explicit unless explicit.nil?
-
-      trust_material_configured?
-    end
-
-    def trust_material_configured?
-      trusted_anchors.any? && crls.any?
-    end
-
-    private
-
-    attr_reader :env
-
-    def trusted_anchors
-      @trusted_anchors ||= parse_pem_collection(
-        'UDAP_TRUST_ANCHORS_PEM',
-        CERTIFICATE_PATTERN,
-        OpenSSL::X509::Certificate
-      )
-    end
-
-    def crls
-      @crls ||= parse_pem_collection('UDAP_CRLS_PEM', CRL_PATTERN, OpenSSL::X509::CRL)
-    end
-
-    def explicit_verify_chain
-      return @explicit_verify_chain if defined?(@explicit_verify_chain)
-
-      value = env.fetch('UDAP_VERIFY_CHAIN', nil).to_s.strip
-      return @explicit_verify_chain = nil if value.empty?
-
-      normalized_value = value.downcase
-      return @explicit_verify_chain = true if TRUTHY_VALUES.include?(normalized_value)
-      return @explicit_verify_chain = false if FALSEY_VALUES.include?(normalized_value)
-
-      raise Safire::Errors::ConfigurationError.new(
-        invalid_attribute: :UDAP_VERIFY_CHAIN,
-        invalid_value: value,
-        valid_values: BOOLEAN_VALUES
-      )
-    end
-
-    def parse_pem_collection(env_key, pattern, parser)
-      raw = env.fetch(env_key, nil).to_s.strip
-      return [] if raw.empty?
-
-      pem_blocks = raw.scan(pattern)
-      raise_certificate_error(env_key, 'no PEM blocks found') if pem_blocks.empty?
-
-      pem_blocks.map { |pem| parser.new(pem) }
-    rescue OpenSSL::X509::CertificateError, OpenSSL::X509::CRLError => e
-      raise_certificate_error(env_key, e.message)
-    end
-
-    def raise_certificate_error(env_key, reason)
-      raise Safire::Errors::CertificateError.new(reason: "#{env_key} is invalid: #{reason}")
-    end
   end
 
   private

--- a/examples/sinatra_app/models/udap_pem_parsing.rb
+++ b/examples/sinatra_app/models/udap_pem_parsing.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'openssl'
+require 'safire'
+
+# Shared PEM collection parsing for UDAP demo configuration models.
+module UdapPemParsing
+  CERTIFICATE_PATTERN = /-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/m
+  CRL_PATTERN = /-----BEGIN X509 CRL-----.*?-----END X509 CRL-----/m
+
+  private
+
+  def parse_pem_collection(env, env_key:, pattern:, parser:)
+    raw = env.fetch(env_key, nil).to_s.strip
+    return [].freeze if raw.empty?
+
+    pem_blocks = raw.scan(pattern)
+    raise_certificate_error(env_key, 'no PEM blocks found') if pem_blocks.empty?
+
+    pem_blocks.map { |pem| parser.new(pem) }.freeze
+  rescue OpenSSL::X509::CertificateError, OpenSSL::X509::CRLError => e
+    raise_certificate_error(env_key, e.message)
+  end
+
+  def raise_certificate_error(env_key, reason)
+    raise Safire::Errors::CertificateError.new(reason: "#{env_key} is invalid: #{reason}")
+  end
+end

--- a/examples/sinatra_app/models/udap_trust_policy.rb
+++ b/examples/sinatra_app/models/udap_trust_policy.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require_relative 'udap_pem_parsing'
+
+# Server trust policy for UDAP signed_metadata validation in the demo app.
+class UdapTrustPolicy
+  include UdapPemParsing
+
+  TRUTHY_VALUES = %w[1 true yes on].freeze
+  FALSEY_VALUES = %w[0 false no off].freeze
+  BOOLEAN_VALUES = (TRUTHY_VALUES + FALSEY_VALUES).freeze
+
+  def initialize(env = ENV)
+    @env = env
+  end
+
+  def server_metadata_kwargs
+    {
+      trusted_anchors: trusted_anchors,
+      crls: crls,
+      verify_chain: verify_chain?
+    }
+  end
+
+  def development_mode?
+    !verify_chain?
+  end
+
+  def chain_verification_disabled_reason
+    return if verify_chain?
+
+    explicit_verify_chain == false ? :explicit_override : :missing_trust_material
+  end
+
+  def verify_chain?
+    explicit = explicit_verify_chain
+    return explicit unless explicit.nil?
+
+    trust_material_configured?
+  end
+
+  def trust_material_configured?
+    trusted_anchors.any? && crls.any?
+  end
+
+  private
+
+  attr_reader :env
+
+  def trusted_anchors
+    @trusted_anchors ||= parse_pem_collection(
+      env,
+      env_key: 'UDAP_TRUST_ANCHORS_PEM',
+      pattern: UdapPemParsing::CERTIFICATE_PATTERN,
+      parser: OpenSSL::X509::Certificate
+    )
+  end
+
+  def crls
+    @crls ||= parse_pem_collection(
+      env,
+      env_key: 'UDAP_CRLS_PEM',
+      pattern: UdapPemParsing::CRL_PATTERN,
+      parser: OpenSSL::X509::CRL
+    )
+  end
+
+  def explicit_verify_chain
+    return @explicit_verify_chain if defined?(@explicit_verify_chain)
+
+    value = env.fetch('UDAP_VERIFY_CHAIN', nil).to_s.strip
+    return @explicit_verify_chain = nil if value.empty?
+
+    normalized_value = value.downcase
+    return @explicit_verify_chain = true if TRUTHY_VALUES.include?(normalized_value)
+    return @explicit_verify_chain = false if FALSEY_VALUES.include?(normalized_value)
+
+    raise Safire::Errors::ConfigurationError.new(
+      invalid_attribute: :UDAP_VERIFY_CHAIN,
+      invalid_value: value,
+      valid_values: BOOLEAN_VALUES
+    )
+  end
+end

--- a/spec/examples/sinatra_app/fhir_server_spec.rb
+++ b/spec/examples/sinatra_app/fhir_server_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe FhirServer do
       name: 'Example FHIR',
       base_url: 'https://fhir.example.com',
       client_id: 'client-123',
+      udap_client_id: 'udap-client-456',
       scopes: %w[openid profile]
     }
   end
@@ -18,9 +19,10 @@ RSpec.describe FhirServer do
 
   describe '#protocols' do
     it 'defaults existing records to SMART' do
-      server = described_class.new(base_attrs.except(:protocols))
+      server = described_class.new(base_attrs.except(:protocols, :udap_client_id))
 
       expect(server.protocols).to eq(['smart'])
+      expect(server.udap_client_id).to be_nil
       expect(server).to be_supports_smart
       expect(server).not_to be_supports_udap
     end
@@ -63,6 +65,12 @@ RSpec.describe FhirServer do
       expect(server).to be_valid
     end
 
+    it 'does not require udap_client_id for UDAP servers' do
+      server = described_class.new(base_attrs.merge(udap_client_id: nil, protocols: ['udap']))
+
+      expect(server).to be_valid
+    end
+
     it 'requires at least one supported protocol' do
       server = described_class.new(base_attrs.merge(protocols: []))
 
@@ -75,6 +83,17 @@ RSpec.describe FhirServer do
 
       expect(server).not_to be_valid
       expect(server.errors).to include('Protocols must be one or more of: smart, udap')
+    end
+  end
+
+  describe '#to_hash' do
+    it 'persists SMART and UDAP client identifiers separately' do
+      server = described_class.new(base_attrs.merge(protocols: %w[smart udap]))
+
+      expect(server.to_hash).to include(
+        'client_id' => 'client-123',
+        'udap_client_id' => 'udap-client-456'
+      )
     end
   end
 end

--- a/spec/examples/sinatra_app/safire_demo_spec.rb
+++ b/spec/examples/sinatra_app/safire_demo_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe SafireDemo do
       'token_endpoint_auth_methods_supported' => ['none']
     }
   end
-  let(:udap_trust_policy) { UdapDiscoveryPresenter::TrustPolicy.new({}) }
+  let(:udap_trust_policy) { UdapTrustPolicy.new({}) }
   let(:udap_metadata) { Safire::Protocols::UdapMetadata.new(udap_metadata_hash) }
   let(:udap_metadata_hash) do
     {
@@ -69,7 +69,7 @@ RSpec.describe SafireDemo do
     allow(FhirServer).to receive(:find).with('udap-only').and_return(udap_server)
     allow(FhirServer).to receive(:find).with('evil-udap').and_return(malicious_udap_server)
     allow(FhirServer).to receive(:find_by_base_url).with(udap_server.base_url).and_return(udap_server)
-    allow(UdapDiscoveryPresenter::TrustPolicy).to receive(:new).and_return(udap_trust_policy)
+    allow(UdapTrustPolicy).to receive(:new).and_return(udap_trust_policy)
   end
 
   describe 'protocol guards' do
@@ -151,6 +151,17 @@ RSpec.describe SafireDemo do
       expect(response.status).to eq(200)
       expect(response.body).to include('Authorization Flow')
       expect(response.body).to include('Provider Standalone Launch')
+    end
+
+    it 'opts into insecure localhost only for local HTTP demo callbacks' do
+      client = instance_double(Safire::Client, server_metadata: smart_metadata)
+      allow(Safire::Client).to receive(:new).and_return(client)
+
+      response = request.get('/demo/smart-only/authorize', 'HTTP_HOST' => 'localhost:4567')
+
+      expect(response.status).to eq(200)
+      expect(Safire::Client).to have_received(:new)
+        .with(hash_including(allow_insecure_localhost: true), client_type: :public)
     end
   end
 

--- a/spec/examples/sinatra_app/udap_client_credentials_spec.rb
+++ b/spec/examples/sinatra_app/udap_client_credentials_spec.rb
@@ -1,0 +1,115 @@
+require 'spec_helper'
+require 'openssl'
+
+require_relative '../../support/udap_certificate_helpers'
+require_relative '../../../examples/sinatra_app/models/udap_client_credentials'
+
+RSpec.describe UdapClientCredentials do
+  include UdapCertificateHelpers
+
+  let(:private_key) { OpenSSL::PKey::RSA.generate(2048) }
+  let(:issuer_key) { OpenSSL::PKey::RSA.generate(2048) }
+  let(:issuer_cert) do
+    build_udap_certificate(
+      key: issuer_key.public_key,
+      uri_san: 'https://issuer.example.com',
+      subject: '/CN=UDAP Issuer',
+      issuer_key: issuer_key
+    )
+  end
+  let(:leaf_cert) do
+    build_udap_certificate(
+      key: private_key.public_key,
+      uri_san: 'https://client.example.com',
+      issuer_cert:,
+      issuer_key:,
+      serial: 2
+    )
+  end
+  let(:chain_pem) { "#{leaf_cert.to_pem}\n#{issuer_cert.to_pem}" }
+  let(:env) do
+    {
+      'UDAP_CLIENT_PRIVATE_KEY_PEM' => private_key.to_pem,
+      'UDAP_CLIENT_CERTIFICATE_CHAIN_PEM' => chain_pem
+    }
+  end
+
+  it 'is configured only when both signing key and certificate chain are present' do
+    expect(described_class.new({})).not_to be_configured
+    expect(described_class.new('UDAP_CLIENT_PRIVATE_KEY_PEM' => private_key.to_pem)).not_to be_configured
+    expect(described_class.new(env)).to be_configured
+  end
+
+  it 'returns Safire client configuration kwargs with parsed signing material' do
+    kwargs = described_class.new(env).client_config_kwargs
+
+    expect(kwargs[:private_key]).to be_a(OpenSSL::PKey::RSA)
+    expect(kwargs[:certificate_chain].map(&:subject)).to eq([leaf_cert.subject, issuer_cert.subject])
+    expect(kwargs[:certificate_chain]).to be_frozen
+    expect(kwargs).not_to have_key(:jwt_algorithm)
+  end
+
+  it 'includes an explicit registration signing algorithm when configured' do
+    credentials = described_class.new(env.merge('UDAP_REGISTRATION_SIGNING_ALGORITHM' => 'RS384'))
+
+    expect(credentials.client_config_kwargs[:jwt_algorithm]).to eq('RS384')
+  end
+
+  it 'raises ConfigurationError when usable credentials are requested but key material is missing' do
+    credentials = described_class.new('UDAP_CLIENT_CERTIFICATE_CHAIN_PEM' => leaf_cert.to_pem)
+
+    expect { credentials.client_config_kwargs }
+      .to raise_error(Safire::Errors::ConfigurationError, /UDAP_CLIENT_PRIVATE_KEY_PEM/)
+  end
+
+  it 'raises ConfigurationError when usable credentials are requested but the chain is missing' do
+    credentials = described_class.new('UDAP_CLIENT_PRIVATE_KEY_PEM' => private_key.to_pem)
+
+    expect { credentials.client_config_kwargs }
+      .to raise_error(Safire::Errors::ConfigurationError, /UDAP_CLIENT_CERTIFICATE_CHAIN_PEM/)
+  end
+
+  it 'raises ConfigurationError for malformed private key PEM without leaking the configured value' do
+    credentials = described_class.new(env.merge('UDAP_CLIENT_PRIVATE_KEY_PEM' => 'not a key'))
+
+    expect { credentials.client_config_kwargs }
+      .to raise_error(Safire::Errors::ConfigurationError) { |error|
+        expect(error.message).to include('UDAP_CLIENT_PRIVATE_KEY_PEM')
+        expect(error.message).not_to include('not a key')
+      }
+  end
+
+  it 'raises ConfigurationError when the configured key is not a private key' do
+    credentials = described_class.new(env.merge('UDAP_CLIENT_PRIVATE_KEY_PEM' => private_key.public_key.to_pem))
+
+    expect { credentials.client_config_kwargs }
+      .to raise_error(Safire::Errors::ConfigurationError, /PEM private key/)
+  end
+
+  it 'raises CertificateError for malformed certificate PEM without leaking the configured value' do
+    credentials = described_class.new(env.merge('UDAP_CLIENT_CERTIFICATE_CHAIN_PEM' => <<~PEM))
+      -----BEGIN CERTIFICATE-----
+      not a certificate
+      -----END CERTIFICATE-----
+    PEM
+
+    expect { credentials.client_config_kwargs }
+      .to raise_error(Safire::Errors::CertificateError) { |error|
+        expect(error.message).to include('UDAP_CLIENT_CERTIFICATE_CHAIN_PEM')
+        expect(error.message).not_to include('not a certificate')
+      }
+  end
+
+  it 'raises ConfigurationError for unknown signing algorithms' do
+    credentials = described_class.new(env.merge('UDAP_REGISTRATION_SIGNING_ALGORITHM' => 'HS256'))
+
+    expect { credentials.client_config_kwargs }
+      .to raise_error(Safire::Errors::ConfigurationError, /UDAP_REGISTRATION_SIGNING_ALGORITHM/)
+  end
+
+  it 'memoizes parsed credentials' do
+    credentials = described_class.new(env)
+
+    expect(credentials.client_config_kwargs[:private_key]).to equal(credentials.client_config_kwargs[:private_key])
+  end
+end

--- a/spec/examples/sinatra_app/udap_discovery_presenter_spec.rb
+++ b/spec/examples/sinatra_app/udap_discovery_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
-require 'openssl'
 
+require_relative '../../../examples/sinatra_app/models/udap_trust_policy'
 require_relative '../../../examples/sinatra_app/models/udap_discovery_presenter'
 
 RSpec.describe UdapDiscoveryPresenter do
@@ -30,7 +30,7 @@ RSpec.describe UdapDiscoveryPresenter do
     described_class.new(
       metadata,
       metadata_valid: metadata_valid,
-      trust_policy: instance_double(described_class::TrustPolicy, verify_chain?: verify_chain)
+      trust_policy: instance_double(UdapTrustPolicy, verify_chain?: verify_chain)
     )
   end
 
@@ -39,7 +39,7 @@ RSpec.describe UdapDiscoveryPresenter do
       presenter = described_class.new(
         metadata,
         metadata_valid: true,
-        trust_policy: described_class::TrustPolicy.new({})
+        trust_policy: UdapTrustPolicy.new({})
       )
 
       expect(presenter.metadata_fields.pluck(:key)).to eq(Safire::Protocols::UdapMetadata::ATTRIBUTES)
@@ -51,7 +51,7 @@ RSpec.describe UdapDiscoveryPresenter do
       presenter = described_class.new(
         metadata,
         metadata_valid: true,
-        trust_policy: described_class::TrustPolicy.new({})
+        trust_policy: UdapTrustPolicy.new({})
       )
 
       expect(presenter.profile_checks).to include(
@@ -67,7 +67,7 @@ RSpec.describe UdapDiscoveryPresenter do
       presenter = described_class.new(
         metadata,
         metadata_valid: true,
-        trust_policy: described_class::TrustPolicy.new({})
+        trust_policy: UdapTrustPolicy.new({})
       )
 
       expect(presenter.capability_checks).to include(
@@ -84,7 +84,7 @@ RSpec.describe UdapDiscoveryPresenter do
       presenter = described_class.new(
         metadata,
         metadata_valid: true,
-        trust_policy: described_class::TrustPolicy.new({})
+        trust_policy: UdapTrustPolicy.new({})
       )
 
       expect(presenter).to be_trust_warning
@@ -94,14 +94,14 @@ RSpec.describe UdapDiscoveryPresenter do
       presenter = described_class.new(
         metadata,
         metadata_valid: true,
-        trust_policy: described_class::TrustPolicy.new({})
+        trust_policy: UdapTrustPolicy.new({})
       )
 
       expect(presenter.trust_warning_reason).to include('complete UDAP trust anchors and CRLs are not configured')
     end
 
     it 'explains explicit override when chain verification is disabled by configuration' do
-      policy = described_class::TrustPolicy.new('UDAP_VERIFY_CHAIN' => 'false')
+      policy = UdapTrustPolicy.new('UDAP_VERIFY_CHAIN' => 'false')
       presenter = described_class.new(
         metadata,
         metadata_valid: true,
@@ -133,109 +133,13 @@ RSpec.describe UdapDiscoveryPresenter do
       presenter = described_class.new(
         metadata,
         metadata_valid: true,
-        trust_policy: described_class::TrustPolicy.new({})
+        trust_policy: UdapTrustPolicy.new({})
       )
 
       expect(presenter.status_text(true)).to eq('Yes')
       expect(presenter.status_text(false)).to eq('No')
       expect(presenter.badge_class(true)).to eq('badge-added')
       expect(presenter.badge_class(false)).to eq('badge-info')
-    end
-  end
-
-  describe UdapDiscoveryPresenter::TrustPolicy do
-    let(:key) { OpenSSL::PKey::RSA.generate(2048) }
-    let(:cert) { build_cert(key) }
-    let(:crl) { build_crl(cert, key) }
-
-    def build_cert(key)
-      cert = OpenSSL::X509::Certificate.new
-      cert.version = 2
-      cert.serial = 1
-      cert.subject = OpenSSL::X509::Name.parse('/CN=Demo UDAP Anchor')
-      cert.issuer = cert.subject
-      cert.public_key = key.public_key
-      cert.not_before = Time.now - 60
-      cert.not_after = Time.now + 86_400
-      cert.sign(key, OpenSSL::Digest.new('SHA256'))
-      cert
-    end
-
-    def build_crl(cert, key)
-      crl = OpenSSL::X509::CRL.new
-      crl.version = 1
-      crl.issuer = cert.subject
-      crl.last_update = Time.now - 60
-      crl.next_update = Time.now + 86_400
-      crl.sign(key, OpenSSL::Digest.new('SHA256'))
-      crl
-    end
-
-    it 'uses development mode when no trust material is configured' do
-      policy = described_class.new({})
-
-      expect(policy.server_metadata_kwargs).to eq(
-        trusted_anchors: [],
-        crls: [],
-        verify_chain: false
-      )
-      expect(policy).to be_development_mode
-      expect(policy.chain_verification_disabled_reason).to eq(:missing_trust_material)
-    end
-
-    it 'enables chain verification when trust anchors and CRLs are configured' do
-      policy = described_class.new(
-        'UDAP_TRUST_ANCHORS_PEM' => cert.to_pem,
-        'UDAP_CRLS_PEM' => crl.to_pem
-      )
-
-      expect(policy.server_metadata_kwargs[:trusted_anchors]).to contain_exactly(be_a(OpenSSL::X509::Certificate))
-      expect(policy.server_metadata_kwargs[:crls]).to contain_exactly(be_a(OpenSSL::X509::CRL))
-      expect(policy.server_metadata_kwargs[:verify_chain]).to be(true)
-      expect(policy).not_to be_development_mode
-      expect(policy.chain_verification_disabled_reason).to be_nil
-    end
-
-    it 'honors an explicit verify_chain=false override' do
-      policy = described_class.new(
-        'UDAP_TRUST_ANCHORS_PEM' => cert.to_pem,
-        'UDAP_CRLS_PEM' => crl.to_pem,
-        'UDAP_VERIFY_CHAIN' => 'false'
-      )
-
-      expect(policy.server_metadata_kwargs[:verify_chain]).to be(false)
-      expect(policy.chain_verification_disabled_reason).to eq(:explicit_override)
-    end
-
-    it 'honors explicit true and false boolean values' do
-      expect(described_class.new('UDAP_VERIFY_CHAIN' => 'yes').server_metadata_kwargs[:verify_chain]).to be(true)
-      expect(described_class.new('UDAP_VERIFY_CHAIN' => '0').server_metadata_kwargs[:verify_chain]).to be(false)
-    end
-
-    it 'raises ConfigurationError for invalid verify_chain values' do
-      policy = described_class.new('UDAP_VERIFY_CHAIN' => 'treu')
-
-      expect { policy.server_metadata_kwargs }
-        .to raise_error(Safire::Errors::ConfigurationError, /UDAP_VERIFY_CHAIN/)
-    end
-
-    it 'raises CertificateError for malformed trust anchor PEM' do
-      malformed_cert = <<~PEM
-        -----BEGIN CERTIFICATE-----
-        not a certificate
-        -----END CERTIFICATE-----
-      PEM
-      policy = described_class.new('UDAP_TRUST_ANCHORS_PEM' => malformed_cert)
-
-      expect { policy.server_metadata_kwargs }
-        .to raise_error(Safire::Errors::CertificateError, /UDAP_TRUST_ANCHORS_PEM/)
-    end
-
-    it 'raises CertificateError for malformed CRL PEM' do
-      policy = described_class.new('UDAP_CRLS_PEM' => 'not pem')
-
-      expect { policy.server_metadata_kwargs }
-        .to raise_error(Safire::Errors::CertificateError, /UDAP_CRLS_PEM/)
     end
   end
 end

--- a/spec/examples/sinatra_app/udap_trust_policy_spec.rb
+++ b/spec/examples/sinatra_app/udap_trust_policy_spec.rb
@@ -1,0 +1,119 @@
+require 'spec_helper'
+require 'openssl'
+
+require_relative '../../../examples/sinatra_app/models/udap_trust_policy'
+
+RSpec.describe UdapTrustPolicy do
+  let(:key) { OpenSSL::PKey::RSA.generate(2048) }
+  let(:cert) { build_cert(key) }
+  let(:crl) { build_crl(cert, key) }
+
+  def build_cert(key)
+    cert = OpenSSL::X509::Certificate.new
+    cert.version = 2
+    cert.serial = 1
+    cert.subject = OpenSSL::X509::Name.parse('/CN=Demo UDAP Anchor')
+    cert.issuer = cert.subject
+    cert.public_key = key.public_key
+    cert.not_before = Time.now - 60
+    cert.not_after = Time.now + 86_400
+    cert.sign(key, OpenSSL::Digest.new('SHA256'))
+    cert
+  end
+
+  def build_crl(cert, key)
+    crl = OpenSSL::X509::CRL.new
+    crl.version = 1
+    crl.issuer = cert.subject
+    crl.last_update = Time.now - 60
+    crl.next_update = Time.now + 86_400
+    crl.sign(key, OpenSSL::Digest.new('SHA256'))
+    crl
+  end
+
+  it 'uses development mode when no trust material is configured' do
+    policy = described_class.new({})
+
+    expect(policy.server_metadata_kwargs).to eq(
+      trusted_anchors: [],
+      crls: [],
+      verify_chain: false
+    )
+    expect(policy).to be_development_mode
+    expect(policy.chain_verification_disabled_reason).to eq(:missing_trust_material)
+  end
+
+  it 'enables chain verification when trust anchors and CRLs are configured' do
+    policy = described_class.new(
+      'UDAP_TRUST_ANCHORS_PEM' => cert.to_pem,
+      'UDAP_CRLS_PEM' => crl.to_pem
+    )
+
+    expect(policy.server_metadata_kwargs[:trusted_anchors]).to contain_exactly(be_a(OpenSSL::X509::Certificate))
+    expect(policy.server_metadata_kwargs[:crls]).to contain_exactly(be_a(OpenSSL::X509::CRL))
+    expect(policy.server_metadata_kwargs[:trusted_anchors]).to be_frozen
+    expect(policy.server_metadata_kwargs[:crls]).to be_frozen
+    expect(policy.server_metadata_kwargs[:verify_chain]).to be(true)
+    expect(policy).not_to be_development_mode
+    expect(policy.chain_verification_disabled_reason).to be_nil
+  end
+
+  [
+    ['trust anchors without CRLs', { 'UDAP_TRUST_ANCHORS_PEM' => :cert }],
+    ['CRLs without trust anchors', { 'UDAP_CRLS_PEM' => :crl }]
+  ].each do |label, env_template|
+    it "stays in development mode when configured with #{label}" do
+      env = env_template.transform_values { |value| value == :cert ? cert.to_pem : crl.to_pem }
+      policy = described_class.new(env)
+
+      expect(policy.server_metadata_kwargs[:verify_chain]).to be(false)
+      expect(policy).to be_development_mode
+      expect(policy.chain_verification_disabled_reason).to eq(:missing_trust_material)
+    end
+  end
+
+  it 'honors an explicit verify_chain=false override' do
+    policy = described_class.new(
+      'UDAP_TRUST_ANCHORS_PEM' => cert.to_pem,
+      'UDAP_CRLS_PEM' => crl.to_pem,
+      'UDAP_VERIFY_CHAIN' => 'false'
+    )
+
+    expect(policy.server_metadata_kwargs[:verify_chain]).to be(false)
+    expect(policy.chain_verification_disabled_reason).to eq(:explicit_override)
+  end
+
+  it 'honors explicit true and false boolean values' do
+    expect(described_class.new('UDAP_VERIFY_CHAIN' => 'yes').server_metadata_kwargs[:verify_chain]).to be(true)
+    expect(described_class.new('UDAP_VERIFY_CHAIN' => '0').server_metadata_kwargs[:verify_chain]).to be(false)
+  end
+
+  it 'raises ConfigurationError for invalid verify_chain values' do
+    policy = described_class.new('UDAP_VERIFY_CHAIN' => 'treu')
+
+    expect { policy.server_metadata_kwargs }
+      .to raise_error(Safire::Errors::ConfigurationError, /UDAP_VERIFY_CHAIN/)
+  end
+
+  it 'raises CertificateError for malformed trust anchor PEM without leaking PEM content' do
+    malformed_cert = <<~PEM
+      -----BEGIN CERTIFICATE-----
+      not a certificate
+      -----END CERTIFICATE-----
+    PEM
+    policy = described_class.new('UDAP_TRUST_ANCHORS_PEM' => malformed_cert)
+
+    expect { policy.server_metadata_kwargs }
+      .to raise_error(Safire::Errors::CertificateError) { |error|
+        expect(error.message).to include('UDAP_TRUST_ANCHORS_PEM')
+        expect(error.message).not_to include('not a certificate')
+      }
+  end
+
+  it 'raises CertificateError for malformed CRL PEM' do
+    policy = described_class.new('UDAP_CRLS_PEM' => 'not pem')
+
+    expect { policy.server_metadata_kwargs }
+      .to raise_error(Safire::Errors::CertificateError, /UDAP_CRLS_PEM/)
+  end
+end


### PR DESCRIPTION
## Summary

This PR adds the demo foundation for UDAP Dynamic Client Registration credentials. It separates UDAP server trust policy from client signing identity, extracts signed metadata trust configuration into a dedicated model, adds a lazy UDAP client signing credential loader, and keeps SMART and UDAP client identifiers separate in demo server storage. It also threads Safire's loopback-only HTTP development policy through the demo so local SMART callbacks and local test servers work without weakening remote HTTPS defaults.

The docs and example environment file now describe the UDAP client signing variables for the upcoming registration UI work, and the DCR cancellation docs clarify that cancellation still requires a successful 2xx HTTP response before body confirmation is accepted.

## Validation

- bundle exec rspec
- bundle exec rubocop --cache false
- bin/docs
- cd docs && bundle exec jekyll build