### PR TITLE
Complete UDAP DCR documentation review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+All notable changes to the packaged Safire gem will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -12,32 +12,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Safire::Client#register_client` and `Safire::Client#cancel_registration` now
   support the UDAP Security STU2 Dynamic Client Registration lifecycle when
   initialized with `protocol: :udap`. Safire performs discovery-bound
-  registration, validates `signed_metadata`, checks `UdapMetadata#valid?`, signs
-  a fresh X.509-backed `software_statement`, posts the fixed UDAP envelope with
-  optional `certifications`, accepts new-registration `201` and update-style
-  `200` registration responses with a valid `client_id`, confirms cancellation
-  responses through an empty `grant_types` array, and preserves UDAP
-  registration error codes such as `invalid_software_statement` and
-  `unapproved_software_statement`.
+  registration against authoritative signed endpoints, checks structural DCR
+  capability, posts the fixed UDAP envelope with optional certification or
+  endorsement JWTs, accepts new-registration `201` and update-style `200`
+  responses with a valid `client_id`, and confirms cancellation through a
+  successful response containing a valid `client_id` and an empty `grant_types`
+  array. OAuth-style failures preserve UDAP error codes such as
+  `invalid_software_statement` and `unapproved_software_statement`.
 - `Safire::Protocols::UdapRegistrationMetadata` validates and normalizes
   caller-controlled UDAP Security STU2 registration and cancellation metadata
   before software-statement signing. It enforces exact grant shapes, HTTPS
   redirect and logo URIs, required `mailto:` contact data, protocol-owned
   fields, JSON-compatible extensions, and immutable canonical output. An
   explicit `allow_insecure_localhost: true` option permits development-only
-  HTTP loopback URIs without allowing remote HTTP.
-- Safire can construct UDAP Security STU2 X.509-backed software statements for
-  Dynamic Client Registration. The signing foundation produces compact JWS
-  values with minimal `alg`/`x5c` headers, exact `iss`/`sub`/`aud` claims, a
-  five-minute lifetime, fresh `jti`, RSA/EC algorithm negotiation constrained
-  by discovery and key type, and local certificate/key/SAN consistency checks.
-  The UDAP registration protocol flow now uses this signing foundation internally.
-- `Safire::ClientConfig` accepts a leaf-first, issuer-ordered
-  `certificate_chain` of PEM strings or `OpenSSL::X509::Certificate` instances
-  as the client signing identity foundation for UDAP Dynamic Client
-  Registration. Configured chains must be non-empty; certificate objects are
-  stored as DER snapshots, and the chain is masked alongside private keys and
-  client secrets in configuration output.
+  HTTP loopback URIs without allowing remote HTTP. Registration software
+  statements use minimal `alg`/`x5c` headers, exact `iss`/`sub`/`aud` claims, a
+  five-minute lifetime, fresh `jti`, key-compatible algorithm negotiation, and
+  local certificate/key/SAN checks. `ClientConfig` accepts and masks the
+  non-empty, leaf-first `certificate_chain` of PEM strings or
+  `OpenSSL::X509::Certificate` instances required for UDAP registration.
 - UDAP Security STU2 discovery is now available with
   `Safire::Client.new(..., protocol: :udap).server_metadata`. Safire fetches
   `/.well-known/udap`, supports community-scoped discovery via `community:`, accepts
@@ -58,34 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   validates.
 - `UdapMetadata#signed_metadata_valid?` allows explicit cryptographic re-validation
   against caller-provided trust anchors and revocation material.
-- The Sinatra demo includes a protocol-aware UDAP Discovery workflow with
-  community-scoped discovery, signed metadata validation status, and configurable
-  UDAP trust material.
-- The Sinatra demo now separates UDAP server trust policy from UDAP client
-  signing credential configuration, documents the signing environment variables
-  used by UDAP registration workflows, stores SMART and UDAP client
-  identifiers separately, and opts local SMART demo callbacks into Safire's
-  loopback-only HTTP development policy.
-- The Sinatra demo includes a UDAP Dynamic Client Registration lifecycle screen
-  with prepopulated client metadata, certificate-backed software-statement
-  signing, community and certification inputs, opt-in grant-matched
-  certification JWT file loading, filtered registration results, manual
-  `udap_client_id` entry for externally registered clients, persistence of the
-  UDAP client URI and community needed for cancellation, duplicate registration
-  prevention, CSRF-protected lifecycle actions, cancellation confirmation,
-  home-page entry points for unregistered UDAP servers, and a development-only
-  HTTP loopback policy aligned with SMART demo registration.
-- The Sinatra demo HTML-escapes SMART metadata and token responses and redacts
-  signing material, client secrets, token fields, unknown response fields, and
-  structurally unexpected values from displayed UDAP registration and
-  cancellation responses.
-- `bin/demo` now prepares the ignored Sinatra demo `.env` file before boot,
-  filling absent local-only session secrets, SMART asymmetric demo credentials,
-  UDAP client signing credentials, and grant-specific sample self-signed
-  certification JWTs while preserving existing nonblank values. Generated
-  certifications are submitted only when explicitly selected in the demo, and
-  legacy, expired, malformed, or signing-key-mismatched managed samples are
-  regenerated without replacing caller-managed custom files.
 - `Safire::Errors::DiscoveryError` accepts a `label:` keyword argument (default:
   `'SMART configuration'`) and exposes it as a readable attribute so callers can
   identify which protocol's discovery failed.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,14 +35,19 @@ Feedback, bug reports, and pull requests are welcome via the [issue tracker](htt
   signed endpoint claim precedence
 - **Protocol-Aware Client Facade** — `Safire::Client.new(..., protocol: :udap)`
   exposes UDAP discovery while rejecting SMART-only `client_type:` values
-- **Demo Workflow** — Sinatra demo supports protocol-aware server setup and a
-  UDAP Discovery screen with signed metadata trust status
 - **UDAP Dynamic Client Registration** — certificate-backed STU2 new
   registration, modification, and cancellation via signed software statements;
   includes metadata validation, signed endpoint precedence, community-scoped
   discovery, certification envelope handling, RFC 7591-shaped registration
   response parsing, and cancellation confirmation through an empty
   `grant_types` response
+
+### Demo Application
+
+- **Protocol-Aware Workflows** — Sinatra demo supports protocol-aware server
+  setup, SMART discovery, registration, authorization, and token workflows,
+  plus UDAP signed metadata discovery and the registration/cancellation
+  lifecycle
 
 ---
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -19,8 +19,8 @@
 # in the templates via {{ site.myvariable }}.
 
 title: Safire Documentation
-tagline: Ruby gem for SMART App Launch and UDAP protocols
-description: SMART App Launch and UDAP implementation library for Ruby
+tagline: Ruby gem for SMART App Launch and UDAP discovery and registration
+description: SMART App Launch and UDAP discovery and registration library for Ruby
 author: Vanessa Fotso
 lang: en-US
 baseurl: /safire

--- a/docs/adr/ADR-002-facade-and-forwardable.md
+++ b/docs/adr/ADR-002-facade-and-forwardable.md
@@ -55,13 +55,15 @@ class Client
   def build_protocol_client
     case @protocol
     when :smart then Protocols::Smart.new(config, client_type:)
-    when :udap  then raise NotImplementedError, 'UDAP protocol client is not yet implemented'
+    when :udap  then Protocols::Udap.new(config)
     end
   end
 end
 ```
 
-`Protocols::Smart` includes `Protocols::Behaviours` to declare the required interface. Future protocol implementations (e.g. `Protocols::Udap`, once it exists) will do the same. Adding a new protocol requires:
+`Protocols::Smart` and `Protocols::Udap` include `Protocols::Behaviours` to
+declare the required interface. Unsupported methods inherit the default
+`NotImplementedError`. Adding another protocol requires:
 1. Implementing the `Behaviours` interface in a new class
 2. Adding a `when` branch to `build_protocol_client` in `Client`
 3. Adding its valid client types to `PROTOCOL_CLIENT_TYPES`
@@ -81,7 +83,10 @@ The original design aimed for "no changes to `Client` itself" when adding a prot
 - Protocol implementations are independently testable
 - `Forwardable` delegation is explicit and greppable
 - The `protocol:` keyword cleanly selects the implementation class without leaking subclass names to callers
-- `client_type=` mutation works naturally — the facade updates `@protocol_client` in place (see [ADR-006]({% link adr/ADR-006-lazy-discovery.md %}) for why this preserves cached discovery)
+- SMART `client_type=` mutation works naturally — the facade updates
+  `@protocol_client` in place (see [ADR-006]({% link adr/ADR-006-lazy-discovery.md %})
+  for why this preserves cached discovery); UDAP rejects `client_type=` because
+  SMART client types are not applicable
 
 **Trade-offs:**
 - `Client` itself has no runtime behaviour — all logic lives in protocol classes; contributors must know to look in `Protocols::Smart` for SMART logic, not in `Client`

--- a/docs/adr/ADR-003-protocol-vs-client-type.md
+++ b/docs/adr/ADR-003-protocol-vs-client-type.md
@@ -31,7 +31,13 @@ Safire::Client.new(config, protocol: :smart, client_type: :confidential_symmetri
 Safire::Client.new(config, protocol: :udap)  # client_type not applicable
 ```
 
-The key structural difference: SMART has three client authentication methods; UDAP has none — UDAP always authenticates via signed JWT assertions (AnT) with an X.509 certificate chain, and this is not user-configurable. Mixing them into one flat enum would create invalid combinations (`:udap_public`, `:udap_confidential_symmetric`) and make `client_type=` mutation impossible to express cleanly.
+The key structural difference: SMART has three client authentication methods,
+while UDAP does not expose SMART-style client types. The UDAP specification
+defines X.509-backed signed JWT assertions (AnT), although those authentication
+flows are not yet implemented by Safire. Mixing the dimensions into one flat
+enum would create invalid combinations (`:udap_public`,
+`:udap_confidential_symmetric`) and make `client_type=` mutation impossible to
+express cleanly.
 
 ---
 
