### PR TITLE
Release v0.4.0

### DIFF
--- a/.claude/skills/release-safire/SKILL.md
+++ b/.claude/skills/release-safire/SKILL.md
@@ -76,7 +76,7 @@ Stage `CHANGELOG.md` only — no other files.
 
 ---
 
-## Phase 5: Bump Version and Update Gemfile.lock (release commit)
+## Phase 5: Bump Version, Update Gemfile.lock and ROADMAP (release commit)
 
 Show the user the exact change to `lib/safire/version.rb`:
 ```ruby
@@ -93,7 +93,7 @@ git add lib/safire/version.rb Gemfile.lock ROADMAP.md
 git commit -s -m "Bump version to X.Y.Z"
 ```
 
-Stage `lib/safire/version.rb` and `Gemfile.lock` only — no other files.
+Stage `lib/safire/version.rb`, `Gemfile.lock`, and `ROADMAP.md` only — no other files.
 
 ---
 
@@ -147,7 +147,7 @@ After the PR is created, tell the user the remaining manual steps:
 ## Rules (never violate)
 
 - All commits use `-s`; subjects are one-line only
-- Two-commit structure on the release branch: docs commit (CHANGELOG) then release commit (version.rb + Gemfile.lock)
+- Two-commit structure on the release branch: docs commit (CHANGELOG) then release commit (version.rb + Gemfile.lock + ROADMAP.md)
 - Never commit a `.gem` file
 - Separate doc changes from code changes into distinct commits
 - Always get explicit user approval before modifying files or running commands

--- a/.claude/skills/release-safire/SKILL.md
+++ b/.claude/skills/release-safire/SKILL.md
@@ -85,9 +85,11 @@ VERSION = 'X.Y.Z'.freeze
 
 Wait for approval, then edit the file and run `bundle install` to regenerate `Gemfile.lock`.
 
+Update the `Latest Published Release` in the Roadmap.md file
+
 Ask the user to approve this commit:
 ```
-git add lib/safire/version.rb Gemfile.lock
+git add lib/safire/version.rb Gemfile.lock ROADMAP.md
 git commit -s -m "Bump version to X.Y.Z"
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-07
+
 ### Added
 
 - `Safire::Client#register_client` and `Safire::Client#cancel_registration` now

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    safire (0.3.0)
+    safire (0.4.0)
       activesupport (>= 7.1, < 9)
       addressable (~> 2.8)
       faraday (~> 2.14)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Safire Roadmap
 
-## Latest Published Release — v0.3.0
+## Latest Published Release — v0.4.0
 
 Safire is in early development (pre-release). The API is functional but not yet stable — breaking changes may occur before v1.0.0. Published to [RubyGems](https://rubygems.org/gems/safire).
 

--- a/lib/safire/version.rb
+++ b/lib/safire/version.rb
@@ -1,4 +1,4 @@
 # lib/safire/version.rb
 module Safire
-  VERSION = '0.3.0'.freeze # Released Date: 2026-04-15
+  VERSION = '0.4.0'.freeze # Released Date: 2026-08-07
 end


### PR DESCRIPTION
## [0.4.0] - 2026-08-07

### Added

- `Safire::Client#register_client` and `Safire::Client#cancel_registration` now
  support the UDAP Security STU2 Dynamic Client Registration lifecycle when
  initialized with `protocol: :udap`. Safire performs discovery-bound
  registration against authoritative signed endpoints, checks structural DCR
  capability, posts the fixed UDAP envelope with optional certification or
  endorsement JWTs, accepts new-registration `201` and update-style `200`
  responses with a valid `client_id`, and confirms cancellation through a
  successful response containing a valid `client_id` and an empty `grant_types`
  array. OAuth-style failures preserve UDAP error codes such as
  `invalid_software_statement` and `unapproved_software_statement`.
- `Safire::Protocols::UdapRegistrationMetadata` validates and normalizes
  caller-controlled UDAP Security STU2 registration and cancellation metadata
  before software-statement signing. It enforces exact grant shapes, HTTPS
  redirect and logo URIs, required `mailto:` contact data, protocol-owned
  fields, JSON-compatible extensions, and immutable canonical output. An
  explicit `allow_insecure_localhost: true` option permits development-only
  HTTP loopback URIs without allowing remote HTTP. Registration software
  statements use minimal `alg`/`x5c` headers, exact `iss`/`sub`/`aud` claims, a
  five-minute lifetime, fresh `jti`, key-compatible algorithm negotiation, and
  local certificate/key/SAN checks. `ClientConfig` accepts and masks the
  non-empty, leaf-first `certificate_chain` of PEM strings or
  `OpenSSL::X509::Certificate` instances required for UDAP registration.
- UDAP Security STU2 discovery is now available with
  `Safire::Client.new(..., protocol: :udap).server_metadata`. Safire fetches
  `/.well-known/udap`, supports community-scoped discovery via `community:`, accepts
  `trusted_anchors:`, `crls:`, `revocation_checker:`, and `verify_chain:` for
  signed metadata trust validation (`verify_chain: false` is for development/test
  only), parses metadata into `Safire::Protocols::UdapMetadata`, and raises
  `DiscoveryError` for HTTP errors, 204 responses, a response body that is not a
  JSON object, or failed signed metadata validation.
- `Safire::Protocols::UdapMetadata` provides STU2 structural validation and helper
  predicates for advertised UDAP profiles and capabilities.
- `Safire::Protocols::UdapSignedMetadataValidator` validates the `signed_metadata`
  JWT per UDAP Security STU2, including RS256, `x5c`, JWT signature, certificate
  chain and revocation checks, issuer/subject/time claims, `jti`, and signed
  endpoint claims.
- UDAP signed endpoint claims are merged over unsigned discovery metadata after
  successful validation. Cached UDAP metadata is revalidated before reuse and
  refetched if the signed JWT, certificate chain, or revocation policy no longer
  validates.
- `UdapMetadata#signed_metadata_valid?` allows explicit cryptographic re-validation
  against caller-provided trust anchors and revocation material.
- `Safire::Errors::DiscoveryError` accepts a `label:` keyword argument (default:
  `'SMART configuration'`) and exposes it as a readable attribute so callers can
  identify which protocol's discovery failed.

### Breaking Changes

- SMART and shared HTTP URI handling now require an explicit
  `allow_insecure_localhost: true` opt-in before accepting HTTP loopback URIs
  or redirects. This aligns SMART local-development behavior with UDAP DCR
  metadata validation while keeping production defaults HTTPS-only.

### Changed

- SMART Dynamic Client Registration now requires successful RFC 7591 responses
  to contain a non-blank string `client_id`. Malformed identifiers that were
  previously accepted now raise `Safire::Errors::RegistrationError`; valid
  registration responses are unchanged.
- Ruby requirement relaxed from `>= 4.0.4` to `>= 3.2` to support Rails 7.1+ apps still
  running on Ruby 3.x. The minimum is 3.2 because the gem uses anonymous keyword splat
  forwarding (`**` without a name), which was introduced in Ruby 3.2.
- ActiveSupport requirement relaxed from `~> 8.0.0` to `>= 7.1, < 9`, resolving the
  bundler conflict that prevented the gem from being used in Rails 8.1 apps or any app
  pinning ActiveSupport 8.1.x.
- `Safire::Client` now raises `ConfigurationError` when `client_type:` is passed explicitly for
  `protocol: :udap`, both at construction and via `client_type=`; previously the value was
  ignored silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
