### PR TITLE
Add client-role contract and shared JSON response parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- SMART and UDAP discovery now accept valid raw JSON-object response bodies even
+  when incorrect or missing response content types leave them undecoded by the
+  HTTP adapter. Malformed and non-object JSON continue to raise protocol-specific
+  `DiscoveryError` failures.
+- Shared discovery, registration, and OAuth error parsing now rejects ambiguous
+  symbol/string key collisions, recursive structures, and non-JSON-compatible
+  adapter-provided Hash values instead of risking silent normalization or
+  unexpected type errors. Valid response behavior is unchanged.
+
 ## [0.4.0] - 2026-08-07
 
 ### Added

--- a/docs/adr/ADR-006-lazy-discovery.md
+++ b/docs/adr/ADR-006-lazy-discovery.md
@@ -125,6 +125,15 @@ end
 
 A 204 response means the server has no UDAP workflows for that community. `Protocols::Udap` raises `DiscoveryError` before the body is parsed, with a descriptive message that identifies the community when one was requested.
 
+SMART and UDAP discovery both require a JSON object but do not depend on the
+HTTP adapter having already decoded it. A shared protocol-neutral parser accepts
+an already parsed Hash or a raw JSON-object string, then deeply normalizes keys
+without mutating adapter-owned data. This allows Safire to interoperate when a
+server sends valid JSON with an incorrect or missing content type; the response
+is still non-conformant at the HTTP layer. Malformed JSON, non-object JSON, and
+ambiguous or non-JSON-compatible adapter Hashes raise the protocol's existing
+`DiscoveryError`.
+
 ---
 
 ## Consequences
@@ -136,6 +145,8 @@ A 204 response means the server has no UDAP workflows for that community. `Proto
 - Callers control when discovery happens — supports application-level caching patterns (see [Advanced Examples]({{ site.baseurl }}/advanced/#metadata-caching))
 - `client_type=` mutation preserves cached SMART metadata — no re-discovery
 - UDAP community-and-trust-policy cache allows a single client instance to serve multiple communities without serving stale signed metadata
+- Discovery parsing is independent of response content-type middleware while
+  still failing closed on unusable object data
 
 **Trade-offs:**
 - Discovery errors surface at first use (e.g. `authorization_url`), not at construction — callers must handle `Errors::DiscoveryError` in their flow logic rather than at the `new` call site

--- a/docs/adr/ADR-008-warn-return-false-for-compliance-validation.md
+++ b/docs/adr/ADR-008-warn-return-false-for-compliance-validation.md
@@ -31,6 +31,12 @@ Option B lets the caller decide what to do: they can check the return value, obs
 
 There is also a clear boundary: **the caller controls the config** (configuration errors should raise — the caller can fix them); **the server controls the response** (compliance violations should warn — the caller cannot fix a remote server).
 
+This caller/server distinction is a useful default, but it is not sufficient
+for security-sensitive runtime decisions. ADR-015 refines the boundary: remote
+data raises when its defect makes the requested client operation unsafe,
+impossible, or unconfirmed. Complete structural conformance remains an explicit
+warn-and-return-false diagnostic when the operation does not depend on it.
+
 ---
 
 ## Decision
@@ -71,5 +77,5 @@ Configuration validation (`ClientConfig#validate!`, `Smart#validate!`) raises `C
 
 **Trade-offs:**
 - Callers who do not call `token_response_valid?` get no compliance signal at all — non-compliant responses are silently accepted; this is intentional (opt-in, not opt-out)
-- The distinction between "warn + return false" and "raise" must be maintained consistently — new validation methods should follow the same rule: server behaviour → warn; caller configuration → raise
+- The distinction between "warn + return false" and "raise" must be maintained consistently. New validation methods follow ADR-015: explicit conformance diagnostics warn, while client obligations and security or operation-readiness failures raise.
 - `token_response_valid?` accepts a `flow:` keyword argument (`:app_launch` default, `:backend_services`) that adjusts which fields are required and what the warning messages say. For example, `token_type` must be `"Bearer"` (App Launch spec) or `"bearer"` (Backend Services spec), and `expires_in` is RECOMMENDED for App Launch but REQUIRED for Backend Services. Callers opt in to the stricter backend-services validation by passing `flow: :backend_services`

--- a/docs/adr/ADR-009-oauth-error-hierarchy.md
+++ b/docs/adr/ADR-009-oauth-error-hierarchy.md
@@ -98,7 +98,9 @@ The module accepts already-received response bodies. It does not send HTTP
 requests, select endpoints, log response values, or apply protocol-specific
 policy.
 
-Registration success responses are normalized to string-keyed hashes and must
+Registration success responses delegate JSON-object parsing to the private,
+protocol-neutral `JSONResponseParsing` collaborator. Raw JSON strings and
+already parsed Hashes are normalized to new, deeply string-keyed hashes and must
 contain a non-blank string `client_id`, as required by RFC 7591. Missing
 `client_id` responses continue to report only the received field names. A
 present but blank or non-string `client_id` raises `RegistrationError` with a