@@ -44,7 +50,7 @@ VALID_PROTOCOLS = %i[smart udap].freeze
 
 PROTOCOL_CLIENT_TYPES = {
   smart: %i[public confidential_symmetric confidential_asymmetric],
-  udap:  nil   # not user-configurable; AnT with x5c always used
+  udap:  nil   # SMART client type is not applicable
 }.freeze
 ```
 
@@ -57,7 +63,8 @@ PROTOCOL_CLIENT_TYPES = {
 ## Consequences
 
 **Benefits:**
-- No invalid combinations — UDAP has no client type choices at all; this is enforced at the type level, not with runtime checks
+- No invalid combinations — the facade rejects every explicit UDAP
+  `client_type:` value at construction and assignment
 - `client_type=` mutation is clean and natural for the "discover first, then select client type" pattern
 - Adding a new SMART client type requires only adding a symbol to `PROTOCOL_CLIENT_TYPES[:smart]`
 - Adding a new protocol requires adding an entry to `PROTOCOL_CLIENT_TYPES` and a branch to `build_protocol_client` (see [ADR-002]({% link adr/ADR-002-facade-and-forwardable.md %}))

--- a/docs/adr/ADR-004-clientconfig-immutability-and-entity-masking.md
+++ b/docs/adr/ADR-004-clientconfig-immutability-and-entity-masking.md
@@ -42,9 +42,10 @@ causes those values to appear as `'[FILTERED]'` in any hash serialisation.
 
 ```ruby
 def to_hash
-  ATTRIBUTES.each_with_object({}) do |attr, hash|
-    value = send(attr)
-    hash[attr] = sensitive_attributes.include?(attr) ? '[FILTERED]' : value
+  instance_variables.each_with_object({}) do |var, hash|
+    key = var.to_s.delete_prefix('@').to_sym
+    value = instance_variable_get(var)
+    hash[key] = sensitive_attributes.include?(key) && !value.nil? ? '[FILTERED]' : value
   end
 end
 ```
@@ -72,7 +73,8 @@ builder. The leaf-first ordering follows the
 - The order and PEM contents of a configured certificate-chain collection
   cannot be changed through the original input array or strings
 - Credentials cannot leak through `inspect`, `to_s`, exception trackers, or log output
-- Validation at construction means invalid configs are caught early, before any network calls
+- Configuration shape and URI validation run at construction; flow-specific
+  credential and signing checks run when the operation uses them
 - The `sensitive_attributes` hook is extensible — subclasses can add fields without modifying `Entity`
 
 **Trade-offs:**

--- a/docs/adr/ADR-006-lazy-discovery.md
+++ b/docs/adr/ADR-006-lazy-discovery.md
@@ -83,7 +83,8 @@ def server_metadata(community: nil, trusted_anchors: [], crls: [], revocation_ch
     trusted_anchors:,
     crls:,
     revocation_checker:,
-    verify_chain:
+    verify_chain:,
+    allow_insecure_localhost: @allow_insecure_localhost
   }
   cache_key = build_cache_key(community, trusted_anchors, crls, revocation_checker, verify_chain)
   cached_entry = @metadata_cache[cache_key]
@@ -111,7 +112,10 @@ def fetch_metadata(community:, trust_policy:)
     trust_policy:
   )
   {
-    metadata: UdapMetadata.new(raw.merge(signed_claims)),
+    metadata: UdapMetadata.new(
+      raw.merge(signed_claims),
+      allow_insecure_localhost: @allow_insecure_localhost
+    ),
     raw:
   }
 end
@@ -127,7 +131,8 @@ A 204 response means the server has no UDAP workflows for that community. `Proto
 
 **Benefits:**
 - `Safire::Client.new` is instantaneous — no network calls, no stubs required at construction time
-- Configuration errors are raised before any HTTP call
+- Construction-time configuration errors are raised before HTTP; requirements
+  specific to an operation are validated when that operation runs
 - Callers control when discovery happens — supports application-level caching patterns (see [Advanced Examples]({{ site.baseurl }}/advanced/#metadata-caching))
 - `client_type=` mutation preserves cached SMART metadata — no re-discovery
 - UDAP community-and-trust-policy cache allows a single client instance to serve multiple communities without serving stale signed metadata

--- a/docs/adr/ADR-007-https-only-redirects-and-localhost-exception.md
+++ b/docs/adr/ADR-007-https-only-redirects-and-localhost-exception.md
@@ -27,7 +27,7 @@ security boundary and can hide production misconfiguration.
 
 ## Decision
 
-For SMART configuration and HTTP redirects, HTTPS is enforced at **two layers**.
+For client configuration and HTTP redirects, HTTPS is enforced at **two layers**.
 Both layers use the same explicit local-development opt-in:
 
 **Layer 1 — `ClientConfig` URI validation:** all URI attributes (`base_url`, `redirect_uri`, `issuer`, `authorization_endpoint`, `token_endpoint`, `jwks_uri`) must use `https://`, except when `allow_insecure_localhost: true` is configured and the host is `localhost` or `127.0.0.1`.

--- a/docs/adr/ADR-010-optional-client-id-dcr-temp-client.md
+++ b/docs/adr/ADR-010-optional-client-id-dcr-temp-client.md
@@ -44,7 +44,9 @@ client = Safire::Client.new({
 })
 ```
 
-Flow methods that require `client_id` (`authorization_url`, `request_access_token`, `request_backend_token`) validate its presence at call time and raise `ConfigurationError` if absent.
+Flow methods that require `client_id` (`authorization_url`,
+`request_access_token`, `refresh_token`, and `request_backend_token`) validate
+its presence at call time and raise `ConfigurationError` if absent.
 
 ### 2026-07-04 amendment: UDAP certificate-backed temp clients
 

--- a/docs/adr/ADR-011-udap-stu2-discovery-conformance.md
+++ b/docs/adr/ADR-011-udap-stu2-discovery-conformance.md
@@ -41,7 +41,8 @@ for `valid?`.
 **Signed metadata:** STU2 uses `signed_metadata` (not the deprecated `signed_endpoints` from
 earlier drafts). `signed_metadata` is treated as a required field by `UdapMetadata#valid?` and
 as an opaque string. Cryptographic validation of the JWT is intentionally deferred to a
-dedicated cryptographic validator; see [ADR-012](ADR-012-udap-signed-metadata-validation.md).
+dedicated cryptographic validator; see
+[ADR-012]({% link adr/ADR-012-udap-signed-metadata-validation.md %}).
 
 **Presence check uses `nil?`, not `blank?`:** Several required array fields — for example,
 `udap_authorization_extensions_supported` — may legitimately be empty arrays in a conformant
@@ -103,7 +104,7 @@ semantics.
 - `valid?` follows the same warn-and-return-false contract as `SmartMetadata#valid?`, giving
   callers a consistent API across protocols
 - `signed_metadata` cryptographic validation stays separate from the entity; see
-  [ADR-012](ADR-012-udap-signed-metadata-validation.md)
+  [ADR-012]({% link adr/ADR-012-udap-signed-metadata-validation.md %})
 
 **Trade-offs:**
 

--- a/docs/adr/ADR-012-udap-signed-metadata-validation.md
+++ b/docs/adr/ADR-012-udap-signed-metadata-validation.md
@@ -39,10 +39,12 @@ the single-responsibility principle and keeps the entity layer free of crypto de
 
 ### Warn-and-return-nil per failure; raise only on unrecoverable parse errors
 
-Each validation step logs a warning via `Safire.logger.warn` and returns `nil` on failure rather
-than raising. This surfaces every applicable warning in a single call. The only exception is a
-malformed DER certificate in `x5c`, which raises `Safire::Errors::CertificateError` because the
-input cannot be interpreted at all, making further validation impossible.
+Validation failures log a warning through `Safire.logger.warn` and return `nil`
+rather than raising. Decode, header, signature, and chain failures stop checks
+that depend on them; once a payload is trusted enough to inspect, claim checks
+run together so one call surfaces every applicable claim warning. The only
+exception is malformed certificate DER in `x5c`, which raises
+`Safire::Errors::CertificateError` because the certificate cannot be parsed.
 
 ### Chain and revocation verification on by default; `verify_chain: false` for dev/test only
 

--- a/docs/adr/ADR-014-udap-software-statement-signing.md
+++ b/docs/adr/ADR-014-udap-software-statement-signing.md
@@ -81,6 +81,11 @@ key, and advertised by the server. Without an explicit algorithm, Safire chooses
 the first key-compatible advertised algorithm, preferring `RS256` over `RS384`
 for RSA keys because `RS256` is the STU2 baseline.
 
+Protocol orchestration separately requires every DCR-capable server to advertise
+mandatory `RS256` support before Safire signs with any compatible advertised
+algorithm. This enforces the server baseline independently from the configured
+client key type.
+
 ### Validate local signing identity, not server trust
 
 Before signing, Safire parses and snapshots the certificate chain, checks that

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -17,7 +17,7 @@ Architecture Decision Records (ADRs) document significant design decisions made 
 | [ADR-003]({% link adr/ADR-003-protocol-vs-client-type.md %}) | `protocol:` and `client_type:` as orthogonal dimensions | Accepted |
 | [ADR-004]({% link adr/ADR-004-clientconfig-immutability-and-entity-masking.md %}) | `ClientConfig` immutability and `Entity` sensitive attribute masking | Accepted |
 | [ADR-005]({% link adr/ADR-005-per-client-http-ownership.md %}) | Per-client `HTTPClient` ownership — no shared connection pool | Accepted |
-| [ADR-006]({% link adr/ADR-006-lazy-discovery.md %}) | Lazy SMART discovery — no HTTP in constructors | Accepted |
+| [ADR-006]({% link adr/ADR-006-lazy-discovery.md %}) | Lazy discovery — no HTTP in constructors | Accepted |
 | [ADR-007]({% link adr/ADR-007-https-only-redirects-and-localhost-exception.md %}) | HTTPS-only enforcement and explicit localhost opt-in | Accepted |
 | [ADR-008]({% link adr/ADR-008-warn-return-false-for-compliance-validation.md %}) | Warn and return false for compliance validation — raise only for configuration errors | Accepted |
 | [ADR-009]({% link adr/ADR-009-oauth-error-hierarchy.md %}) | `OAuthError` base class and `ReceivesFields` mixin for protocol error hierarchy | Accepted |

--- a/docs/configuration/client-setup.md
+++ b/docs/configuration/client-setup.md
@@ -46,7 +46,13 @@ client = Safire::Client.new(config)
 ```
 
 {: .note }
-> `client_id` is the only authorization parameter validated at call time rather than at construction. `authorization_url`, `request_access_token`, `refresh_token`, and `request_backend_token` each raise `Safire::Errors::ConfigurationError` if `client_id` is absent when called. This means you can build a client without a `client_id` and call `register_client` to obtain one at runtime. See [SMART Dynamic Client Registration]({{ site.baseurl }}/smart-on-fhir/dynamic-client-registration/) or [UDAP Dynamic Client Registration]({{ site.baseurl }}/udap/dynamic-client-registration/) for details.
+> `client_id` is intentionally optional at construction. `authorization_url`,
+> `request_access_token`, `refresh_token`, and `request_backend_token` validate
+> it when called. This permits a temporary client to call `register_client` and
+> obtain an identifier first. Other flow-specific credentials and signing
+> requirements may also be validated when the operation that needs them runs.
+> See [SMART Dynamic Client Registration]({{ site.baseurl }}/smart-on-fhir/dynamic-client-registration/)
+> or [UDAP Dynamic Client Registration]({{ site.baseurl }}/udap/dynamic-client-registration/).
 
 ---
 
@@ -198,7 +204,10 @@ For a decision guide on which workflow to use, see [SMART App Launch — Choosin
 
 ## URI Validation
 
-All URI parameters are validated at initialization. Safire raises `Safire::Errors::ConfigurationError` for any violation:
+All URI attributes supplied through `ClientConfig` are validated at
+initialization. Per-call values, such as UDAP registration metadata, are
+validated by the operation-specific value object or protocol flow. Safire
+raises `Safire::Errors::ConfigurationError` for invalid configuration URIs:
 
 - URIs must be well-formed (scheme + host required)
 - URIs must use `https` — required for SMART App Launch and UDAP discovery

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -50,7 +50,7 @@ flowchart TD
 | `certificate_chain` | Array of PEM strings / OpenSSL::X509::Certificate | No | — | Non-empty, leaf-first, issuer-ordered client certificate chain for UDAP software-statement signing |
 | `kid` | String | No | — | Key ID matching the public key registered with the server |
 | `jwt_algorithm` | String | No | auto | SMART: `RS384` or `ES384`; UDAP registration: `RS256`, `RS384`, `ES256`, or `ES384`, constrained by the key and server metadata |
-| `jwks_uri` | String | No | — | URL to client's public JWKS, included as `jku` in JWT header |
+| `jwks_uri` | String | No | — | SMART-only URL to the client's public JWKS, included as `jku` in SMART JWT assertions |
 | `scopes` | Array | No | — | Default scopes for authorization requests |
 | `authorization_endpoint` | String | No | — | Override the discovered authorization endpoint |
 | `token_endpoint` | String | No | — | Override the discovered token endpoint |

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ layout: default
 title: Home
 nav_order: 1
 permalink: /
-description: "Safire is a Ruby gem implementing SMART App Launch 2.2.0 and UDAP Security STU2 for healthcare client applications."
+description: "Safire implements SMART App Launch 2.2.0 plus UDAP Security STU2 discovery and Dynamic Client Registration for Ruby clients."
 ---
 
 # Safire Documentation
@@ -55,7 +55,8 @@ A Sinatra-based demo app is included to help you explore Safire's features:
 bin/demo
 ```
 
-Visit http://localhost:4567 to test SMART discovery, authorization flows, token management, and backend services token requests.
+Visit http://localhost:4567 to test SMART registration and authorization flows,
+UDAP signed metadata discovery, and the UDAP registration lifecycle.
 
 See [`examples/sinatra_app/README.md`](https://github.com/vanessuniq/safire/tree/main/examples/sinatra_app) for details.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -99,7 +99,7 @@ def fetch_client_secret
 end
 ```
 
-### Private Keys (Confidential Asymmetric)
+### Private Keys and Client Certificates
 
 ```ruby
 # ❌ NEVER: render or log the key
@@ -130,7 +130,8 @@ def fetch_private_key
 end
 ```
 
-Use strong keys:
+For SMART confidential-asymmetric flows, use strong keys compatible with the
+SMART signing algorithms:
 
 ```ruby
 # RSA: minimum 2048-bit, 4096-bit recommended
@@ -142,6 +143,38 @@ key = OpenSSL::PKey::EC.generate('secp384r1')
 
 {: .note }
 > Safire automatically masks `client_secret` and `private_key` in `inspect` output and error messages, so they will not appear in Rails logs even if a `ClientConfig` object is accidentally logged.
+
+UDAP Dynamic Client Registration additionally requires a leaf-first client
+certificate chain. The certificates contain public material, but they identify
+the client's operational signing identity and can be large, so Safire masks
+`certificate_chain` in `ClientConfig#inspect` and `#to_hash` as well.
+
+```ruby
+udap_client = Safire::Client.new(
+  {
+    base_url: 'https://fhir.example.com',
+    private_key: Rails.application.credentials.udap[:private_key_pem],
+    certificate_chain: [
+      File.read(ENV.fetch('UDAP_CLIENT_CERTIFICATE_PATH')),
+      File.read(ENV.fetch('UDAP_CLIENT_ISSUING_CA_PATH'))
+    ]
+  },
+  protocol: :udap
+)
+```
+
+Keep the two UDAP trust directions separate:
+
+- `private_key` and `certificate_chain` identify the client and sign
+  registration software statements.
+- `trusted_anchors`, `crls`, and `revocation_checker` validate the server's
+  discovery `signed_metadata`.
+
+Never use `verify_chain: false` or `allow_insecure_localhost: true` in
+production. The generated credentials and self-declaration JWTs in the
+unbundled Sinatra demo are development fixtures, not production trust material.
+See [UDAP Dynamic Client Registration]({% link udap/dynamic-client-registration/index.md %})
+for the complete trust model.
 
 ---
 

--- a/docs/troubleshooting/client-errors.md
+++ b/docs/troubleshooting/client-errors.md
@@ -38,7 +38,7 @@ For UDAP, the registration endpoint is always discovery-bound. Safire raises
 `DiscoveryError` before POSTing when discovery fails, `signed_metadata` cannot
 be validated, `UdapMetadata#valid?` reports structural non-conformance, the
 server does not advertise `udap_dcr`, or the server does not publish
-registration signing algorithms:
+mandatory `RS256` registration signing support:
 
 ```ruby
 registration = udap_client.register_client(
@@ -66,7 +66,9 @@ Common causes:
 - non-HTTPS redirect or logo URIs, except HTTP localhost when explicitly enabled for development
 - reserved claims such as `iss`, `sub`, `aud`, `exp`, `jti`, `software_statement`, `certifications`, or `udap`
 - `certifications:` is not `nil` or an array of compact JWS strings
-- discovery declares required certifications, but `certifications:` is omitted or empty
+- discovery declares required certification policy URIs, but `certifications:`
+  is omitted or empty; the server still decides whether supplied JWTs satisfy
+  those policies
 
 ### `CertificateError`: UDAP client signing identity cannot support registration
 

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -28,7 +28,7 @@ Safire raises typed errors so you can handle each failure category separately:
 
 | Error class | When raised |
 |-------------|-------------|
-| `Safire::Errors::ConfigurationError` | Missing or invalid client configuration — caught at construction time |
+| `Safire::Errors::ConfigurationError` | Missing or incompatible configuration; URI and shape errors may be caught at construction, while flow-specific requirements are checked when used |
 | `Safire::Errors::DiscoveryError` | SMART or UDAP metadata discovery failed (HTTP error, invalid JSON, missing SMART `token_endpoint` when required, or UDAP `signed_metadata` validation failure) |
 | `Safire::Errors::ValidationError` | Caller-controlled input is invalid before a request is sent, such as UDAP registration metadata or certification JWT shape |
 | `Safire::Errors::CertificateError` | UDAP `x5c` certificate data could not be parsed or the configured UDAP client certificate chain cannot support signing |

--- a/docs/udap.md
+++ b/docs/udap.md
@@ -12,26 +12,21 @@ has_children: true
 {: .no_toc }
 
 <div class="code-example" markdown="1">
-**Implemented now:** UDAP Security STU2 discovery (`/.well-known/udap`)
-including signed metadata validation and optional community scoping, plus
-certificate-backed Dynamic Client Registration for registration, modification,
-and cancellation. JWT client authentication and Tiered OAuth remain planned. See
-[ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md).
+Safire implements UDAP Security STU2 discovery, signed metadata validation,
+community scoping, and certificate-backed Dynamic Client Registration for new
+registration, modification, and cancellation. JWT client authentication and
+Tiered OAuth remain planned.
 </div>
-
-## Table of contents
-{: .no_toc .text-delta }
-
-1. TOC
-{:toc}
-
----
 
 ## Overview
 
-UDAP (Unified Data Access Profiles) is a security framework for healthcare data exchange defined by the [UDAP Security STU2 / v2.0.0 Implementation Guide](https://hl7.org/fhir/us/udap-security/STU2/index.html). It extends standard OAuth 2.0 with X.509 certificate-based identity, dynamic client registration, and trust community models, designed primarily for backend system-to-system integration and cross-organizational data access.
+UDAP (Unified Data Access Profiles) is a security framework for healthcare data
+exchange defined by the
+[UDAP Security STU2 / v2.0.0 Implementation Guide](https://hl7.org/fhir/us/udap-security/STU2/index.html).
+It adds X.509-based identity, signed metadata, dynamic registration, and trust
+community semantics to OAuth-based workflows.
 
-UDAP is a separate protocol from SMART. In Safire, select it via `protocol: :udap` rather than a `client_type:`.
+Select UDAP independently from SMART client authentication types:
 
 ```ruby
 client = Safire::Client.new(
@@ -40,51 +35,46 @@ client = Safire::Client.new(
 )
 ```
 
-`client_type:` is not applicable to UDAP. Passing one explicitly, or assigning `client.client_type = ...` on a UDAP client, raises `Safire::Errors::ConfigurationError`.
-
----
+`client_type:` is not applicable to UDAP. Passing one explicitly, or assigning
+`client.client_type = ...` on a UDAP client, raises
+`Safire::Errors::ConfigurationError`.
 
 ## Discovery
 
-UDAP server metadata discovery fetches `/.well-known/udap`, validates the `signed_metadata` JWT, and merges the authoritative signed endpoint claims into a `UdapMetadata` object. Results are cached per community and trust policy within a client instance. Cache hits revalidate the cached `signed_metadata` before returning; if the JWT, certificate chain, or revocation policy no longer validates, Safire discards the cached entry and refetches discovery metadata.
+`server_metadata` fetches `/.well-known/udap`, validates the required
+`signed_metadata` JWT, and merges authoritative signed endpoint claims over
+their unsigned JSON counterparts before returning `UdapMetadata`.
 
-### Trust anchors and revocation
+### Server trust and revocation
 
-Per UDAP Security STU2, `signed_metadata` JWT signature, X.509 chain verification, and certificate revocation status checking are performed on every production discovery call. Provide your trust anchors as `OpenSSL::X509::Certificate` objects and either CRLs as `OpenSSL::X509::CRL` objects or a custom `revocation_checker:`:
+Production discovery requires caller-supplied trust anchors plus an explicit
+revocation policy. Use CRLs or a custom checker:
 
 ```ruby
-ca_cert = OpenSSL::X509::Certificate.new(File.read('udap_ca.pem'))
-ca_crl  = OpenSSL::X509::CRL.new(File.read('udap_ca.crl'))
-
-client = Safire::Client.new(
-  { base_url: 'https://fhir.example.com' },
-  protocol: :udap
-)
+ca_cert = OpenSSL::X509::Certificate.new(File.read('udap-ca.pem'))
+ca_crl  = OpenSSL::X509::CRL.new(File.read('udap-ca.crl'))
 
 metadata = client.server_metadata(
   trusted_anchors: [ca_cert],
   crls:            [ca_crl]
 )
-puts metadata.token_endpoint
-puts metadata.udap_versions_supported.inspect
-puts metadata.udap_profiles_supported.inspect
 ```
 
-{: .note }
-> **Development and testing**: Pass `verify_chain: false` to skip X.509 chain and revocation validation when working with self-signed certificates or local servers that do not have a CA-issued UDAP certificate. Never use `verify_chain: false` in production.
->
-> ```ruby
-> metadata = client.server_metadata(verify_chain: false)
-> ```
->
-> Local HTTP loopback servers also require `allow_insecure_localhost: true`
-> in the client configuration. That option permits HTTP only on `localhost`
-> and `127.0.0.1`; it is a Safire development exception, not UDAP production
-> conformance.
+Safire verifies the JWT signature, certificate chain and revocation status,
+issuer/SAN relationship, time claims, `jti`, and signed endpoint claims. Results
+are cached per community and trust policy, but cache hits revalidate the signed
+metadata before reuse. An expired or newly untrusted entry is discarded and
+refetched.
+
+{: .warning }
+> `verify_chain: false` skips X.509 chain and revocation validation. Use it only
+> for development and tests. Local HTTP loopback servers separately require
+> `allow_insecure_localhost: true` in `ClientConfig`; this permits HTTP only on
+> `localhost` and `127.0.0.1` and is not production UDAP conformance.
 
 ### Community-scoped discovery
 
-Many UDAP servers host multiple trust communities at the same base URL, each scoped by a community URI. Pass `community:` to target a specific community:
+Pass a trust-community URI when a server supports multiple communities:
 
 ```ruby
 metadata = client.server_metadata(
@@ -92,89 +82,69 @@ metadata = client.server_metadata(
   trusted_anchors: [ca_cert],
   crls:            [ca_crl]
 )
-puts metadata.token_endpoint
 ```
 
-Results are cached separately per community and trust policy. Calling `server_metadata` with different community, `trusted_anchors`, `crls`, or `revocation_checker` arguments uses a separate cache entry, and each cached entry is revalidated before reuse.
+Different community, trust-anchor, CRL, revocation-checker, or chain-verification
+arguments use separate cache entries.
 
-### Validation helpers
+### Structural and capability helpers
 
-`UdapMetadata#valid?` checks the structure and STU2 value rules in the discovered JSON. It verifies required fields, fixed STU2 values such as `udap_versions_supported == ["1"]`, required profile advertisements, array types, conditional fields, and endpoint URL shape. It logs warnings and returns `false` for non-conformant metadata.
+`UdapMetadata#valid?` checks required fields, exact STU2 fixed values, array and
+string types, conditional fields, subset rules, and endpoint URL shape. It logs
+each violation and returns `false`; it does not repeat cryptographic validation.
 
 ```ruby
-metadata = client.server_metadata(trusted_anchors: [ca_cert], crls: [ca_crl])
-
 unless metadata.valid?
-  # Safire.logger.warn has already logged each conformance violation.
+  # Safire.logger.warn has already recorded each structural violation.
   raise 'UDAP metadata is structurally non-conformant'
 end
 ```
 
-`server_metadata` already validates `signed_metadata` before returning. Use `signed_metadata_valid?` when you need to re-check an existing metadata object against a different trust policy:
+Profile-only helpers inspect raw profile advertisements. Capability helpers add
+the endpoint or grant preconditions Safire can verify locally:
 
-```ruby
-metadata.signed_metadata_valid?(
-  base_url:         'https://fhir.example.com',
-  trusted_anchors: [alternate_ca],
-  crls:            [alternate_crl]
-)
-```
+| Capability helper | Checks |
+|-------------------|--------|
+| `supports_dynamic_registration?` | `udap_dcr` profile plus a valid `registration_endpoint` |
+| `supports_jwt_client_auth?` | `udap_authn` profile plus a valid `token_endpoint` |
+| `supports_client_authorization?` | `udap_authz`, `client_credentials`, and a valid `token_endpoint` |
+| `supports_authorization_code?` | `authorization_code` grant advertisement |
+| `supports_refresh_token?` | `refresh_token` grant advertisement |
+| `supports_tiered_oauth?` | `udap_to` profile advertisement |
+| `supports_signed_metadata?` | Compact-JWS-shaped `signed_metadata` value |
 
-Support helpers expose advertised profiles and usable discovery capabilities.
-Capability helpers combine profile or grant signals with the endpoint
-preconditions Safire can verify during discovery. These describe what the
-server advertises; `register_client` performs its own discovery-bound checks
-before submitting a UDAP registration request.
+The corresponding profile helpers are `dynamic_registration_profile?`,
+`jwt_client_auth_profile?`, `client_authorization_profile?`, and
+`tiered_oauth_profile?`.
 
-| Helper | Checks |
-|--------|--------|
-| `supports_dynamic_registration?` | `udap_dcr` profile and a valid endpoint URL for `registration_endpoint` |
-| `supports_jwt_client_auth?` | `udap_authn` profile and a valid endpoint URL for `token_endpoint` |
-| `supports_client_authorization?` | `udap_authz` profile, `client_credentials` grant, and a valid endpoint URL for `token_endpoint` |
-| `supports_authorization_code?` | `authorization_code` appears in `grant_types_supported` |
-| `supports_refresh_token?` | `refresh_token` appears in `grant_types_supported` |
-| `supports_tiered_oauth?` | `udap_to` profile is advertised |
-| `supports_signed_metadata?` | `signed_metadata` is present in compact-JWS format |
+Use `signed_metadata_valid?(base_url:, ...)` only when explicitly revalidating
+an existing metadata object against another trust policy. Metadata returned by
+`server_metadata` is already cryptographically validated.
 
-```ruby
-metadata.supports_dynamic_registration?
-metadata.supports_jwt_client_auth?
-metadata.supports_client_authorization?
-metadata.supports_authorization_code?
-metadata.supports_refresh_token?
-metadata.supports_tiered_oauth?
-metadata.supports_signed_metadata?
-```
+### Discovery failures
 
-Profile-only helpers check only whether a profile string appears in `udap_profiles_supported`; they do not check endpoints or grant types. Use these when you need to inspect the raw advertisement separately from capability readiness.
-
-```ruby
-metadata.dynamic_registration_profile?
-metadata.jwt_client_auth_profile?
-metadata.client_authorization_profile?
-metadata.tiered_oauth_profile?
-```
-
----
+| Condition | Safire behavior |
+|-----------|-----------------|
+| `404 Not Found` | Raises `DiscoveryError`; clients treat the server as not supporting UDAP workflows |
+| `204 No Content` | Raises `DiscoveryError` before body parsing; no UDAP workflow is available for that community |
+| Invalid `signed_metadata` | Raises `DiscoveryError` after validation warnings |
+| Malformed DER in JOSE `x5c` | Raises `CertificateError` |
+| Invalid `community:` | Raises `ConfigurationError` before HTTP |
+| Connection, TLS, timeout, or blocked redirect failure | Raises `NetworkError` |
 
 ## Dynamic Client Registration
 
-UDAP Dynamic Client Registration is available through the same facade method as
-SMART registration, selected by `protocol: :udap`. Safire discovers and
-validates UDAP metadata, signs your registration metadata into a
-`software_statement`, posts the fixed UDAP request envelope, and returns the
-server's registration response. Use `register_client` for new registration and
-modification, and `cancel_registration` for cancellation.
+UDAP DCR is discovery-bound. Safire validates discovery metadata, signs
+caller-controlled registration metadata into a short-lived X.509-backed
+`software_statement`, and POSTs the fixed UDAP envelope to the authoritative
+signed `registration_endpoint`.
 
 ```ruby
 client = Safire::Client.new(
   {
     base_url: 'https://fhir.example.com',
     private_key: File.read('client-key.pem'),
-    certificate_chain: [
-      File.read('client-cert.pem'),
-      File.read('issuing-ca.pem')
-    ]
+    certificate_chain: [File.read('client-cert.pem')]
   },
   protocol: :udap
 )
@@ -184,98 +154,49 @@ registration = client.register_client(
     client_name: 'Example Backend Service',
     contacts: ['mailto:security@example.com'],
     grant_types: ['client_credentials'],
-    scope: 'system/Patient.rs system/Observation.rs'
+    scope: 'system/Patient.rs'
   },
   client_uri:      'https://client.example.com',
   trusted_anchors: [ca_cert],
   crls:            [ca_crl]
 )
-
-registration['client_id']
 ```
 
-Cancel an existing registration with the same discovery and trust policy:
+Use `register_client` again with the same client URI and community to request a
+modification. Use `cancel_registration` to send a fresh software statement with
+an empty `grant_types` array. Safire accepts cancellation only when a successful
+response contains a non-blank `client_id` and an empty `grant_types` array.
 
-```ruby
-cancellation = client.cancel_registration(
-  {
-    client_name: 'Example Backend Service',
-    contacts: ['mailto:security@example.com'],
-    scope: 'system/Patient.rs system/Observation.rs'
-  },
-  client_uri:      'https://client.example.com',
-  trusted_anchors: [ca_cert],
-  crls:            [ca_crl]
-)
-
-cancellation['grant_types'] # => []
-```
-
-Pass `community:` when registering, modifying, or cancelling within a specific
-UDAP trust community.
-Pass `certifications:` when the community requires third-party certification
-JWTs. Safire shape-checks those JWT strings and sends them to the authorization
-server; it does not create, verify, or interpret certification contents.
+Pass `certifications:` when required by community policy. Certification and
+endorsement JWTs may be signed by the client operator or a third party. Safire
+validates their compact-JWS shape but leaves issuer, signature, claims, and
+policy evaluation to the authorization server.
 
 See [Dynamic Client Registration]({% link udap/dynamic-client-registration/index.md %})
-for metadata rules, software-statement behavior, trust-policy keywords,
-certification handling, and error boundaries.
+for prerequisites and public API usage, [Registration Metadata]({% link udap/dynamic-client-registration/registration-metadata.md %})
+for input rules, [Software Statements]({% link udap/dynamic-client-registration/software-statement.md %})
+for signing behavior, and [Registration Lifecycle]({% link udap/dynamic-client-registration/lifecycle.md %})
+for modification and cancellation semantics.
 
-### Error handling
+## Scope and Protocol Choice
 
-| Condition | Error raised |
-|-----------|-------------|
-| HTTP 404 | `Safire::Errors::DiscoveryError` with `status` set to `404`; per STU2, clients should treat this as "UDAP workflows are not supported" |
-| Other HTTP 4xx/5xx | `Safire::Errors::DiscoveryError` with `status` populated |
-| Server returns HTTP 204 | `Safire::Errors::DiscoveryError` (server signals no UDAP workflows for the requested community) |
-| `signed_metadata` JWT validation fails | `Safire::Errors::DiscoveryError` (invalid signature, chain, revocation status, endpoint claim, or missing required claim) |
-| Malformed DER certificate in `x5c` header | `Safire::Errors::CertificateError` |
-| Connection failure, timeout, SSL error, or redirect to a non-HTTPS URL | `Safire::Errors::NetworkError` |
-| `community:` is not a valid URI string | `Safire::Errors::ConfigurationError` (raised before any HTTP call) |
+Safire does not yet implement UDAP JWT client authentication, token acquisition,
+authorization-code handling, or Tiered OAuth. Those methods continue to raise
+`NotImplementedError` on a UDAP client. Dynamic registration obtains a
+`client_id`, but the later UDAP authentication and authorization flows remain
+separate roadmap work.
 
----
+| Feature | SMART App Launch in Safire | UDAP Security in Safire |
+|---------|----------------------------|--------------------------|
+| Discovery | SMART configuration JSON | Signed UDAP metadata with X.509 trust validation |
+| Dynamic registration | RFC 7591 metadata request | STU2 X.509-backed software statement |
+| Implemented client flows | App Launch and Backend Services | Registration lifecycle only |
+| Client selection | `client_type:` | `protocol: :udap`; no `client_type:` |
+| Trust model | Per-server client registration and registered keys/secrets | Certificate trust communities and signed metadata |
 
-## Planned Features
+Resources:
 
-### Client Flows
-
-- **JWT Client Authentication** — authenticate on every request using a signed JWT assertion (Authentication Token, AnT) with an X.509 certificate chain in the `x5c` header; the registered `client_id` is reused as `iss` and `sub` in each assertion
-- **Tiered OAuth** — delegated authorization for multi-system access per the UDAP Security IG
-- **Pushed Authorization Requests (RFC 9126)** — PAR support for pre-registering authorization requests
-
-### Trust Framework
-
-- **Client certificate trust management for auth flows** — apply trust anchors
-  and community policy to future UDAP client authentication flows; registration
-  server acceptance of the submitted client certificate remains the
-  authorization server's trust decision
-- **Trust Community Support** — integration with UDAP trust communities (e.g. Carequality, CommonWell)
-
----
-
-## Comparison with SMART
-
-| Feature | SMART | UDAP |
-|---------|-------|------|
-| Primary use case | User-facing apps, EHR launch | B2B, backend services, cross-org access |
-| Client registration | Pre-registered per server, optional DCR (recommended) | Dynamic (DCR) or pre-registered |
-| Authentication | Client secrets or `private_key_jwt` | Signed JWT assertions (AnT) with X.509 `x5c` chain |
-| Trust model | Per-server registration | Certificate-based trust communities |
-| Safire selection | `client_type: :public / :confidential_symmetric / :confidential_asymmetric` | `protocol: :udap` |
-
-### When to use UDAP
-
-| Scenario | Why UDAP |
-|----------|----------|
-| **Backend / B2B Integration** | Server-to-server flows without user interaction; certificate-based identity replaces pre-shared secrets |
-| **Dynamic Client Registration** | Clients can register programmatically without manual server-side approval |
-| **Cross-Organization Access** | Trust communities allow clients to be recognized across participant organizations without per-server registration |
-| **High-Assurance Identity** | X.509 certificates provide stronger identity guarantees than client secrets |
-
-### Resources
-
-- [UDAP Security STU2 / v2.0.0 IG](https://hl7.org/fhir/us/udap-security/STU2/index.html) — HL7 Implementation Guide
-- [UDAP JWT Client Auth](https://www.udap.org/udap-jwt-client-auth.html) — JWT assertion specification
-- [UDAP Dynamic Client Registration](https://www.udap.org/udap-dynamic-client-registration.html) — DCR specification
-- [RFC 9126 — Pushed Authorization Requests](https://datatracker.ietf.org/doc/html/rfc9126)
-- [UDAP Tiered OAuth](https://hl7.org/fhir/us/udap-security/STU2/user.html) — Tiered OAuth for User Authentication
+- [UDAP Security STU2 / v2.0.0 IG](https://hl7.org/fhir/us/udap-security/STU2/index.html)
+- [UDAP Dynamic Client Registration STU1](https://www.udap.org/udap-dynamic-client-registration-stu1.html)
+- [UDAP Certifications and Endorsements STU1](https://www.udap.org/udap-certifications-and-endorsements-stu1.html)
+- [Safire roadmap](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md)

--- a/docs/udap/dynamic-client-registration/index.md
+++ b/docs/udap/dynamic-client-registration/index.md
@@ -12,18 +12,26 @@ has_children: true
 
 {: .no_toc }
 
-<div class="code-example" markdown="1">
-**Current status:** Safire implements UDAP Security STU2 new registration and
-registration modification through `Safire::Client#register_client`, and
-registration cancellation through `Safire::Client#cancel_registration`.
-</div>
+Safire implements the UDAP Security STU2 registration lifecycle for
+certificate-backed clients that can protect a private key. Use
+`Safire::Client#register_client` for new registrations and modifications, and
+`Safire::Client#cancel_registration` for cancellation.
 
-## Register a Client
+## Prerequisites
 
-Create a temporary UDAP client with the FHIR server base URL plus the client
-signing identity. Then call `register_client` with registration metadata and
-the exact `client_uri` that appears as a URI Subject Alternative Name in the
-leaf certificate.
+A registration combines two separate trust directions:
+
+- **Server trust:** Safire validates the authorization server's
+  `signed_metadata` using `trusted_anchors:` plus `crls:` or a
+  `revocation_checker:`.
+- **Client identity:** Safire signs the registration `software_statement` using
+  the client's private key and leaf-first X.509 certificate chain.
+
+The client certificate's URI Subject Alternative Name must exactly match the
+`client_uri:` supplied to the registration call. Safire does not derive this
+identifier from the FHIR server URL or canonicalize it before comparison.
+
+Configure reusable client credentials when constructing the UDAP client:
 
 ```ruby
 client = Safire::Client.new(
@@ -37,7 +45,25 @@ client = Safire::Client.new(
   },
   protocol: :udap
 )
+```
 
+Applications that select signing identities dynamically may instead pass
+`private_key:`, `certificate_chain:`, and `jwt_algorithm:` to each
+`register_client` or `cancel_registration` call. Per-call values override the
+configured defaults without mutating the client.
+
+Before posting, Safire requires structurally conformant discovery metadata,
+the `udap_dcr` profile, a usable signed `registration_endpoint`, and mandatory
+`RS256` support in
+`registration_endpoint_jwt_signing_alg_values_supported`. See
+[Registration Metadata]({% link udap/dynamic-client-registration/registration-metadata.md %})
+for caller input and grant rules.
+
+## Register or Modify
+
+Register a client-credentials application:
+
+```ruby
 registration = client.register_client(
   {
     client_name: 'Example Backend Service',
@@ -50,55 +76,13 @@ registration = client.register_client(
   crls:            [ca_crl]
 )
 
-client_id = registration['client_id']
+client_id = registration.fetch('client_id')
 ```
 
-Safire performs these steps:
-
-1. Discovers UDAP metadata from `/.well-known/udap`, optionally scoped by
-   `community:`.
-2. Validates `signed_metadata` using the supplied server trust policy.
-3. Runs `UdapMetadata#valid?` because registration is about to trust and act on
-   the discovered registration endpoint.
-4. Verifies that the server advertises the `udap_dcr` profile and a usable
-   `registration_endpoint`.
-5. Validates caller registration metadata.
-6. Signs a fresh `software_statement` JWT using the configured or per-call
-   client signing identity.
-7. POSTs the UDAP request envelope and returns the parsed registration response.
-
-Calling `register_client` again with the same `client_uri` and community
-requests modification of the existing registration. Safire returns the server
-response without assuming the `client_id` is unchanged.
-
-Use `cancel_registration` to cancel an existing registration. Cancellation
-uses the same discovery, trust policy, certifications, and signing identity as
-registration, but Safire signs the metadata in cancellation mode and injects an
-empty `grant_types` array:
-
-```ruby
-cancellation = client.cancel_registration(
-  {
-    client_name: 'Example Backend Service',
-    contacts: ['mailto:security@example.com'],
-    scope: 'system/Patient.rs system/Observation.rs'
-  },
-  client_uri:      'https://client.example.com',
-  trusted_anchors: [ca_cert],
-  crls:            [ca_crl]
-)
-
-cancellation['grant_types'] # => []
-```
-
-See [Registration Lifecycle]({% link udap/dynamic-client-registration/lifecycle.md %})
-for modification and cancellation behavior.
-
-### Authorization-code registration
-
-Authorization-code clients include redirect and logo metadata. Safire generates
-`response_types: ["code"]` and `token_endpoint_auth_method: "private_key_jwt"`
-inside the signed software statement.
+Authorization-code clients also supply redirect and logo metadata. Safire
+generates `response_types: ["code"]` and
+`token_endpoint_auth_method: "private_key_jwt"` inside the signed software
+statement.
 
 ```ruby
 registration = client.register_client(
@@ -116,9 +100,15 @@ registration = client.register_client(
 )
 ```
 
-### Community, trust policy, and certifications
+Calling `register_client` again against the same registration endpoint with the
+same `client_uri` and trust community requests modification. The authorization
+server may preserve the existing `client_id` or issue a replacement; use the
+identifier returned by the latest accepted response.
 
-Use `community:` when registering against a specific UDAP trust community:
+## Communities and Certifications
+
+Pass `community:` when the authorization server participates in multiple UDAP
+trust communities:
 
 ```ruby
 registration = client.register_client(
@@ -131,11 +121,13 @@ registration = client.register_client(
 ```
 
 `trusted_anchors:`, `crls:`, `revocation_checker:`, and `verify_chain:` apply
-to server `signed_metadata` validation during discovery. They are not the
-client signing certificate chain.
+only to server `signed_metadata` validation. They are not the client signing
+certificate chain. Passing `verify_chain: false` skips server chain and
+revocation checks and is suitable only for development and tests.
 
-Pass `certifications:` when the discovered community requires or accepts
-third-party certification JWTs:
+UDAP certifications and endorsements may be signed by the client application
+operator or by a third party, depending on the trust community's certification
+definition. Supply the resulting compact JWS values through `certifications:`:
 
 ```ruby
 registration = client.register_client(
@@ -147,144 +139,60 @@ registration = client.register_client(
 )
 ```
 
-`certifications: nil` omits the envelope field. `certifications: []` sends an
-explicit empty array, which is useful for modification requests that clear
-optional certifications. If discovery advertises required certifications,
-Safire rejects `nil` and `[]` locally. Safire shape-checks certification values
-as compact JWS strings but does not create, decode, verify, or interpret their
-contents.
+`certifications: nil` omits the request member. An explicit `[]` sends an empty
+array and can remove optional certifications during modification. When
+discovery advertises non-empty `udap_certifications_required`, Safire rejects
+both forms before signing unless at least one compact JWS is supplied.
 
-### Errors
+Safire checks only collection and compact-JWS shape. It does not create,
+interpret, or cryptographically validate certification or endorsement JWTs;
+the authorization server decides whether they satisfy the advertised policy
+URIs.
+
+## Request, Response, and Errors
+
+Safire performs the following sequence for every registration lifecycle call:
+
+1. Discovers and cryptographically validates community-scoped UDAP metadata.
+2. Runs `UdapMetadata#valid?` because DCR is about to act on the discovered
+   registration endpoint.
+3. Verifies the DCR profile and mandatory registration algorithm advertisement.
+4. Validates caller metadata and certification shape.
+5. Signs a fresh five-minute software statement with a fresh `jti`.
+6. POSTs the fixed UDAP request envelope to the authoritative signed endpoint.
+7. Parses the RFC 7591-shaped response into a string-keyed `Hash`.
+
+The request body contains only:
+
+```json
+{
+  "software_statement": "<compact JWS>",
+  "certifications": ["<compact JWS>"],
+  "udap": "1"
+}
+```
+
+The `certifications` member is omitted when its argument is `nil`. Registration
+accepts `201 Created` for a new registration and `200 OK` for an update-style
+response. Both require a non-blank string `client_id`. The authorization server
+may reject or replace requested registration metadata; treat the returned
+response as the effective server registration rather than assuming it echoes
+the software statement.
 
 | Error | When raised |
 |-------|-------------|
-| `Safire::Errors::DiscoveryError` | Discovery fails, `signed_metadata` cannot be validated, discovered metadata is structurally non-conformant, or the server does not advertise usable UDAP DCR capability |
-| `Safire::Errors::ValidationError` | Caller metadata or the `certifications:` collection is invalid before signing |
-| `Safire::Errors::ConfigurationError` | Signing configuration is missing or incompatible, such as an unsupported explicit `jwt_algorithm` |
-| `Safire::Errors::CertificateError` | The configured client certificate chain cannot support signing or does not match `client_uri:` |
-| `Safire::Errors::RegistrationError` | The registration server returns an OAuth error response, a registration response status other than `200` or `201`, any successful response lacks a non-blank string `client_id`, or a cancellation response does not confirm cancellation with an empty `grant_types` array |
-| `Safire::Errors::NetworkError` | Connection failure, timeout, SSL error, or blocked non-HTTPS redirect |
+| `Safire::Errors::DiscoveryError` | Discovery or `signed_metadata` validation fails, metadata is structurally non-conformant for DCR, or required DCR capability is absent |
+| `Safire::Errors::ValidationError` | Caller metadata or certification input is invalid before signing |
+| `Safire::Errors::ConfigurationError` | Signing configuration or algorithm selection is missing or incompatible |
+| `Safire::Errors::CertificateError` | The client key, certificate chain, validity period, ordering, or URI SAN cannot support signing |
+| `Safire::Errors::RegistrationError` | The server rejects the request or returns a malformed lifecycle response |
+| `Safire::Errors::NetworkError` | The request fails at the transport layer |
 
-## Validate Metadata
+Continue with [Software Statements]({% link udap/dynamic-client-registration/software-statement.md %})
+for signing details and [Registration Lifecycle]({% link udap/dynamic-client-registration/lifecycle.md %})
+for modification, replacement, logical groups, and cancellation. See
+[Client and Registration Errors]({% link troubleshooting/client-errors.md %})
+for remediation guidance.
 
-`register_client` builds `UdapRegistrationMetadata` internally. You can also
-construct it directly when you want to validate metadata before invoking the
-network flow:
-
-```ruby
-metadata = Safire::Protocols::UdapRegistrationMetadata.new(
-  {
-    client_name: 'Example Health App',
-    contacts: ['mailto:security@example.com'],
-    grant_types: %w[authorization_code refresh_token],
-    scope: 'openid system/Patient.rs',
-    redirect_uris: ['https://app.example.com/callback'],
-    logo_uri: 'https://app.example.com/logo.png',
-    software_id: 'example-health-app'
-  }
-)
-
-normalized = metadata.to_h
-normalized['response_types']              # => ["code"]
-normalized['token_endpoint_auth_method']  # => "private_key_jwt"
-```
-
-Top-level symbol keys are normalized to strings. `to_h` returns a defensive
-copy, so changing it cannot alter the validated metadata held by the object.
-Invalid input raises `Safire::Errors::ValidationError`; the error identifies the
-attribute without including its value.
-
-## Metadata Rules
-
-| Field | Requirement |
-|-------|-------------|
-| `client_name` | Required nonblank string |
-| `contacts` | Required nonempty array of absolute URI strings, including at least one valid `mailto:` email address |
-| `grant_types` | Required for registration; exact permitted combinations are listed below |
-| `scope` | Required nonblank, space-delimited OAuth scope string |
-| `redirect_uris` | Required only for `authorization_code`; every value must use HTTPS by default |
-| `logo_uri` | Required only for `authorization_code`; must use HTTPS by default and reference a PNG, JPEG/JPG, or GIF |
-| `response_types` | Generated by Safire as `["code"]` for `authorization_code` |
-| `token_endpoint_auth_method` | Generated by Safire as `"private_key_jwt"` |
-
-### Local development
-
-UDAP Security STU2 requires HTTPS for redirect and logo URIs. Safire enforces
-that requirement by default, including on localhost.
-
-For a local server that does not terminate TLS, explicitly enable the narrow
-development exception:
-
-```ruby
-metadata = Safire::Protocols::UdapRegistrationMetadata.new(
-  {
-    client_name: 'Local Health App',
-    contacts: ['mailto:developer@example.com'],
-    grant_types: ['authorization_code'],
-    scope: 'openid',
-    redirect_uris: ['http://localhost:4567/callback'],
-    logo_uri: 'http://localhost:4567/logo.png'
-  },
-  allow_insecure_localhost: ENV['APP_ENV'] == 'development'
-)
-```
-
-`allow_insecure_localhost: true` permits HTTP only for `localhost` and
-`127.0.0.1`, with an optional port. Remote HTTP hosts remain rejected. Safire
-logs a warning when the exception is actually used because the resulting
-registration metadata is non-conformant and may be rejected by a conformant
-UDAP server.
-
-Safire does not infer the application environment. The host application must
-connect the option to its own development setting, and production should leave
-the default `false` unchanged.
-
-Safire preserves unknown RFC 7591 extension fields when their values are valid
-JSON data. It rejects Ruby-specific values, non-finite numbers, nested objects
-with non-string keys, and recursive collections.
-
-## Grant Profiles
-
-Registration accepts these grant combinations:
-
-| Client flow | `grant_types` | Conditional metadata |
-|-------------|---------------|----------------------|
-| Authorization code | `["authorization_code"]` | `redirect_uris`, `logo_uri`; Safire adds `response_types: ["code"]` |
-| Authorization code with refresh | `["authorization_code", "refresh_token"]` | Same authorization metadata |
-| Client credentials | `["client_credentials"]` | `redirect_uris`, `logo_uri`, and `response_types` must be absent |
-
-Exactly one primary grant is allowed. Unknown grant types, duplicate values,
-`refresh_token` without `authorization_code`, and combining
-`authorization_code` with `client_credentials` raise `ValidationError`.
-
-Cancellation uses the same value object with `operation: :cancel`. Omit
-`grant_types`; Safire injects an empty array and excludes authorization-only
-metadata.
-
-```ruby
-cancellation = Safire::Protocols::UdapRegistrationMetadata.new(
-  {
-    client_name: 'Example Health App',
-    contacts: ['mailto:security@example.com'],
-    scope: 'openid system/Patient.rs'
-  },
-  operation: :cancel
-)
-
-cancellation.to_h['grant_types'] # => []
-```
-
-## Protocol-Owned Fields
-
-Callers cannot override the generated fields above or supply registered JWT
-claims (`iss`, `sub`, `aud`, `iat`, `exp`, `jti`) and request-envelope fields
-(`software_statement`, `certifications`, `udap`). Those values belong to the
-software-statement and registration request builders.
-
-See [Software Statements]({% link udap/dynamic-client-registration/software-statement.md %})
-for the implemented signing foundation, including `x5c`, exact URI comparison,
-algorithm selection, and certificate/key checks.
-
-See the
-[UDAP Security STU2 registration profile](https://hl7.org/fhir/us/udap-security/STU2/registration.html)
-for the normative requirements.
+The [UDAP Security STU2 registration profile](https://hl7.org/fhir/us/udap-security/STU2/registration.html)
+is the normative source for these requirements.

--- a/docs/udap/dynamic-client-registration/lifecycle.md
+++ b/docs/udap/dynamic-client-registration/lifecycle.md
@@ -20,8 +20,8 @@ response rules.
 ## Create or Modify
 
 Call `register_client` for both new registration and modification. A repeated
-call with the same `client_uri` and community requests modification of the
-existing registration.
+call against the same registration endpoint with the same `client_uri` and
+community requests modification of the existing registration.
 
 ```ruby
 registration = client.register_client(
@@ -40,6 +40,23 @@ registration = client.register_client(
 Safire accepts new-registration `201 Created` responses and update-style `200`
 responses. Either response must be a JSON object with a non-blank string
 `client_id`.
+
+The authorization server identifies the registration from the software
+statement's client URI (`iss`) and certificate trust-community context, not from
+a caller-supplied `client_id`. A modification replaces the prior registration
+metadata and may also replace optional certifications. Pass
+`certifications: []` to explicitly clear optional certifications.
+
+The server should preserve the previous `client_id`. If it returns a different
+one, STU2 requires the server to cancel the old registration and the client to
+use only the replacement identifier. Safire returns the response without
+assuming that the identifier is unchanged.
+
+FHIR servers that advertise the same `registration_endpoint` belong to one
+logical registration group. Registering against one server in that group may
+therefore register the client for every endpoint in the group. Safire does not
+attempt to infer these groups from different FHIR base URLs; use the discovered
+registration endpoint and server documentation when managing registrations.
 
 ## Cancel
 
@@ -66,6 +83,12 @@ cancellation['grant_types'] # => []
 Cancellation uses the same discovery-bound registration endpoint, community
 scoping, trust policy, `certifications:`, and X.509 signing configuration as
 `register_client`.
+
+The cancellation request does not send a `client_id`. The authorization server
+identifies the existing registration from the same client URI and
+trust-community identity used for registration. Applications should still
+compare the response `client_id` with the identifier they currently store before
+discarding local registration state.
 
 Unlike registration, Safire does not require a specific success status such as
 `200` or `201` for cancellation, but the final HTTP response must still be a

--- a/docs/udap/dynamic-client-registration/registration-metadata.md
+++ b/docs/udap/dynamic-client-registration/registration-metadata.md
@@ -1,0 +1,133 @@
+---
+layout: default
+title: Registration Metadata
+parent: Dynamic Client Registration
+grand_parent: UDAP
+nav_order: 1
+permalink: /udap/dynamic-client-registration/registration-metadata/
+description: "UDAP Security STU2 registration metadata, grant profiles, URI rules, and local validation."
+---
+
+# Registration Metadata
+
+{: .no_toc }
+
+`register_client` validates caller-controlled metadata before signing it into a
+software statement. Invalid input raises `Safire::Errors::ValidationError` and
+no registration request is sent.
+
+## Validate Input
+
+Applications normally pass a `Hash` to `register_client`. To validate and
+normalize metadata independently, construct
+`Safire::Protocols::UdapRegistrationMetadata` directly:
+
+```ruby
+metadata = Safire::Protocols::UdapRegistrationMetadata.new(
+  {
+    client_name: 'Example Health App',
+    contacts: ['mailto:security@example.com'],
+    grant_types: %w[authorization_code refresh_token],
+    scope: 'openid fhirUser patient/*.rs',
+    redirect_uris: ['https://app.example.com/callback'],
+    logo_uri: 'https://app.example.com/logo.png',
+    software_id: 'example-health-app'
+  }
+)
+
+normalized = metadata.to_h
+normalized['response_types']             # => ["code"]
+normalized['token_endpoint_auth_method'] # => "private_key_jwt"
+```
+
+Top-level symbol keys are normalized to strings. Conflicting symbol and string
+forms of one key are rejected. The validated representation is deeply frozen,
+and `to_h` returns a defensive copy.
+
+## Field Requirements
+
+| Field | Requirement |
+|-------|-------------|
+| `client_name` | Required non-blank string |
+| `contacts` | Required non-empty array of absolute URI strings, including at least one valid `mailto:` email address |
+| `grant_types` | Required for registration; must match one supported grant profile |
+| `scope` | Required non-blank, space-delimited OAuth scope string |
+| `redirect_uris` | Required only with `authorization_code`; every value uses HTTPS by default |
+| `logo_uri` | Required only with `authorization_code`; uses HTTPS by default and references PNG, JPEG/JPG, or GIF content by path |
+| `response_types` | Generated as `["code"]` for `authorization_code` |
+| `token_endpoint_auth_method` | Generated as `"private_key_jwt"` |
+
+Contact entries may use absolute URI schemes such as `mailto:`, `tel:`, or
+`sip:`, but the collection must contain at least one syntactically valid email
+address in a `mailto:` URI.
+
+Safire preserves unknown RFC 7591 extension fields when their values are valid
+JSON data. It rejects Ruby-specific objects, non-finite numbers, recursive
+collections, and nested objects with non-string keys.
+
+## Grant Profiles
+
+Registration accepts exactly one primary grant:
+
+| Client flow | `grant_types` | Conditional metadata |
+|-------------|---------------|----------------------|
+| Authorization code | `["authorization_code"]` | `redirect_uris`, `logo_uri`; Safire adds `response_types: ["code"]` |
+| Authorization code with refresh | `["authorization_code", "refresh_token"]` | Same authorization metadata |
+| Client credentials | `["client_credentials"]` | `redirect_uris`, `logo_uri`, and `response_types` are absent |
+
+Unknown or duplicate grant values, `refresh_token` without
+`authorization_code`, and combining `authorization_code` with
+`client_credentials` are rejected.
+
+Cancellation uses the same value object with `operation: :cancel`. Callers omit
+`grant_types`; Safire injects an empty array and excludes authorization-only
+metadata:
+
+```ruby
+cancellation = Safire::Protocols::UdapRegistrationMetadata.new(
+  {
+    client_name: 'Example Health App',
+    contacts: ['mailto:security@example.com'],
+    scope: 'system/Patient.rs'
+  },
+  operation: :cancel
+)
+
+cancellation.to_h['grant_types'] # => []
+```
+
+## URI and Ownership Rules
+
+UDAP Security STU2 requires HTTPS for `redirect_uris` and `logo_uri`. Safire
+enforces that requirement by default. For an HTTP loopback service used only in
+local development, applications may explicitly enable the narrow exception:
+
+```ruby
+metadata = Safire::Protocols::UdapRegistrationMetadata.new(
+  {
+    client_name: 'Local Health App',
+    contacts: ['mailto:developer@example.com'],
+    grant_types: ['authorization_code'],
+    scope: 'openid',
+    redirect_uris: ['http://localhost:4567/callback'],
+    logo_uri: 'http://localhost:4567/logo.png'
+  },
+  allow_insecure_localhost: ENV['APP_ENV'] == 'development'
+)
+```
+
+This option permits HTTP only on `localhost` and `127.0.0.1`, logs a warning
+when exercised, and produces non-conformant metadata that must not be used in
+production. Safire does not infer the application environment.
+
+Callers cannot supply protocol-owned values:
+
+- generated fields: `response_types`, `token_endpoint_auth_method`
+- registered JWT claims: `iss`, `sub`, `aud`, `iat`, `exp`, `jti`
+- request-envelope fields: `software_statement`, `certifications`, `udap`
+
+These values are generated at the layer that owns them, preventing caller
+metadata from overriding security claims or creating ambiguous request values.
+
+See [Software Statements]({% link udap/dynamic-client-registration/software-statement.md %})
+for the claims added after metadata validation.

--- a/docs/udap/dynamic-client-registration/software-statement.md
+++ b/docs/udap/dynamic-client-registration/software-statement.md
@@ -40,7 +40,8 @@ leaf-first, issuer-ordered certificate chain encoded as Base64 DER strings,
 without PEM wrappers.
 
 Safire does not emit `typ`, `kid`, `jku`, or `x5u` for registration software
-statements.
+statements. STU2's experimental `jku` alternative applies only to access-token
+request and response workflows, not registration requests.
 
 ## Signing Identity
 
@@ -84,7 +85,8 @@ When `jwt_algorithm` is omitted, Safire selects the first compatible advertised
 algorithm. RSA keys prefer `RS256` because it is the STU2 baseline. An explicit
 algorithm must be advertised by the server and compatible with the key. Safire
 raises `DiscoveryError` before signing if the server metadata omits mandatory
-`RS256` registration signing support.
+`RS256` registration signing support, even when the client will use another
+compatible algorithm also advertised by the server.
 
 ## Validation Boundaries
 
@@ -103,6 +105,11 @@ Safire performs local consistency checks before signing:
 Safire does not decide whether the authorization server trusts the client
 certificate. Chain validation, revocation status, and community trust for the
 client certificate are authorization-server decisions during registration.
+
+The server trust policy used to validate discovery metadata is separate. Pass
+`trusted_anchors:`, `crls:`, or `revocation_checker:` to `register_client` or
+`cancel_registration`; do not place server trust anchors in the client
+`certificate_chain`.
 
 See [ADR-014]({% link adr/ADR-014-udap-software-statement-signing.md %}) for
 the signing design rationale.

--- a/examples/sinatra_app/README.md
+++ b/examples/sinatra_app/README.md
@@ -4,7 +4,7 @@ A Sinatra-based web application that demonstrates the Safire gem for SMART autho
 
 ## Features
 
-- **Dynamic Client Registration**: Register this application with a SMART server at runtime using RFC 7591 to obtain a `client_id` automatically
+- **SMART Dynamic Client Registration**: Register this application with a SMART server at runtime using RFC 7591 to obtain a `client_id` automatically
 - **Server Management**: Add, edit, and remove FHIR server configurations with protocol-aware SMART and UDAP sections
 - **SMART Discovery**: View server capabilities from `/.well-known/smart-configuration` including supported scopes, capabilities, and endpoints
 - **UDAP Discovery**: Fetch `/.well-known/udap`, validate `signed_metadata`, inspect STU2 fields, and run community-scoped discovery
@@ -200,14 +200,31 @@ path.
 
 ### Adding a FHIR Server
 
-The home page offers dynamic SMART registration or manual server setup.
+The home page offers protocol-specific SMART and UDAP dynamic registration,
+plus manual server setup.
 
-**Register Dynamically (RFC 7591)** — if the server advertises a `registration_endpoint`:
+**SMART Dynamic Registration (RFC 7591)** creates the server entry as part of
+registration when the SMART server advertises a `registration_endpoint`:
 
 1. Click "Register with a Server" on the home page
 2. Enter the server name and base URL
 3. Choose grant types, authentication method, and optional scope
 4. Click "Register Client" — the app POSTs your metadata to the server, receives a `client_id`, and saves the server entry automatically
+
+**UDAP Dynamic Registration (STU2)** starts from an existing UDAP-enabled server
+entry because discovery, protocol selection, and optional community context
+belong to that server:
+
+1. Add a UDAP server manually if it is not already configured
+2. Use the home-page UDAP action or open the server detail page
+3. Review the prepopulated client metadata and choose a grant profile
+4. Register the certificate-backed software statement; the returned
+   `udap_client_id`, exact client URI, and community are stored on that server
+
+Once a UDAP client ID is stored, registration actions become lifecycle
+management actions. The demo prevents duplicate registration and offers
+cancellation when the stored registration also has the client URI context
+needed to reproduce its issuer identity.
 
 **Add Server Manually** — for SMART credentials, UDAP discovery, or both:
 

--- a/lib/safire/protocols/behaviours.rb
+++ b/lib/safire/protocols/behaviours.rb
@@ -4,7 +4,8 @@ module Safire
     #
     # Include this module in a protocol class to declare conformance with the
     # Safire protocol interface. Each method raises +NotImplementedError+ by
-    # default; concrete protocol classes must override every method.
+    # default; concrete protocol classes override the methods they support so
+    # unsupported flows fail explicitly through the shared contract.
     #
     # @abstract
     # @api private

--- a/lib/safire/protocols/udap.rb
+++ b/lib/safire/protocols/udap.rb
@@ -9,8 +9,8 @@ module Safire
     # Discovery results are cached per community within each instance.
     #
     # Other UDAP flows (B2B client credentials token acquisition, B2C authorization
-    # code, and Tiered OAuth) raise +NotImplementedError+ and are planned for
-    # future PRs.
+    # code, and Tiered OAuth) raise +NotImplementedError+ and remain planned for
+    # future releases.
     #
     # This is an internal class used exclusively by {Safire::Client}. Do not
     # instantiate it directly — use {Safire::Client} instead.
@@ -105,8 +105,8 @@ module Safire
       # @param client_uri [String] exact URI used as +iss+ and +sub+ and required
       #   to appear as a URI SAN in the leaf certificate
       # @param community [String, nil] optional UDAP community URI for discovery
-      # @param certifications [Array<String>, nil] optional third-party certification
-      #   JWTs; +nil+ omits the field and +[]+ sends an explicit empty collection
+      # @param certifications [Array<String>, nil] optional client-operator or third-party
+      #   certification/endorsement JWTs; +nil+ omits the field and +[]+ sends an explicit empty collection
       # @param trusted_anchors [Array<OpenSSL::X509::Certificate>] server trust anchors
       #   for signed metadata validation
       # @param crls [Array<OpenSSL::X509::CRL>] revocation lists for signed metadata validation
@@ -166,8 +166,8 @@ module Safire
       # @param client_uri [String] exact URI used as +iss+ and +sub+ and required
       #   to appear as a URI SAN in the leaf certificate
       # @param community [String, nil] optional UDAP community URI for discovery
-      # @param certifications [Array<String>, nil] optional third-party certification
-      #   JWTs; +nil+ omits the field and +[]+ sends an explicit empty collection
+      # @param certifications [Array<String>, nil] optional client-operator or third-party
+      #   certification/endorsement JWTs; +nil+ omits the field and +[]+ sends an explicit empty collection
       # @param trusted_anchors [Array<OpenSSL::X509::Certificate>] server trust anchors
       #   for signed metadata validation
       # @param crls [Array<OpenSSL::X509::CRL>] revocation lists for signed metadata validation

--- a/safire.gemspec
+++ b/safire.gemspec
@@ -6,12 +6,11 @@ Gem::Specification.new do |spec|
   spec.version               = Safire::VERSION
   spec.authors               = ['Vanessa Fotso']
   spec.email                 = ['vanessuniq@gmail.com']
-  spec.summary               = 'SMART App Launch and UDAP implementation for Ruby'
-  spec.description           = 'A Ruby gem implementing the SMART App Launch 2.2.0 specification and UDAP Security ' \
-                               'protocol for healthcare client applications. It supports OAuth 2.0 authorization ' \
-                               'against HL7 FHIR servers, including PKCE, private_key_jwt assertions (RS384 and ' \
-                               'ES384), confidential client flows, and the Backend Services system-to-system ' \
-                               '(client_credentials) grant.'
+  spec.summary               = 'SMART App Launch and UDAP discovery and registration for Ruby'
+  spec.description           = 'A Ruby gem implementing SMART App Launch 2.2.0 and UDAP Security STU2 for ' \
+                               'healthcare client applications. It supports SMART OAuth 2.0 authorization, PKCE, ' \
+                               'private_key_jwt assertions, Backend Services, UDAP signed metadata discovery, and ' \
+                               'certificate-backed UDAP Dynamic Client Registration.'
   spec.homepage              = 'https://github.com/vanessuniq/safire'
   spec.license               = 'Apache-2.0'
   spec.required_ruby_version = '>= 3.2'

--- a/spec/safire/client_spec.rb
+++ b/spec/safire/client_spec.rb
@@ -80,6 +80,11 @@ RSpec.describe Safire::Client do
         .to raise_error(Safire::Errors::ConfigurationError, /client_type.*bogus/i)
     end
 
+    it 'raises ConfigurationError for a non-string, non-symbol client_type' do
+      expect { described_class.new(config, client_type: Object.new) }
+        .to raise_error(Safire::Errors::ConfigurationError, /client_type/)
+    end
+
     it 'symbolizes a string client_type keyword' do
       client = described_class.new(config, client_type: 'confidential_symmetric')
       expect(client.client_type).to eq(:confidential_symmetric)

--- a/spec/safire/protocols/udap_registration_metadata_spec.rb
+++ b/spec/safire/protocols/udap_registration_metadata_spec.rb
@@ -204,7 +204,11 @@ RSpec.describe Safire::Protocols::UdapRegistrationMetadata do
     end
 
     it 'preserves non-mail contact URIs alongside a valid mailto contact' do
-      input[:contacts] = ['https://example.com/security', 'mailto:security@example.com']
+      input[:contacts] = [
+        'mailto:security@example.com',
+        'tel:+1-555-0100',
+        'sip:security@example.com'
+      ]
 
       expect(metadata.to_h['contacts']).to eq(input[:contacts])
     end

--- a/spec/safire/protocols/udap_signed_metadata_validator_spec.rb
+++ b/spec/safire/protocols/udap_signed_metadata_validator_spec.rb
@@ -292,6 +292,22 @@ RSpec.describe Safire::Protocols::UdapSignedMetadataValidator do
         end
       end
 
+      context 'when a custom revocation checker raises' do
+        it 'fails closed and logs a revocation failure' do
+          checker = ->(**_kwargs) { raise 'revocation service unavailable' }
+
+          result = validator.signed_endpoint_claims(
+            base_url:,
+            trusted_anchors: [cert],
+            revocation_checker: checker,
+            verify_chain: true
+          )
+
+          expect(result).to be_nil
+          expect(Safire.logger).to have_received(:warn).with(/certificate revocation check failed/)
+        end
+      end
+
       context 'when no trusted anchors are provided for a self-signed cert' do
         it 'returns nil' do
           expect(

--- a/spec/safire/protocols/udap_software_statement_spec.rb
+++ b/spec/safire/protocols/udap_software_statement_spec.rb
@@ -240,6 +240,15 @@ RSpec.describe Safire::Protocols::UdapSoftwareStatement do
       expect(header['alg']).to eq('ES384')
     end
 
+    it 'rejects EC curves without a supported UDAP signing algorithm' do
+      ec_key = OpenSSL::PKey::EC.generate('secp521r1')
+      cert = build_valid_certificate(key: ec_key, uri_san: client_uri)
+
+      expect do
+        build_statement(private_key: ec_key, certificate_chain: [cert], supported_algorithms: ['ES384'])
+      end.to raise_error(Safire::Errors::ConfigurationError, /algorithm/)
+    end
+
     it 'honors an explicit compatible algorithm when advertised' do
       statement = build_statement(algorithm: 'RS384', supported_algorithms: %w[RS256 RS384])
       _payload, header = decode_statement(statement, algorithm: 'RS384')
@@ -310,8 +319,18 @@ RSpec.describe Safire::Protocols::UdapSoftwareStatement do
         .to raise_error(Safire::Errors::ConfigurationError, /private_key/)
     end
 
+    it 'rejects unsupported private key input types' do
+      expect { build_statement(private_key: Object.new) }
+        .to raise_error(Safire::Errors::ConfigurationError, /private_key/)
+    end
+
     it 'rejects an empty certificate chain' do
       expect { build_statement(certificate_chain: []) }
+        .to raise_error(Safire::Errors::ConfigurationError, /certificate_chain/)
+    end
+
+    it 'rejects unsupported certificate chain entry types' do
+      expect { build_statement(certificate_chain: [nil]) }
         .to raise_error(Safire::Errors::ConfigurationError, /certificate_chain/)
     end
 
@@ -419,6 +438,11 @@ RSpec.describe Safire::Protocols::UdapSoftwareStatement do
       bad_clock = class_double(Time, now: Object.new)
 
       expect { build_statement(clock: bad_clock) }
+        .to raise_error(Safire::Errors::ConfigurationError, /clock/)
+    end
+
+    it 'requires the clock to respond to now' do
+      expect { build_statement(clock: Object.new) }
         .to raise_error(Safire::Errors::ConfigurationError, /clock/)
     end
 

--- a/spec/safire/protocols/udap_spec.rb
+++ b/spec/safire/protocols/udap_spec.rb
@@ -648,7 +648,7 @@ RSpec.describe Safire::Protocols::Udap do
       expect(WebMock).not_to have_requested(:post, registration_endpoint)
     end
 
-    it 'raises DiscoveryError when the server does not advertise UDAP DCR capability' do
+    it 'raises DiscoveryError when metadata omits the required UDAP DCR profile' do
       stub_udap(
         body: registration_discovery_body.merge(
           'udap_profiles_supported' => %w[udap_authn udap_authz]
@@ -656,7 +656,21 @@ RSpec.describe Safire::Protocols::Udap do
       )
 
       expect { udap.register_client(client_metadata, client_uri:) }
-        .to raise_error(Safire::Errors::DiscoveryError, /Dynamic Client Registration/)
+        .to raise_error(Safire::Errors::DiscoveryError, /structurally conformant/)
+      expect(WebMock).not_to have_requested(:post, registration_endpoint)
+    end
+
+    it 'raises DiscoveryError when conformant metadata does not expose usable DCR capability' do
+      discovered = instance_double(
+        Safire::Protocols::UdapMetadata,
+        valid?: true,
+        supports_dynamic_registration?: false
+      )
+      stub_udap
+      allow(Safire::Protocols::UdapMetadata).to receive(:new).and_return(discovered)
+
+      expect { udap.register_client(client_metadata, client_uri:) }
+        .to raise_error(Safire::Errors::DiscoveryError, /does not advertise UDAP Dynamic Client Registration/)
       expect(WebMock).not_to have_requested(:post, registration_endpoint)
     end
 


### PR DESCRIPTION
## Summary

This final UDAP Dynamic Client Registration editorial pass reviews the completed STU2 feature as one release unit. It reorganizes the UDAP guides around prerequisites, trust, registration metadata, software statements, lifecycle behavior, and errors; adds a focused registration metadata page; aligns the relevant ADRs and public API documentation with the merged implementation; and corrects stale cross-document wording.

The changelog now describes only capabilities packaged in the Safire gem, while demo-specific behavior remains in the example documentation. The roadmap lists the cross-protocol demo application independently from SMART and UDAP features, and the gem metadata now accurately limits UDAP support to signed discovery and Dynamic Client Registration. Focused regression examples cover meaningful validation branches found during the final coverage audit. No runtime behavior changes are introduced.

## Verification

- `COVERAGE=true bundle exec rspec`: 979 examples, 0 failures; 93.03% line coverage
- `bundle exec rubocop`: 76 files, no offenses
- `bin/docs`: passed
- `cd docs && bundle exec jekyll build`: passed
- Rendered internal documentation links and assets: passed
- `bundle exec bundler-audit check`: no vulnerabilities
- Gem build and package-boundary inspection: passed