@@ -106,9 +108,14 @@ structural error description. This intentionally hardens SMART registration:
 valid RFC 7591 responses are unchanged, while malformed identifiers that were
 previously accepted through `present?` now fail closed.
 
-Malformed or non-object OAuth error bodies produce an error containing the HTTP
-status only. Parsed JSON objects preserve their protocol error codes, including
-UDAP-specific values such as `invalid_software_statement`.
+Malformed, non-object, ambiguous, or non-JSON-compatible OAuth error bodies
+produce an error containing the HTTP status only. Parsed JSON objects preserve
+their protocol error codes, including UDAP-specific values such as
+`invalid_software_statement`. Symbol/string key collisions and the other Ruby
+structure guards apply only to adapter-supplied or directly passed Hashes;
+`JSON.parse` and Faraday's JSON middleware produce string-keyed Hashes. The
+guards prevent local normalization from silently overwriting ambiguous values,
+not collisions in JSON received on the wire.
 
 ### Amendment consequences
 
@@ -118,6 +125,8 @@ UDAP-specific values such as `invalid_software_statement`.
   construction or endpoint policy
 - response key normalization makes direct and middleware-parsed hashes behave
   consistently
+- strict adapter-Hash validation makes response translation total for cyclic or
+  non-JSON-compatible Ruby values
 - malformed successful registrations fail before an invalid identifier reaches
   application state
 

--- a/docs/adr/ADR-015-client-role-and-runtime-readiness.md
+++ b/docs/adr/ADR-015-client-role-and-runtime-readiness.md
@@ -1,0 +1,113 @@
+---
+layout: default
+title: "ADR-015: Client role and runtime readiness"
+parent: Architecture Decision Records
+nav_order: 15
+---
+
+# ADR-015: Client role and runtime readiness
+
+**Status:** Accepted
+
+---
+
+## Context
+
+Safire consumes metadata and protocol responses from remote SMART App Launch
+and UDAP servers. Some defects make a client request unsafe or impossible;
+others are server conformance defects that an interoperable client can report
+without blocking an otherwise valid operation.
+
+A blanket rule such as "caller input raises, server input warns" is not
+sufficient at a protocol trust boundary. A server controls discovery and token
+responses, but Safire must still reject an untrusted value when it is needed to
+select a secure endpoint, validate a signed assertion, protect credentials, or
+establish that a lifecycle operation completed. Conversely, complete server
+certification is outside a client library's runtime role.
+
+Safire therefore needs a consistent way to distinguish operational readiness
+from optional conformance diagnostics. Comprehensive server certification
+belongs in a conformance harness such as Inferno.
+
+## Decision
+
+Safire classifies protocol checks by their effect on the requested client
+operation:
+
+1. **Runtime hard failure:** reject a condition that would violate a client
+   obligation, make the operation unsafe or impossible, expose credentials, or
+   leave a security-sensitive result unconfirmed. This includes malformed wire
+   shapes required by the operation and failed UDAP signed-metadata trust
+   validation.
+2. **Warning or negotiation:** report a server defect or uncertain capability
+   when Safire can still send a safe, conformant request and the server remains
+   authoritative for acceptance.
+3. **Explicit diagnostic:** methods such as `SmartMetadata#valid?`,
+   `UdapMetadata#valid?`, and `Smart#token_response_valid?` warn and return a
+   Boolean when called. Discovery does not automatically promote every failed
+   diagnostic into a workflow failure.
+4. **Server-owned decision:** authorization grants, requested scope approval,
+   client registration policy, certifications, and issued credentials are
+   decided by the authorization server. Safire validates its request and the
+   response shape it must consume, but does not predict the policy result.
+
+This decision refines ADR-008. Server-controlled data is warning-only when the
+defect does not cross a security or operation-readiness boundary; its remote
+origin alone does not determine the error behavior.
+
+Protocol response bodies that must be JSON objects use the private,
+protocol-neutral `JSONResponseParsing` collaborator. It accepts an already
+parsed `Hash` or a raw JSON string, produces a new deeply string-keyed Hash, and
+rejects malformed or non-object JSON. Adapter-supplied Hashes also fail closed
+when they contain recursive structures, unsupported JSON key or value types,
+non-finite numbers, invalid string encodings, excessive nesting, or keys that
+collide after symbol-to-string normalization. The collaborator returns a parse
+failure and leaves each consumer to choose its protocol-specific error class.
+
+Parsing a valid raw JSON object allows interoperability when an HTTP adapter did
+not decode the body because the server sent an incorrect or missing content
+type. Safire's tolerance does not make that server response conformant.
+
+## Operation Matrix
+
+This matrix covers the public protocol operations currently implemented by the
+`Safire::Client` facade.
+
+| Protocol operation | Runtime hard failures | Warning or explicit diagnostic | Server-owned decision |
+|--------------------|-----------------------|--------------------------------|-----------------------|
+| SMART `server_metadata` | Transport/HTTP failure or a body that cannot be used as a JSON object | `SmartMetadata#valid?` is caller-invoked | Advertised capabilities |
+| SMART `authorization_url` | Invalid method; missing client ID, scopes, redirect URI, or usable authorization endpoint | Metadata diagnostics remain explicit | User authorization, launch context, and granted scopes |
+| SMART `request_access_token` | Missing client credentials; unusable token endpoint; OAuth error; malformed token response or missing access token | `token_response_valid?` is caller-invoked | Code acceptance and issued token contents |
+| SMART `refresh_token` | Missing client credentials; unusable token endpoint; OAuth error; malformed token response or missing access token | `token_response_valid?` is caller-invoked | Refresh-token acceptance and issued scope |
+| SMART `request_backend_token` | Missing client ID or signing credentials; unusable token endpoint; OAuth error; malformed token response or missing access token | `token_response_valid?(flow: :backend_services)` is caller-invoked | Client authentication, requested scope, and token issuance |
+| SMART `register_client` | Missing or unsafe registration endpoint; OAuth error; malformed response or missing/invalid client ID | SMART metadata diagnostics remain explicit | Registration policy and issued credentials |
+| SMART `token_response_valid?` | None; this is not an operational gate | Warns and returns `false` for response conformance defects | Caller decides whether a failed diagnostic is acceptable |
+| UDAP `server_metadata` | Transport/HTTP/204 failure; non-object JSON; failed signed-metadata signature, chain, revocation, issuer, time, or endpoint validation | `UdapMetadata#valid?` is caller-invoked | Supported communities, profiles, and capabilities |
+| UDAP `register_client` | Untrusted discovery; unusable DCR capability; invalid client metadata, certification shape, signing identity, or response; server rejection | Full metadata validation is temporarily a gate until ALIGN-2 narrows it to DCR readiness | Registration policy, certification acceptance, and issued client ID |
+| UDAP `cancel_registration` | The registration gates above plus a response that does not positively confirm the client ID and empty grants | Full metadata validation is temporarily a gate until ALIGN-2; ALIGN-2 adds warning-only scope compatibility for lifecycle-safe cleanup | Cancellation policy and confirmation response |
+
+SMART cancellation and UDAP authorization, token, refresh, backend-token, and
+token-response operations are not implemented. They raise
+`NotImplementedError` through the shared protocol contract rather than implying
+runtime support.
+
+## Consequences
+
+**Benefits:**
+
+- Runtime failures now have an operation or security rationale rather than
+  serving as blanket server certification.
+- Callers retain explicit tools for enforcing stricter server conformance.
+- Shared JSON-object parsing is total for untrusted adapter output and preserves
+  protocol-specific error ownership.
+- Valid raw JSON objects remain usable even when response content-type handling
+  is imperfect.
+
+**Trade-offs:**
+
+- The same metadata defect can be diagnostic in one flow and fatal in another
+  when the latter needs the affected field to proceed safely.
+- Tolerating a raw JSON object can hide an HTTP content-type defect unless the
+  caller separately audits server conformance.
+- The operation matrix must be updated whenever a public protocol operation or
+  runtime gate is added or materially changed.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -26,3 +26,4 @@ Architecture Decision Records (ADRs) document significant design decisions made 
 | [ADR-012]({% link adr/ADR-012-udap-signed-metadata-validation.md %}) | `signed_metadata` JWT validation — design and chain verification defaults | Accepted |
 | [ADR-013]({% link adr/ADR-013-udap-registration-request-model.md %}) | UDAP registration metadata as an immutable value object | Accepted |
 | [ADR-014]({% link adr/ADR-014-udap-software-statement-signing.md %}) | UDAP software-statement signing | Accepted |
+| [ADR-015]({% link adr/ADR-015-client-role-and-runtime-readiness.md %}) | Client role and runtime readiness | Accepted |

--- a/docs/smart-on-fhir/discovery/index.md
+++ b/docs/smart-on-fhir/discovery/index.md
@@ -44,6 +44,12 @@ metadata = client.server_metadata
 
 `server_metadata` returns a `Safire::Protocols::SmartMetadata` object with typed accessors for all fields. See [Metadata Fields and Validation]({% link smart-on-fhir/discovery/metadata.md %}) for the full field reference and validation rules.
 
+Safire accepts either an already parsed Hash or a raw JSON-object body. This
+keeps discovery usable when a server sends valid JSON with an incorrect or
+missing content type and Faraday therefore leaves the body as a String. The
+server response is still non-conformant at the HTTP layer. Malformed JSON and
+valid JSON arrays, scalars, booleans, or `null` raise `DiscoveryError`.
+
 ---
 
 ## Error Handling
@@ -57,7 +63,7 @@ rescue Safire::Errors::DiscoveryError => e
     puts 'FHIR server does not support SMART App Launch'
   when /timeout/i
     puts 'Discovery request timed out'
-  when /expected JSON object/
+  when /not a usable JSON object/
     puts 'Server returned invalid SMART configuration'
   else
     puts "Discovery failed: #{e.message}"

--- a/docs/troubleshooting/auth-errors.md
+++ b/docs/troubleshooting/auth-errors.md
@@ -60,7 +60,7 @@ config = Safire::ClientConfig.new(
 ### `DiscoveryError`: Invalid SMART configuration format
 
 ```
-Safire::Errors::DiscoveryError: ... response is not a JSON object
+Safire::Errors::DiscoveryError: ... response is not a usable JSON object
 ```
 
 The server returned an HTML error page, a JSON array, or malformed JSON. Inspect the raw response:
@@ -69,7 +69,14 @@ The server returned an HTML error page, a JSON array, or malformed JSON. Inspect
 curl https://fhir.example.com/.well-known/smart-configuration
 ```
 
-The response must be a JSON object (`{...}`) with at least `authorization_endpoint` and `token_endpoint`.
+The response body must be a JSON object (`{...}`). Safire can parse a valid raw
+JSON-object string when an incorrect or missing response content type leaves it
+undecoded, but that HTTP response is still non-conformant.
+
+Missing metadata fields are handled separately from body parsing.
+`server_metadata` returns a `SmartMetadata` object, and `metadata.valid?` is the
+explicit structural diagnostic. An authorization or token operation raises only
+when an endpoint or capability required by that operation is unavailable.
 
 ---
 

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -61,7 +61,13 @@ end
 
 ### SMART discovery
 
-SMART clients fetch `/.well-known/smart-configuration` lazily when metadata or an auth flow needs it. A `DiscoveryError` means the SMART metadata endpoint returned an HTTP error, did not return a JSON object, or a token request needed discovery but the response did not include `token_endpoint`.
+SMART clients fetch `/.well-known/smart-configuration` lazily when metadata or an auth flow needs it. A `DiscoveryError` means the SMART metadata endpoint returned an HTTP error, did not provide a usable JSON object, or a token request needed discovery but the response did not include `token_endpoint`.
+
+Discovery parses valid raw JSON-object strings even when an incorrect or missing
+response content type prevents Faraday from decoding the body. That tolerance
+does not make the server response conformant. Malformed JSON, JSON arrays or
+scalars, and adapter-provided Hashes with ambiguous normalized keys, cycles, or
+non-JSON-compatible values are treated as unusable JSON-object responses.
 
 ```ruby
 begin

--- a/docs/udap.md
+++ b/docs/udap.md
@@ -45,6 +45,12 @@ client = Safire::Client.new(
 `signed_metadata` JWT, and merges authoritative signed endpoint claims over
 their unsigned JSON counterparts before returning `UdapMetadata`.
 
+Discovery accepts an already parsed Hash or a raw JSON-object body. A valid raw
+object remains usable when an incorrect or missing response content type causes
+Faraday to leave it as a String, although the server response is still
+non-conformant at the HTTP layer. Malformed JSON and valid non-object JSON raise
+`DiscoveryError` before signed-metadata validation.
+
 ### Server trust and revocation
 
 Production discovery requires caller-supplied trust anchors plus an explicit
@@ -127,6 +133,7 @@ an existing metadata object against another trust policy. Metadata returned by
 |-----------|-----------------|
 | `404 Not Found` | Raises `DiscoveryError`; clients treat the server as not supporting UDAP workflows |
 | `204 No Content` | Raises `DiscoveryError` before body parsing; no UDAP workflow is available for that community |
+| Malformed or non-object JSON | Raises `DiscoveryError` before signed-metadata validation |
 | Invalid `signed_metadata` | Raises `DiscoveryError` after validation warnings |
 | Malformed DER in JOSE `x5c` | Raises `CertificateError` |
 | Invalid `community:` | Raises `ConfigurationError` before HTTP |

--- a/lib/safire/protocols/json_response_parsing.rb
+++ b/lib/safire/protocols/json_response_parsing.rb
@@ -1,0 +1,104 @@
+module Safire
+  module Protocols
+    # Parses protocol response bodies into JSON-compatible, string-keyed Hashes.
+    #
+    # Consumers remain responsible for translating a nil result into their
+    # protocol-specific error. This collaborator performs no HTTP or policy work.
+    #
+    # @api private
+    module JSONResponseParsing
+      INVALID = Object.new.freeze
+      MAX_NESTING = 100
+
+      class << self
+        # @param body [Hash, String, Object] parsed or raw response body
+        # @return [Hash, nil] normalized JSON object, or nil when unusable
+        def parse_object(body)
+          parsed = body.is_a?(String) ? JSON.parse(body) : body
+          return unless parsed.is_a?(Hash)
+
+          normalized = normalize_value(parsed, {}, 0)
+          normalized unless normalized.equal?(INVALID)
+        rescue JSON::ParserError, EncodingError
+          nil
+        end
+
+        private
+
+        def normalize_value(value, ancestors, depth)
+          case value
+          when Hash then normalize_hash(value, ancestors, depth)
+          when Array then normalize_array(value, ancestors, depth)
+          else normalize_scalar(value)
+          end
+        end
+
+        def normalize_scalar(value)
+          case value
+          when String then normalize_string(value)
+          when Float then value.finite? ? value : INVALID
+          when Integer, TrueClass, FalseClass, NilClass then value
+          else INVALID
+          end
+        end
+
+        def normalize_hash(value, ancestors, depth)
+          return INVALID if depth >= MAX_NESTING
+
+          with_ancestor(value, ancestors) do
+            value.each_with_object({}) do |(key, item), normalized|
+              key = normalize_key(key)
+              break INVALID if key.equal?(INVALID) || normalized.key?(key)
+
+              item = normalize_value(item, ancestors, depth + 1)
+              break INVALID if item.equal?(INVALID)
+
+              normalized[key] = item
+            end
+          end
+        end
+
+        def normalize_array(value, ancestors, depth)
+          return INVALID if depth >= MAX_NESTING
+
+          with_ancestor(value, ancestors) do
+            value.each_with_object([]) do |item, normalized|
+              item = normalize_value(item, ancestors, depth + 1)
+              break INVALID if item.equal?(INVALID)
+
+              normalized << item
+            end
+          end
+        end
+
+        def normalize_key(key)
+          return INVALID unless key.is_a?(String) || key.is_a?(Symbol)
+
+          normalize_string(key.to_s)
+        end
+
+        def normalize_string(value)
+          return INVALID unless value.valid_encoding?
+
+          value.encode(Encoding::UTF_8)
+        rescue EncodingError
+          INVALID
+        end
+
+        def with_ancestor(value, ancestors)
+          object_id = value.object_id
+          added = false
+          return INVALID if ancestors.key?(object_id)
+
+          ancestors[object_id] = true
+          added = true
+          yield
+        ensure
+          ancestors.delete(object_id) if added
+        end
+      end
+
+      private_constant :INVALID, :MAX_NESTING
+    end
+  end
+end

--- a/lib/safire/protocols/oauth_response_handling.rb
+++ b/lib/safire/protocols/oauth_response_handling.rb
@@ -23,7 +23,7 @@ module Safire
 
       def parse_registration_response(body)
         response = json_object(body)
-        raise Errors::RegistrationError.new(error_description: 'response is not a JSON object') unless response
+        raise Errors::RegistrationError.new(error_description: 'response is not a usable JSON object') unless response
 
         client_id = response['client_id']
         return response if client_id.is_a?(String) && client_id.present?
@@ -38,10 +38,7 @@ module Safire
       end
 
       def json_object(body)
-        parsed = body.is_a?(String) ? JSON.parse(body) : body
-        parsed.deep_stringify_keys if parsed.is_a?(Hash)
-      rescue JSON::ParserError
-        nil
+        JSONResponseParsing.parse_object(body)
       end
     end
   end

--- a/lib/safire/protocols/smart.rb
+++ b/lib/safire/protocols/smart.rb
@@ -344,11 +344,12 @@ module Safire
       end
 
       def parse_discovery_body(body)
-        return body if body.is_a?(Hash)
+        parsed = JSONResponseParsing.parse_object(body)
+        return parsed if parsed
 
         raise Errors::DiscoveryError.new(
           endpoint: well_known_endpoint,
-          error_description: 'response is not a JSON object'
+          error_description: 'response is not a usable JSON object'
         )
       end
 

--- a/lib/safire/protocols/udap.rb
+++ b/lib/safire/protocols/udap.rb
@@ -62,7 +62,7 @@ module Safire
       # @param verify_chain [Boolean] when +false+, skips X.509 chain validation (dev/test only)
       # @return [Safire::Protocols::UdapMetadata] parsed UDAP metadata with authoritative signed endpoint claims
       # @raise [Safire::Errors::DiscoveryError] if the server returns an HTTP error, a 204 response,
-      #   a body that is not a JSON object, or if +signed_metadata+ JWT validation fails
+      #   a body that is not a usable JSON object, or if +signed_metadata+ JWT validation fails
       # @raise [Safire::Errors::NetworkError] on connection failure, timeout, SSL error,
       #   or a redirect to a non-HTTPS URL
       # @raise [Safire::Errors::ConfigurationError] if +community+ is not a URI
@@ -521,11 +521,12 @@ module Safire
       end
 
       def parse_discovery_body(body, endpoint)
-        return body if body.is_a?(Hash)
+        parsed = JSONResponseParsing.parse_object(body)
+        return parsed if parsed
 
         raise Errors::DiscoveryError.new(
           endpoint: endpoint,
-          error_description: 'response is not a JSON object',
+          error_description: 'response is not a usable JSON object',
           label: 'UDAP metadata'
         )
       end

--- a/spec/safire/protocols/json_response_parsing_spec.rb
+++ b/spec/safire/protocols/json_response_parsing_spec.rb
@@ -1,0 +1,128 @@
+require 'spec_helper'
+
+RSpec.describe Safire::Protocols::JSONResponseParsing do
+  describe '.parse_object' do
+    it 'returns a deeply normalized copy of a Hash without mutating the caller' do
+      client_id = +'client-123'
+      body = {
+        client_id:,
+        metadata: [{ redirect_uri: 'https://app.example.com/callback' }]
+      }
+
+      result = described_class.parse_object(body)
+
+      expect(result).to eq(
+        'client_id' => 'client-123',
+        'metadata' => [{ 'redirect_uri' => 'https://app.example.com/callback' }]
+      )
+      expect(body).to eq(
+        client_id: 'client-123',
+        metadata: [{ redirect_uri: 'https://app.example.com/callback' }]
+      )
+      expect(result).not_to equal(body)
+      expect(result['client_id']).not_to equal(client_id)
+    end
+
+    it 'parses a raw JSON object string' do
+      body = '{"client_id":"client-123","metadata":{"active":true}}'
+
+      expect(described_class.parse_object(body)).to eq(
+        'client_id' => 'client-123',
+        'metadata' => { 'active' => true }
+      )
+    end
+
+    it 'allows a shared non-recursive object to appear more than once' do
+      shared = { value: 1 }
+
+      expect(described_class.parse_object(left: shared, right: shared)).to eq(
+        'left' => { 'value' => 1 },
+        'right' => { 'value' => 1 }
+      )
+    end
+
+    it 'rejects string and symbol keys that normalize to the same key' do
+      expect(described_class.parse_object('client_id' => 'first', client_id: 'second')).to be_nil
+    end
+
+    it 'rejects nested normalization collisions' do
+      body = { metadata: { 'active' => true, active: false } }
+
+      expect(described_class.parse_object(body)).to be_nil
+    end
+
+    it 'rejects unsupported Hash key types' do
+      expect(described_class.parse_object(Object.new => 'value')).to be_nil
+    end
+
+    it 'rejects unsupported value types' do
+      expect(described_class.parse_object('generated_at' => Time.now)).to be_nil
+    end
+
+    it 'rejects non-finite JSON numbers' do
+      expect(described_class.parse_object('value' => Float::NAN)).to be_nil
+      expect(described_class.parse_object('value' => Float::INFINITY)).to be_nil
+      expect(described_class.parse_object('value' => -Float::INFINITY)).to be_nil
+    end
+
+    it 'rejects a recursive Hash' do
+      body = {}
+      body['self'] = body
+
+      expect(described_class.parse_object(body)).to be_nil
+    end
+
+    it 'rejects a recursive Array' do
+      values = []
+      values << values
+
+      expect(described_class.parse_object('values' => values)).to be_nil
+    end
+
+    it 'rejects an excessively nested adapter-supplied structure' do
+      body = { 'value' => true }
+      150.times { body = { 'nested' => body } }
+
+      expect(described_class.parse_object(body)).to be_nil
+    end
+
+    it 'rejects invalid string encoding' do
+      body = { 'value' => "\xFF".force_encoding(Encoding::UTF_8) }
+
+      expect(described_class.parse_object(body)).to be_nil
+    end
+
+    it 'rejects binary strings that cannot be represented as JSON text' do
+      expect(described_class.parse_object('value' => "\xFF".b)).to be_nil
+    end
+
+    it 'transcodes compatible strings to UTF-8 without mutating the caller' do
+      value = "caf\xE9".force_encoding(Encoding::ISO_8859_1)
+
+      result = described_class.parse_object('value' => value)
+
+      expect(result['value']).to eq("caf\u00E9")
+      expect(result['value'].encoding).to eq(Encoding::UTF_8)
+      expect(value.encoding).to eq(Encoding::ISO_8859_1)
+    end
+
+    [
+      nil,
+      '',
+      '{not-json',
+      '[]',
+      '"value"',
+      '123',
+      'true',
+      'null',
+      [],
+      'value',
+      123,
+      true
+    ].each do |body|
+      it "rejects non-object input #{body.inspect}" do
+        expect(described_class.parse_object(body)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/safire/protocols/oauth_response_handling_spec.rb
+++ b/spec/safire/protocols/oauth_response_handling_spec.rb
@@ -79,12 +79,34 @@ RSpec.describe Safire::Protocols::OAuthResponseHandling do
 
     it 'rejects a non-object JSON value' do
       expect { handler.parse_registration(%w[not an object]) }
-        .to raise_error(Safire::Errors::RegistrationError, /not a JSON object/)
+        .to raise_error(Safire::Errors::RegistrationError, /not a usable JSON object/)
     end
 
     it 'rejects a malformed JSON body that was not parsed by middleware' do
       expect { handler.parse_registration('{not-json') }
-        .to raise_error(Safire::Errors::RegistrationError, /not a JSON object/)
+        .to raise_error(Safire::Errors::RegistrationError, /not a usable JSON object/)
+    end
+
+    it 'rejects normalized-key collisions instead of selecting a client_id value' do
+      body = { 'client_id' => 'string-client', client_id: 'symbol-client' }
+
+      expect { handler.parse_registration(body) }
+        .to raise_error(Safire::Errors::RegistrationError, /not a usable JSON object/)
+    end
+
+    it 'rejects recursive adapter-supplied Hash bodies without leaking a Ruby exception' do
+      body = { 'client_id' => 'client-123' }
+      body['metadata'] = body
+
+      expect { handler.parse_registration(body) }
+        .to raise_error(Safire::Errors::RegistrationError, /not a usable JSON object/)
+    end
+
+    it 'rejects non-JSON-compatible adapter-supplied values' do
+      body = { 'client_id' => 'client-123', 'generated_at' => Time.now }
+
+      expect { handler.parse_registration(body) }
+        .to raise_error(Safire::Errors::RegistrationError, /not a usable JSON object/)
     end
   end
 
@@ -179,6 +201,47 @@ RSpec.describe Safire::Protocols::OAuthResponseHandling do
       faraday_error = instance_double(
         Faraday::Error,
         response: { status: 400, body: ['invalid_request'] }
+      )
+
+      error = handler.build_oauth_error(faraday_error, Safire::Errors::RegistrationError)
+
+      expect(error.status).to eq(400)
+      expect(error.error_code).to be_nil
+      expect(error.error_description).to be_nil
+    end
+
+    it 'returns a status-only error for a normalized-key collision' do
+      faraday_error = instance_double(
+        Faraday::Error,
+        response: {
+          status: 400,
+          body: { 'error' => 'string-error', error: 'symbol-error' }
+        }
+      )
+
+      error = handler.build_oauth_error(faraday_error, Safire::Errors::RegistrationError)
+
+      expect(error.status).to eq(400)
+      expect(error.error_code).to be_nil
+      expect(error.error_description).to be_nil
+    end
+
+    it 'returns a status-only error for a recursive adapter-supplied Hash body' do
+      body = { 'error' => 'invalid_request' }
+      body['details'] = body
+      faraday_error = instance_double(Faraday::Error, response: { status: 400, body: })
+
+      error = handler.build_oauth_error(faraday_error, Safire::Errors::RegistrationError)
+
+      expect(error.status).to eq(400)
+      expect(error.error_code).to be_nil
+      expect(error.error_description).to be_nil
+    end
+
+    it 'returns a status-only error for non-JSON-compatible adapter values' do
+      faraday_error = instance_double(
+        Faraday::Error,
+        response: { status: 400, body: { 'error' => 'invalid_request', 'generated_at' => Time.now } }
       )
 
       error = handler.build_oauth_error(faraday_error, Safire::Errors::RegistrationError)

--- a/spec/safire/protocols/smart_spec.rb
+++ b/spec/safire/protocols/smart_spec.rb
@@ -246,6 +246,17 @@ RSpec.describe Safire::Protocols::Smart do
       expect(metadata.capabilities).to eq(smart_metadata_body['capabilities'])
     end
 
+    it 'parses a raw JSON object when the response content type is incorrect' do
+      stub_request(:get, well_known_url).to_return(
+        status: 200,
+        body: smart_metadata_body.to_json,
+        headers: { 'Content-Type' => 'text/plain' }
+      )
+
+      expect(described_class.new(config).server_metadata.token_endpoint)
+        .to eq(smart_metadata_body['token_endpoint'])
+    end
+
     it 'raises on 404' do
       stub_request(:get, well_known_url).to_return(status: 404)
       expect { described_class.new(config).server_metadata }
@@ -263,7 +274,38 @@ RSpec.describe Safire::Protocols::Smart do
         status: 200, body: '[]', headers: { 'Content-Type' => 'application/json' }
       )
       expect { described_class.new(config).server_metadata }
-        .to raise_error(Safire::Errors::DiscoveryError, /response is not a JSON object/)
+        .to raise_error(Safire::Errors::DiscoveryError, /response is not a usable JSON object/)
+    end
+
+    it 'raises DiscoveryError for an ambiguous adapter-supplied Hash' do
+      smart = described_class.new(config)
+      response_body = smart_metadata_body.merge(token_endpoint: 'https://other.example.com/token')
+      response = instance_double(Faraday::Response, body: response_body)
+      allow(smart.instance_variable_get(:@http_client)).to receive(:get).and_return(response)
+
+      expect { smart.server_metadata }
+        .to raise_error(Safire::Errors::DiscoveryError, /response is not a usable JSON object/)
+    end
+
+    it 'raises DiscoveryError for a recursive adapter-supplied Hash' do
+      smart = described_class.new(config)
+      response_body = smart_metadata_body.dup
+      response_body['metadata'] = response_body
+      response = instance_double(Faraday::Response, body: response_body)
+      allow(smart.instance_variable_get(:@http_client)).to receive(:get).and_return(response)
+
+      expect { smart.server_metadata }
+        .to raise_error(Safire::Errors::DiscoveryError, /response is not a usable JSON object/)
+    end
+
+    it 'raises DiscoveryError for non-JSON-compatible adapter values' do
+      smart = described_class.new(config)
+      response_body = smart_metadata_body.merge('generated_at' => Time.now)
+      response = instance_double(Faraday::Response, body: response_body)
+      allow(smart.instance_variable_get(:@http_client)).to receive(:get).and_return(response)
+
+      expect { smart.server_metadata }
+        .to raise_error(Safire::Errors::DiscoveryError, /response is not a usable JSON object/)
     end
 
     it 'handles base_url with or without trailing slash' do

--- a/spec/safire/protocols/udap_spec.rb
+++ b/spec/safire/protocols/udap_spec.rb
@@ -58,6 +58,41 @@ RSpec.describe Safire::Protocols::Udap do
       instance_double(Safire::Protocols::UdapSignedMetadataValidator, signed_endpoint_claims: signed_claims)
     end
 
+    it 'parses a raw JSON object when the response content type is incorrect' do
+      stub_udap(content_type: 'text/plain')
+      allow(Safire::Protocols::UdapSignedMetadataValidator).to receive(:new).and_return(validator_double)
+
+      expect(udap.server_metadata.token_endpoint).to eq(valid_metadata['token_endpoint'])
+    end
+
+    it 'raises DiscoveryError for an ambiguous adapter-supplied Hash' do
+      response_body = valid_metadata.merge(token_endpoint: 'https://other.example.com/token')
+      response = instance_double(Faraday::Response, status: 200, body: response_body)
+      allow(udap.instance_variable_get(:@http_client)).to receive(:get).and_return(response)
+
+      expect { udap.server_metadata }
+        .to raise_error(Safire::Errors::DiscoveryError, /response is not a usable JSON object/)
+    end
+
+    it 'raises DiscoveryError for a recursive adapter-supplied Hash' do
+      response_body = valid_metadata.dup
+      response_body['metadata'] = response_body
+      response = instance_double(Faraday::Response, status: 200, body: response_body)
+      allow(udap.instance_variable_get(:@http_client)).to receive(:get).and_return(response)
+
+      expect { udap.server_metadata }
+        .to raise_error(Safire::Errors::DiscoveryError, /response is not a usable JSON object/)
+    end
+
+    it 'raises DiscoveryError for non-JSON-compatible adapter values' do
+      response_body = valid_metadata.merge('generated_at' => Time.now)
+      response = instance_double(Faraday::Response, status: 200, body: response_body)
+      allow(udap.instance_variable_get(:@http_client)).to receive(:get).and_return(response)
+
+      expect { udap.server_metadata }
+        .to raise_error(Safire::Errors::DiscoveryError, /response is not a usable JSON object/)
+    end
+
     it 'passes the insecure-localhost policy to the HTTP client' do
       allow(Safire::HTTPClient).to receive(:new).and_call_original
 
@@ -327,7 +362,8 @@ RSpec.describe Safire::Protocols::Udap do
       end
 
       it 'raises DiscoveryError' do
-        expect { udap.server_metadata }.to raise_error(Safire::Errors::DiscoveryError, /not a JSON object/)
+        expect { udap.server_metadata }
+          .to raise_error(Safire::Errors::DiscoveryError, /not a usable JSON object/)
       end
     end
 


### PR DESCRIPTION
## Summary

This PR begins the client-role alignment series by introducing one strict, protocol-neutral JSON-object response boundary. SMART and UDAP discovery now recover valid raw JSON objects when an incorrect or missing content type leaves the body undecoded, while malformed, non-object, recursive, ambiguous, excessively nested, or otherwise non-JSON-compatible adapter values fail through the existing protocol-specific errors. Registration success and OAuth error handling use the same normalization without changing valid response behavior.

ADR-015 records Safire's role as an interoperable client library rather than a server certification suite. Its operation matrix distinguishes runtime and security failures from warnings, explicit conformance diagnostics, and policy decisions owned by the authorization server. Related ADRs, discovery guides, troubleshooting documentation, and the changelog now use that same boundary and terminology.

## Validation

- `bundle exec rspec` - 1,019 examples, 0 failures
- `bundle exec rspec --tag live` - 13 examples, 0 failures
- `bundle exec rubocop` - 78 files, no offenses
- `bundle audit` - no vulnerabilities found
- `bin/docs` - successful
- `cd docs && bundle exec jekyll build` - successful
