### PR TITLE
Align UDAP DCR readiness with client responsibilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   symbol/string key collisions, recursive structures, and non-JSON-compatible
   adapter-provided Hash values instead of risking silent normalization or
   unexpected type errors. Valid response behavior is unchanged.
+- UDAP Dynamic Client Registration now validates and snapshots caller metadata
+  before discovery, then gates only on trusted DCR profile, endpoint, algorithm,
+  and certification-requirement values. Unrelated discovery conformance defects
+  remain available through `UdapMetadata#valid?` without blocking an otherwise
+  usable registration request.
+- UDAP registration warns when a server omits the STU2 `RS256` baseline and can
+  negotiate another advertised, supported, key-compatible algorithm. In the
+  v0.4.1 compatibility phase, missing or insufficient `scopes_supported`
+  metadata produces aggregated warnings while registration, modification, and
+  lifecycle-safe cancellation continue; exact wildcard advertisement becomes a
+  registration requirement in v0.5.0.
 
 ## [0.4.0] - 2026-08-07
 

--- a/docs/adr/ADR-013-udap-registration-request-model.md
+++ b/docs/adr/ADR-013-udap-registration-request-model.md
@@ -41,6 +41,11 @@ construction. Invalid input raises `Safire::Errors::ValidationError` with the
 failing attribute and a value-free reason. The class does not inherit from
 `Entity` and does not use the discovery layer's warn-and-return-false contract.
 
+Registration orchestration constructs this value object once, before discovery
+or other network activity. Scope diagnostics and software-statement signing
+consume the same immutable instance; Safire does not independently normalize
+the caller's raw Hash at multiple stages.
+
 Top-level string and symbol keys are normalized to strings. Supplying both forms
 of one key is rejected rather than allowing insertion order to decide which
 value is signed. The value object and its canonical internal hash are frozen,
@@ -94,6 +99,7 @@ regular expression.
 ## Consequences
 
 - Signing code can consume one canonical, already validated metadata hash.
+- Invalid caller metadata fails before discovery, signing, or POSTing.
 - Caller mutations cannot change metadata between validation and signing.
 - Protocol-owned claims cannot be shadowed through caller input.
 - Plain HTTP remains impossible for remote hosts; local HTTP requires a literal

--- a/docs/adr/ADR-014-udap-software-statement-signing.md
+++ b/docs/adr/ADR-014-udap-software-statement-signing.md
@@ -81,10 +81,14 @@ key, and advertised by the server. Without an explicit algorithm, Safire chooses
 the first key-compatible advertised algorithm, preferring `RS256` over `RS384`
 for RSA keys because `RS256` is the STU2 baseline.
 
-Protocol orchestration separately requires every DCR-capable server to advertise
-mandatory `RS256` support before Safire signs with any compatible advertised
-algorithm. This enforces the server baseline independently from the configured
-client key type.
+Protocol orchestration requires the advertised value to be a non-empty array of
+algorithm names. A malformed or empty value makes safe algorithm selection
+impossible and raises `DiscoveryError`. Because STU2 requires every FHIR server
+to support `RS256`, Safire warns when it is absent. The warning diagnoses the
+server baseline without blocking an otherwise interoperable request: the
+builder may still select another advertised, Safire-supported,
+key-compatible algorithm. A valid advertisement with no usable intersection
+raises `ConfigurationError`.
 
 ### Validate local signing identity, not server trust
 

--- a/docs/adr/ADR-015-client-role-and-runtime-readiness.md
+++ b/docs/adr/ADR-015-client-role-and-runtime-readiness.md
@@ -88,6 +88,13 @@ may collectively cover a requested permission set. STU2 does not guarantee that
 the server accepts the combined token, so this permissive inference must not be
 reused as a hard-failure decision without a separate normative rule.
 
+Scope diagnostics log only the requested scope category and count, never the
+raw token values. SMART v2 scopes may carry FHIR search constraints, and opaque
+custom scopes may encode equally sensitive application context in forms Safire
+cannot safely redact. Count-and-category logging preserves the operational and
+migration signal without copying caller-controlled authorization details into
+application logs.
+
 ## Operation Matrix
 
 This matrix covers the public protocol operations currently implemented by the

--- a/docs/adr/ADR-015-client-role-and-runtime-readiness.md
+++ b/docs/adr/ADR-015-client-role-and-runtime-readiness.md
@@ -68,6 +68,26 @@ Parsing a valid raw JSON object allows interoperability when an HTTP adapter did
 not decode the body because the server sent an incorrect or missing content
 type. Safire's tolerance does not make that server response conformant.
 
+UDAP DCR uses focused readiness rather than calling `UdapMetadata#valid?` as an
+operational gate. Safire requires trusted discovery, an advertised `udap_dcr`
+profile, a usable authoritative registration endpoint, usable registration
+algorithm metadata, and type-safe certification requirements. Other structural
+conformance checks remain available through the explicit `valid?` diagnostic.
+
+In v0.4.1, requested UDAP registration scopes are diagnostic only. Requested
+tokens containing a literal `*` are classified first and compared by exact
+membership in `scopes_supported`; narrower recognized SMART FHIR scopes may be
+covered by broader advertised scopes. Unrecognized syntax uses exact membership.
+Missing, malformed, or insufficient advertisements produce separate aggregated
+warnings while the server remains authoritative for negotiation. Registration
+and modification move to exact wildcard enforcement in v0.5.0; cancellation
+remains warning-only so an existing registration can still be removed.
+
+For warning suppression only, compatible advertised FHIR permission fragments
+may collectively cover a requested permission set. STU2 does not guarantee that
+the server accepts the combined token, so this permissive inference must not be
+reused as a hard-failure decision without a separate normative rule.
+
 ## Operation Matrix
 
 This matrix covers the public protocol operations currently implemented by the
@@ -83,8 +103,8 @@ This matrix covers the public protocol operations currently implemented by the
 | SMART `register_client` | Missing or unsafe registration endpoint; OAuth error; malformed response or missing/invalid client ID | SMART metadata diagnostics remain explicit | Registration policy and issued credentials |
 | SMART `token_response_valid?` | None; this is not an operational gate | Warns and returns `false` for response conformance defects | Caller decides whether a failed diagnostic is acceptable |
 | UDAP `server_metadata` | Transport/HTTP/204 failure; non-object JSON; failed signed-metadata signature, chain, revocation, issuer, time, or endpoint validation | `UdapMetadata#valid?` is caller-invoked | Supported communities, profiles, and capabilities |
-| UDAP `register_client` | Untrusted discovery; unusable DCR capability; invalid client metadata, certification shape, signing identity, or response; server rejection | Full metadata validation is temporarily a gate until ALIGN-2 narrows it to DCR readiness | Registration policy, certification acceptance, and issued client ID |
-| UDAP `cancel_registration` | The registration gates above plus a response that does not positively confirm the client ID and empty grants | Full metadata validation is temporarily a gate until ALIGN-2; ALIGN-2 adds warning-only scope compatibility for lifecycle-safe cleanup | Cancellation policy and confirmation response |
+| UDAP `register_client` | Untrusted discovery; unusable DCR profile, endpoint, algorithm, or certification-requirement metadata; invalid client metadata, signing identity, or response; server rejection | Missing RS256 and unconfirmed scope support warn; `UdapMetadata#valid?` remains caller-invoked | Registration policy, scope and certification acceptance, and issued client ID |
+| UDAP `cancel_registration` | The registration gates above plus a response that does not positively confirm the client ID and empty grants | Scope compatibility remains warning-only for lifecycle-safe cleanup; `UdapMetadata#valid?` remains caller-invoked | Cancellation policy and confirmation response |
 
 SMART cancellation and UDAP authorization, token, refresh, backend-token, and
 token-response operations are not implemented. They raise

--- a/docs/troubleshooting/client-errors.md
+++ b/docs/troubleshooting/client-errors.md
@@ -36,9 +36,10 @@ registration = client.register_client(
 
 For UDAP, the registration endpoint is always discovery-bound. Safire raises
 `DiscoveryError` before POSTing when discovery fails, `signed_metadata` cannot
-be validated, `UdapMetadata#valid?` reports structural non-conformance, the
-server does not advertise `udap_dcr`, or the server does not publish
-mandatory `RS256` registration signing support:
+be validated, the server does not advertise usable `udap_dcr` capability, or
+the registration algorithm and certification-requirement fields cannot be used
+safely. Full structural conformance remains an explicit
+`UdapMetadata#valid?` diagnostic and is not an automatic DCR gate:
 
 ```ruby
 registration = udap_client.register_client(
@@ -48,6 +49,15 @@ registration = udap_client.register_client(
   crls:            [ca_crl]
 )
 ```
+
+A missing `RS256` advertisement produces a warning because STU2 requires that
+server baseline, but Safire can proceed with another advertised, supported,
+key-compatible algorithm. Missing, malformed, or insufficient
+`scopes_supported` also warns in v0.4.1 instead of blocking DCR. Requested
+wildcards are checked by exact membership; narrower non-wildcard SMART FHIR
+scopes may be covered by broader advertised scopes. Registration and
+modification will reject unadvertised wildcard requests in v0.5.0, while
+cancellation remains warning-only.
 
 ### `ValidationError`: UDAP registration metadata or certifications are invalid
 

--- a/docs/udap/dynamic-client-registration/index.md
+++ b/docs/udap/dynamic-client-registration/index.md
@@ -52,10 +52,10 @@ Applications that select signing identities dynamically may instead pass
 `register_client` or `cancel_registration` call. Per-call values override the
 configured defaults without mutating the client.
 
-Before posting, Safire requires structurally conformant discovery metadata,
-the `udap_dcr` profile, a usable signed `registration_endpoint`, and mandatory
-`RS256` support in
-`registration_endpoint_jwt_signing_alg_values_supported`. See
+Before posting, Safire requires trusted discovery, the `udap_dcr` profile, a
+usable authoritative `registration_endpoint`, and a non-empty array of
+registration signing algorithms. Call `metadata.valid?` separately when an
+application needs a full structural conformance diagnostic. See
 [Registration Metadata]({% link udap/dynamic-client-registration/registration-metadata.md %})
 for caller input and grant rules.
 
@@ -105,6 +105,14 @@ same `client_uri` and trust community requests modification. The authorization
 server may preserve the existing `client_id` or issue a replacement; use the
 identifier returned by the latest accepted response.
 
+In v0.4.1, Safire warns but still submits when a requested wildcard scope is not
+advertised exactly in `scopes_supported`. Non-wildcard SMART FHIR scopes are
+quiet when a broader advertised scope covers them; any remaining unconfirmed
+tokens appear in one warning. Missing or malformed scope metadata also warns
+rather than blocks. Registration and modification will require exact wildcard
+advertisement in v0.5.0, while the authorization server remains responsible for
+the scopes it grants.
+
 ## Communities and Certifications
 
 Pass `community:` when the authorization server participates in multiple UDAP
@@ -153,11 +161,10 @@ URIs.
 
 Safire performs the following sequence for every registration lifecycle call:
 
-1. Discovers and cryptographically validates community-scoped UDAP metadata.
-2. Runs `UdapMetadata#valid?` because DCR is about to act on the discovered
-   registration endpoint.
-3. Verifies the DCR profile and mandatory registration algorithm advertisement.
-4. Validates caller metadata and certification shape.
+1. Validates and snapshots caller metadata and certification input.
+2. Discovers and cryptographically validates community-scoped UDAP metadata.
+3. Checks the focused DCR profile, endpoint, algorithm, and certification fields.
+4. Reports scope-advertisement uncertainty according to the release policy above.
 5. Signs a fresh five-minute software statement with a fresh `jti`.
 6. POSTs the fixed UDAP request envelope to the authoritative signed endpoint.
 7. Parses the RFC 7591-shaped response into a string-keyed `Hash`.
@@ -181,7 +188,7 @@ the software statement.
 
 | Error | When raised |
 |-------|-------------|
-| `Safire::Errors::DiscoveryError` | Discovery or `signed_metadata` validation fails, metadata is structurally non-conformant for DCR, or required DCR capability is absent |
+| `Safire::Errors::DiscoveryError` | Discovery or `signed_metadata` validation fails, or a DCR profile, endpoint, algorithm, or certification-requirement value cannot be used safely |
 | `Safire::Errors::ValidationError` | Caller metadata or certification input is invalid before signing |
 | `Safire::Errors::ConfigurationError` | Signing configuration or algorithm selection is missing or incompatible |
 | `Safire::Errors::CertificateError` | The client key, certificate chain, validity period, ordering, or URI SAN cannot support signing |

--- a/docs/udap/dynamic-client-registration/index.md
+++ b/docs/udap/dynamic-client-registration/index.md
@@ -108,10 +108,12 @@ identifier returned by the latest accepted response.
 In v0.4.1, Safire warns but still submits when a requested wildcard scope is not
 advertised exactly in `scopes_supported`. Non-wildcard SMART FHIR scopes are
 quiet when a broader advertised scope covers them; any remaining unconfirmed
-tokens appear in one warning. Missing or malformed scope metadata also warns
-rather than blocks. Registration and modification will require exact wildcard
-advertisement in v0.5.0, while the authorization server remains responsible for
-the scopes it grants.
+tokens produce one warning. Scope warnings report only the scope category and
+count because constrained SMART scopes and opaque custom scopes may contain
+sensitive values that do not belong in application logs. Missing or malformed
+scope metadata also warns rather than blocks. Registration and modification
+will require exact wildcard advertisement in v0.5.0, while the authorization
+server remains responsible for the scopes it grants.
 
 ## Communities and Certifications
 

--- a/docs/udap/dynamic-client-registration/lifecycle.md
+++ b/docs/udap/dynamic-client-registration/lifecycle.md
@@ -103,7 +103,7 @@ Both lifecycle methods raise the same Safire error families:
 
 | Error | Meaning |
 |-------|---------|
-| `Safire::Errors::DiscoveryError` | UDAP discovery failed, signed metadata was not trusted, metadata was structurally non-conformant for DCR, or the server did not advertise usable UDAP DCR capability |
+| `Safire::Errors::DiscoveryError` | UDAP discovery or signed-metadata trust failed, or a DCR profile, endpoint, algorithm, or certification-requirement value could not be used safely |
 | `Safire::Errors::ValidationError` | Caller metadata or `certifications:` failed local validation before signing |
 | `Safire::Errors::ConfigurationError` | Signing configuration is missing or incompatible |
 | `Safire::Errors::CertificateError` | The private key, certificate chain, validity period, or `client_uri` SAN check failed |

--- a/docs/udap/dynamic-client-registration/software-statement.md
+++ b/docs/udap/dynamic-client-registration/software-statement.md
@@ -83,10 +83,13 @@ that list with the configured private key:
 
 When `jwt_algorithm` is omitted, Safire selects the first compatible advertised
 algorithm. RSA keys prefer `RS256` because it is the STU2 baseline. An explicit
-algorithm must be advertised by the server and compatible with the key. Safire
-raises `DiscoveryError` before signing if the server metadata omits mandatory
-`RS256` registration signing support, even when the client will use another
-compatible algorithm also advertised by the server.
+algorithm must be advertised by the server and compatible with the key.
+
+The advertised value must be a non-empty array of strings; malformed or empty
+metadata raises `DiscoveryError` before signing. STU2 requires FHIR servers to
+support `RS256`, so Safire warns when it is missing, but can proceed with another
+advertised, supported, key-compatible algorithm. A valid advertisement with no
+usable algorithm raises `ConfigurationError`.
 
 ## Validation Boundaries
 

--- a/examples/sinatra_app/Gemfile.lock
+++ b/examples/sinatra_app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    safire (0.3.0)
+    safire (0.4.0)
       activesupport (>= 7.1, < 9)
       addressable (~> 2.8)
       faraday (~> 2.14)

--- a/examples/sinatra_app/README.md
+++ b/examples/sinatra_app/README.md
@@ -314,10 +314,14 @@ The registration screen supports:
 - `client_credentials` registration for system access
 - `authorization_code` registration with the demo callback URI, logo URI, and
   Safire-generated `response_types: ["code"]`
+- editable scopes prepopulated from the selected server; when none are
+  configured, the operator must enter the access this demo client intends to
+  request before registration
 - optional `community`, pasted certification or endorsement JWTs, and explicit
   selection of grant-matched JWTs from the configured file
-- persistence of the returned `client_id`, exact client URI, and optional
-  community so cancellation uses the original registration identity
+- persistence of the returned `client_id`, effective registration scope, exact
+  client URI, and optional community so cancellation uses the original
+  registration context
 - cancellation only when the server confirms the same returned `client_id`
 
 The page displays only allowlisted registration metadata fields. Unknown fields

--- a/examples/sinatra_app/app.rb
+++ b/examples/sinatra_app/app.rb
@@ -316,9 +316,11 @@ class SafireDemo < Sinatra::Base
     @udap_registration_presenter = build_udap_registration_presenter
     if @server.udap_client_id.present?
       @udap_registration_presenter = build_udap_registration_presenter(error: duplicate_udap_registration_error)
+    elsif @udap_registration_presenter.scope.blank?
+      @udap_registration_presenter = build_udap_registration_presenter(error: missing_udap_registration_scope_error)
     else
       registration = perform_udap_registration
-      persist_udap_registration!(registration['client_id'])
+      persist_udap_registration!(registration)
       @udap_registration_presenter = build_udap_registration_presenter(
         registration_response: registration,
         form_params: {}
@@ -848,15 +850,30 @@ class SafireDemo < Sinatra::Base
     )
   end
 
+  def missing_udap_registration_scope_error
+    Safire::Errors::ValidationError.new(
+      attribute: :scope,
+      reason: 'must describe the access this demo client intends to request'
+    )
+  end
+
   def parse_list_param(value)
     value.to_s.split(/[,\s]+/).map(&:strip).reject(&:empty?)
   end
 
-  def persist_udap_registration!(client_id)
-    @server.udap_client_id = client_id
+  def persist_udap_registration!(registration)
+    @server.udap_client_id = registration.fetch('client_id')
     @server.udap_client_uri = udap_registration_client_uri
     @server.udap_community = udap_registration_community
+    @server.udap_scope = effective_udap_registration_scope(registration)
     @server.save
+  end
+
+  def effective_udap_registration_scope(registration)
+    returned_scope = registration['scope']
+    return returned_scope.strip if returned_scope.is_a?(String) && returned_scope.present?
+
+    @udap_registration_presenter.scope.strip
   end
 
   def clear_udap_registration_if_confirmed!(expected_client_id, response)
@@ -865,6 +882,7 @@ class SafireDemo < Sinatra::Base
     @server.udap_client_id = nil
     @server.udap_client_uri = nil
     @server.udap_community = nil
+    @server.udap_scope = nil
     @server.save
   end
 
@@ -873,7 +891,8 @@ class SafireDemo < Sinatra::Base
 
     {
       'client_uri' => @server.udap_client_uri,
-      'community' => @server.udap_community
+      'community' => @server.udap_community,
+      'scope' => @server.udap_scope.presence || @server.scopes.join(' ')
     }
   end
 

--- a/examples/sinatra_app/models/fhir_server.rb
+++ b/examples/sinatra_app/models/fhir_server.rb
@@ -23,6 +23,7 @@ class FhirServer
     udap_client_id
     udap_client_uri
     udap_community
+    udap_scope
     client_secret
     scopes
     protocols

--- a/examples/sinatra_app/models/udap_registration_presenter.rb
+++ b/examples/sinatra_app/models/udap_registration_presenter.rb
@@ -24,13 +24,12 @@ class UdapRegistrationPresenter
   FILTERED_VALUE = '[FILTERED]'
   DEFAULT_CLIENT_NAME = 'Safire Demo App'
   DEFAULT_CONTACTS = 'mailto:admin@example.com'
-  DEFAULT_SCOPE = 'system/*.rs'
   DEMO_LOGO_PATH = '/safire-demo-logo.png'
   CERTIFICATIONS_FILE_ENV = 'UDAP_CLIENT_CERTIFICATIONS_FILE'
   APP_ROOT = File.expand_path('..', __dir__)
 
   private_constant :GRANT_TYPES, :DISPLAYABLE_RESPONSE_FIELDS, :FILTERED_VALUE,
-                   :DEFAULT_CLIENT_NAME, :DEFAULT_CONTACTS, :DEFAULT_SCOPE,
+                   :DEFAULT_CLIENT_NAME, :DEFAULT_CONTACTS,
                    :DEMO_LOGO_PATH, :CERTIFICATIONS_FILE_ENV, :APP_ROOT
 
   attr_reader :server, :registration_response, :cancellation_response,
@@ -107,7 +106,9 @@ class UdapRegistrationPresenter
   end
 
   def scope
-    param('scope').presence || server.scopes.join(' ').presence || DEFAULT_SCOPE
+    return param('scope').to_s if param_supplied?('scope')
+
+    server.scopes.join(' ')
   end
 
   def community
@@ -170,6 +171,10 @@ class UdapRegistrationPresenter
 
   def param(name)
     @params[name] || @params[name.to_sym]
+  end
+
+  def param_supplied?(name)
+    @params.key?(name) || @params.key?(name.to_sym)
   end
 
   def env_value(name)

--- a/lib/safire/protocols/udap.rb
+++ b/lib/safire/protocols/udap.rb
@@ -91,10 +91,11 @@ module Safire
 
       # Dynamically registers or modifies a UDAP client using STU2 Dynamic Client Registration.
       #
-      # UDAP registration is discovery-bound: Safire first discovers and validates
-      # UDAP metadata, then posts a fixed request envelope to the discovered
-      # +registration_endpoint+. The caller-provided metadata is validated and signed
-      # into the +software_statement+ JWT; it is not duplicated at the top level.
+      # UDAP registration is discovery-bound: Safire validates caller metadata,
+      # discovers trusted UDAP metadata, checks the fields required by DCR, then
+      # posts a fixed request envelope to the discovered +registration_endpoint+.
+      # Caller metadata is signed into the +software_statement+ JWT; it is not
+      # duplicated at the top level.
       #
       # Calling this method again with the same +client_uri+ and community requests
       # modification of the existing registration. Safire accepts both 201 Created
@@ -118,8 +119,8 @@ module Safire
       #   leaf-first client signing certificate chain; defaults to configuration
       # @param jwt_algorithm [String, nil] optional explicit registration signing algorithm
       # @return [Hash] registration response from the authorization server
-      # @raise [Safire::Errors::DiscoveryError] when UDAP discovery is unavailable,
-      #   structurally non-conformant for registration, or does not advertise UDAP DCR
+      # @raise [Safire::Errors::DiscoveryError] when UDAP discovery is unavailable or
+      #   untrusted, or required DCR capability metadata cannot be used safely
       # @raise [Safire::Errors::ValidationError] when caller metadata or certifications are invalid
       # @raise [Safire::Errors::ConfigurationError] when signing configuration is missing or incompatible
       # @raise [Safire::Errors::CertificateError] when the client certificate chain cannot support signing
@@ -179,8 +180,8 @@ module Safire
       #   leaf-first client signing certificate chain; defaults to configuration
       # @param jwt_algorithm [String, nil] optional explicit registration signing algorithm
       # @return [Hash] cancellation response from the authorization server
-      # @raise [Safire::Errors::DiscoveryError] when UDAP discovery is unavailable,
-      #   structurally non-conformant for registration, or does not advertise UDAP DCR
+      # @raise [Safire::Errors::DiscoveryError] when UDAP discovery is unavailable or
+      #   untrusted, or required DCR capability metadata cannot be used safely
       # @raise [Safire::Errors::ValidationError] when caller metadata or certifications are invalid
       # @raise [Safire::Errors::ConfigurationError] when signing configuration is missing or incompatible
       # @raise [Safire::Errors::CertificateError] when the client certificate chain cannot support signing
@@ -226,19 +227,17 @@ module Safire
       def prepare_registration_request(metadata, operation:, client_uri:, community:, trusted_anchors:, crls:,
                                        revocation_checker:, verify_chain:, certifications:, private_key:,
                                        certificate_chain:, jwt_algorithm:)
+        registration_metadata = build_registration_metadata(metadata, operation:)
+        certifications = normalize_certifications!(certifications)
         community = normalize_community(community)
         discovered = registration_server_metadata(
-          community:,
-          trusted_anchors:,
-          crls:,
-          revocation_checker:,
-          verify_chain:
+          community:, trusted_anchors:, crls:, revocation_checker:, verify_chain:
         )
-        certifications = validate_certifications!(certifications, discovered)
-        software_statement = registration_software_statement(
-          metadata,
+        validate_required_certifications!(certifications, discovered, community:)
+        validate_registration_scopes!(registration_metadata, discovered, operation:)
+        software_statement = build_software_statement(
+          registration_metadata,
           discovered,
-          operation:,
           client_uri:,
           private_key:,
           certificate_chain:,
@@ -255,13 +254,6 @@ module Safire
       end
 
       def validate_registration_discovery!(metadata, community:)
-        unless metadata.valid?
-          registration_discovery_error!(
-            'UDAP metadata is not structurally conformant for Dynamic Client Registration',
-            community
-          )
-        end
-
         return if metadata.supports_dynamic_registration?
 
         registration_discovery_error!(
@@ -272,11 +264,17 @@ module Safire
 
       def validate_registration_signing_algorithms!(metadata, community:)
         algorithms = metadata.registration_endpoint_jwt_signing_alg_values_supported
+        unless algorithms.is_a?(Array) && algorithms.any? && algorithms.all?(String)
+          registration_discovery_error!(
+            'registration signing algorithm metadata must be a non-empty array of strings',
+            community
+          )
+        end
         return if algorithms.include?(MANDATORY_REGISTRATION_ALGORITHM)
 
-        registration_discovery_error!(
-          "server does not advertise mandatory #{MANDATORY_REGISTRATION_ALGORITHM} registration signing support",
-          community
+        Safire.logger.warn(
+          '[UDAP] registration metadata does not advertise the required RS256 baseline; ' \
+          'registration may proceed only with another advertised, supported, key-compatible algorithm'
         )
       end
 
@@ -288,16 +286,94 @@ module Safire
         )
       end
 
-      def validate_certifications!(certifications, metadata)
-        normalized = normalize_certifications!(certifications)
-        required = Array(metadata.udap_certifications_required)
-        return normalized if required.empty? || normalized.present?
+      def validate_required_certifications!(certifications, metadata, community:)
+        required = metadata.udap_certifications_required
+        unless required.nil? || (required.is_a?(Array) && required.all?(String))
+          registration_discovery_error!(
+            'udap_certifications_required must be an array of strings when present',
+            community
+          )
+        end
+        return if required.blank? || certifications.present?
 
         raise Errors::ValidationError.new(
           attribute: :certifications,
           reason: 'must not be nil or empty when UDAP metadata advertises required certification URIs: ' \
                   "#{required.join(', ')}"
         )
+      end
+
+      def validate_registration_scopes!(registration_metadata, discovered, operation:)
+        wildcards, non_wildcards = registration_scope_groups(registration_metadata)
+        advertised = discovered.scopes_supported
+
+        unless usable_scope_advertisement?(advertised)
+          return warn_unconfirmed_scopes(wildcards, non_wildcards, operation:)
+        end
+
+        coverage = UdapScopeCoverage.new(advertised)
+        unadvertised_wildcards = wildcards.reject { |scope| coverage.advertised_exactly?(scope) }
+        warn_unadvertised_wildcards(unadvertised_wildcards, operation:)
+        uncovered = coverage.uncovered_non_wildcards_for_warning(non_wildcards)
+        warn_uncovered_non_wildcards(uncovered)
+      end
+
+      def registration_scope_groups(registration_metadata)
+        requested = registration_metadata.to_h.fetch('scope').split.uniq
+        requested.partition { |scope| UdapScopeCoverage.requested_wildcard?(scope) }
+      end
+
+      def warn_unconfirmed_scopes(wildcards, non_wildcards, operation:)
+        warn_unconfirmed_wildcards(wildcards, operation:)
+        warn_unconfirmed_non_wildcards(non_wildcards)
+      end
+
+      def usable_scope_advertisement?(scopes)
+        scopes.is_a?(Array) && scopes.any? && scopes.all? { |scope| scope.is_a?(String) && scope.present? }
+      end
+
+      def warn_unadvertised_wildcards(scopes, operation:)
+        return if scopes.empty?
+
+        Safire.logger.warn(
+          "[UDAP] requested wildcard scope(s) #{scopes.join(', ')} are not advertised exactly in " \
+          "scopes_supported; #{scope_warning_lifecycle(operation)}"
+        )
+      end
+
+      def warn_unconfirmed_wildcards(scopes, operation:)
+        return if scopes.empty?
+
+        Safire.logger.warn(
+          "[UDAP] requested wildcard scope(s) #{scopes.join(', ')} cannot be confirmed as advertised exactly " \
+          "because scopes_supported is missing, empty, or malformed; #{scope_warning_lifecycle(operation)}"
+        )
+      end
+
+      def warn_uncovered_non_wildcards(scopes)
+        return if scopes.empty?
+
+        Safire.logger.warn(
+          '[UDAP] requested non-wildcard scope(s) are not listed or locally covered by scopes_supported: ' \
+          "#{scopes.join(', ')}; proceeding with server-side scope negotiation"
+        )
+      end
+
+      def warn_unconfirmed_non_wildcards(scopes)
+        return if scopes.empty?
+
+        Safire.logger.warn(
+          '[UDAP] cannot confirm requested non-wildcard scope coverage because scopes_supported is missing, ' \
+          "empty, or malformed: #{scopes.join(', ')}; proceeding with server-side scope negotiation"
+        )
+      end
+
+      def scope_warning_lifecycle(operation)
+        if operation == :cancel
+          return 'cancellation proceeds and remains warning-only so existing access can be removed'
+        end
+
+        'registration proceeds in v0.4.1, but registration and modification will fail in v0.5.0'
       end
 
       def normalize_certifications!(certifications)
@@ -313,28 +389,19 @@ module Safire
         certifications.map { |entry| entry.dup.freeze }.freeze
       end
 
+      def build_registration_metadata(metadata, operation:)
+        UdapRegistrationMetadata.new(
+          metadata,
+          operation:,
+          allow_insecure_localhost: @allow_insecure_localhost
+        )
+      end
+
       def compact_jws?(value)
         return false unless value.is_a?(String) && value.present?
 
         parts = value.split('.', -1)
         parts.length == 3 && parts.all? { |part| Safire::Protocols::COMPACT_JWS_SEGMENT.match?(part) }
-      end
-
-      def registration_software_statement(metadata, discovered, operation:, client_uri:,
-                                          private_key:, certificate_chain:, jwt_algorithm:)
-        registration_metadata = UdapRegistrationMetadata.new(
-          metadata,
-          operation:,
-          allow_insecure_localhost: @allow_insecure_localhost
-        )
-        build_software_statement(
-          registration_metadata,
-          discovered,
-          client_uri:,
-          private_key:,
-          certificate_chain:,
-          jwt_algorithm:
-        )
       end
 
       def build_software_statement(metadata, discovered, client_uri:, private_key:, certificate_chain:, jwt_algorithm:)

--- a/lib/safire/protocols/udap.rb
+++ b/lib/safire/protocols/udap.rb
@@ -336,7 +336,7 @@ module Safire
         return if scopes.empty?
 
         Safire.logger.warn(
-          "[UDAP] requested wildcard scope(s) #{scopes.join(', ')} are not advertised exactly in " \
+          "[UDAP] #{scope_warning_summary(scopes, 'wildcard')}; no exact advertisement in " \
           "scopes_supported; #{scope_warning_lifecycle(operation)}"
         )
       end
@@ -345,7 +345,7 @@ module Safire
         return if scopes.empty?
 
         Safire.logger.warn(
-          "[UDAP] requested wildcard scope(s) #{scopes.join(', ')} cannot be confirmed as advertised exactly " \
+          "[UDAP] #{scope_warning_summary(scopes, 'wildcard')}; exact advertisement cannot be confirmed " \
           "because scopes_supported is missing, empty, or malformed; #{scope_warning_lifecycle(operation)}"
         )
       end
@@ -354,8 +354,8 @@ module Safire
         return if scopes.empty?
 
         Safire.logger.warn(
-          '[UDAP] requested non-wildcard scope(s) are not listed or locally covered by scopes_supported: ' \
-          "#{scopes.join(', ')}; proceeding with server-side scope negotiation"
+          "[UDAP] #{scope_warning_summary(scopes, 'non-wildcard')}; coverage is not listed or locally proven " \
+          'by scopes_supported; proceeding with server-side scope negotiation'
         )
       end
 
@@ -363,9 +363,13 @@ module Safire
         return if scopes.empty?
 
         Safire.logger.warn(
-          '[UDAP] cannot confirm requested non-wildcard scope coverage because scopes_supported is missing, ' \
-          "empty, or malformed: #{scopes.join(', ')}; proceeding with server-side scope negotiation"
+          "[UDAP] #{scope_warning_summary(scopes, 'non-wildcard')}; coverage cannot be confirmed because " \
+          'scopes_supported is missing, empty, or malformed; proceeding with server-side scope negotiation'
         )
+      end
+
+      def scope_warning_summary(scopes, category)
+        "requested #{category} scope count=#{scopes.length}"
       end
 
       def scope_warning_lifecycle(operation)

--- a/lib/safire/protocols/udap_scope_coverage.rb
+++ b/lib/safire/protocols/udap_scope_coverage.rb
@@ -1,0 +1,122 @@
+module Safire
+  module Protocols
+    # Evaluates warning-only coverage of requested non-wildcard SMART FHIR scopes
+    # against exhaustive UDAP +scopes_supported+ metadata.
+    #
+    # This collaborator deliberately does not authorize requests or decide hard
+    # failures. Exact wildcard-advertisement policy remains with {Udap}; this
+    # class only identifies non-wildcard scopes that cannot be locally proven to
+    # be covered for diagnostic purposes.
+    #
+    # @api private
+    class UdapScopeCoverage
+      ACCESS_CONTEXTS = %w[patient user system].freeze
+      INTERACTION_ORDER = %w[c r u d s].freeze
+      V1_PERMISSIONS = {
+        'read' => %w[r s].freeze,
+        'write' => %w[c u d].freeze,
+        '*' => INTERACTION_ORDER
+      }.freeze
+      FHIR_SCOPE_PATTERN = %r{\A(#{ACCESS_CONTEXTS.join('|')})/(\*|[A-Z][A-Za-z0-9]*)\.([^?]+)(?:\?(.+))?\z}
+      ParsedScope = Data.define(:context, :resource, :permissions, :constraint)
+
+      private_constant :ACCESS_CONTEXTS, :INTERACTION_ORDER, :V1_PERMISSIONS,
+                       :FHIR_SCOPE_PATTERN, :ParsedScope
+
+      def self.requested_wildcard?(scope)
+        scope.is_a?(String) && scope.include?('*')
+      end
+
+      def initialize(advertised_scopes)
+        unless advertised_scopes.is_a?(Array) && advertised_scopes.all?(String)
+          raise ArgumentError, 'advertised_scopes must be an array of strings'
+        end
+
+        @advertised_scopes = immutable_strings(advertised_scopes)
+        @parsed_advertised_scopes = @advertised_scopes.filter_map { |scope| parse_scope(scope) }.freeze
+        freeze
+      end
+
+      def advertised_exactly?(scope)
+        @advertised_scopes.include?(scope)
+      end
+
+      # Returns requested non-wildcard scopes not exactly advertised or covered
+      # by recognized SMART FHIR resource scopes. Compatible advertised entries
+      # may contribute a union of permissions for warning suppression only.
+      #
+      # @param requested_scopes [Array<String>]
+      # @return [Array<String>] deduplicated uncovered scopes in request order
+      def uncovered_non_wildcards_for_warning(requested_scopes)
+        validate_requested_scopes!(requested_scopes)
+        unique_scopes = requested_scopes.uniq
+        if unique_scopes.any? { |scope| self.class.requested_wildcard?(scope) }
+          raise ArgumentError, 'requested_scopes must not contain wildcard scopes'
+        end
+
+        unique_scopes.reject { |scope| advertised_exactly?(scope) || covered_fhir_scope?(scope) }
+      end
+
+      private
+
+      def immutable_strings(values)
+        values.map { |value| value.dup.freeze }.freeze
+      end
+
+      def validate_requested_scopes!(scopes)
+        return if scopes.is_a?(Array) && scopes.all?(String)
+
+        raise ArgumentError, 'requested_scopes must be an array of strings'
+      end
+
+      def covered_fhir_scope?(scope)
+        requested = parse_scope(scope)
+        return false unless requested
+
+        advertised_permissions = @parsed_advertised_scopes.filter_map do |advertised|
+          advertised.permissions if compatible_scope?(advertised, requested)
+        end.flatten.uniq
+        (requested.permissions - advertised_permissions).empty?
+      end
+
+      def compatible_scope?(advertised, requested)
+        advertised.context == requested.context &&
+          resource_covers?(advertised.resource, requested.resource) &&
+          constraint_covers?(advertised.constraint, requested.constraint)
+      end
+
+      def resource_covers?(advertised, requested)
+        advertised == '*' || advertised == requested
+      end
+
+      def constraint_covers?(advertised, requested)
+        advertised.nil? || advertised == requested
+      end
+
+      def parse_scope(scope)
+        match = FHIR_SCOPE_PATTERN.match(scope)
+        return unless match
+
+        permissions = normalize_permissions(match[3])
+        return unless permissions
+
+        ParsedScope.new(
+          context: match[1],
+          resource: match[2],
+          permissions:,
+          constraint: match[4]
+        )
+      end
+
+      def normalize_permissions(value)
+        return V1_PERMISSIONS.fetch(value) if V1_PERMISSIONS.key?(value)
+
+        characters = value.chars
+        return if characters.empty?
+        return unless characters == INTERACTION_ORDER.select { |interaction| characters.include?(interaction) }
+
+        characters.freeze
+      end
+    end
+  end
+end

--- a/spec/examples/sinatra_app/fhir_server_spec.rb
+++ b/spec/examples/sinatra_app/fhir_server_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe FhirServer do
       udap_client_id: 'udap-client-456',
       udap_client_uri: 'https://client.example.com',
       udap_community: 'https://community.example.org/udap',
+      udap_scope: 'system/Patient.rs',
       scopes: %w[openid profile]
     }
   end
@@ -119,7 +120,8 @@ RSpec.describe FhirServer do
         'client_id' => 'client-123',
         'udap_client_id' => 'udap-client-456',
         'udap_client_uri' => 'https://client.example.com',
-        'udap_community' => 'https://community.example.org/udap'
+        'udap_community' => 'https://community.example.org/udap',
+        'udap_scope' => 'system/Patient.rs'
       )
     end
   end

--- a/spec/examples/sinatra_app/safire_demo_spec.rb
+++ b/spec/examples/sinatra_app/safire_demo_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe SafireDemo do
       client_id: nil,
       udap_client_id: 'stored-udap-client',
       udap_client_uri: 'http://localhost:4567',
-      udap_community: 'https://community.example.org/udap'
+      udap_community: 'https://community.example.org/udap',
+      udap_scope: 'system/Patient.rs'
     )
   end
   let(:malicious_udap_server) do
@@ -69,7 +70,7 @@ RSpec.describe SafireDemo do
   end
 
   def build_server(id, protocols:, client_id: 'client-123', udap_client_id: nil,
-                   udap_client_uri: nil, udap_community: nil, name: nil)
+                   udap_client_uri: nil, udap_community: nil, udap_scope: nil, name: nil)
     FhirServer.new(
       id: id,
       name: name || id.tr('-', ' ').split.map(&:capitalize).join(' '),
@@ -78,6 +79,7 @@ RSpec.describe SafireDemo do
       udap_client_id: udap_client_id,
       udap_client_uri: udap_client_uri,
       udap_community: udap_community,
+      udap_scope: udap_scope,
       scopes: %w[openid profile],
       protocols: protocols
     )
@@ -124,13 +126,13 @@ RSpec.describe SafireDemo do
     )
   end
 
-  def expect_system_access_registration_request
+  def expect_system_access_registration_request(scope: 'system/*.rs')
     expect(udap_client).to have_received(:register_client).with(
       hash_including(
         client_name: 'Safire Demo App',
         contacts: ['mailto:admin@example.com'],
         grant_types: ['client_credentials'],
-        scope: 'system/*.rs'
+        scope:
       ),
       client_uri: 'http://localhost:4567',
       community: 'https://community.example.org/udap',
@@ -141,7 +143,11 @@ RSpec.describe SafireDemo do
 
   def expect_stored_context_cancellation_request
     expect(udap_client).to have_received(:cancel_registration).with(
-      hash_including(client_name: 'Safire Demo App', contacts: ['mailto:admin@example.com'], scope: 'openid profile'),
+      hash_including(
+        client_name: 'Safire Demo App',
+        contacts: ['mailto:admin@example.com'],
+        scope: 'system/Patient.rs'
+      ),
       client_uri: 'http://localhost:4567',
       community: 'https://community.example.org/udap',
       certifications: nil,
@@ -643,19 +649,32 @@ RSpec.describe SafireDemo do
       response = form_response(
         :post,
         '/demo/udap-only/udap-registration',
-        params: registration_params,
+        params: registration_params.merge(scope: 'system/Patient.rs'),
         env: { 'HTTP_HOST' => 'localhost:4567' }
       )
 
       expect(response.status).to eq(200)
       expect_local_udap_client_configuration
-      expect_system_access_registration_request
+      expect_system_access_registration_request(scope: 'system/Patient.rs')
       expect(udap_server.udap_client_id).to eq('new-udap-client')
       expect(udap_server.udap_client_uri).to eq('http://localhost:4567')
       expect(udap_server.udap_community).to eq('https://community.example.org/udap')
+      expect(udap_server.udap_scope).to eq('system/*.rs')
       expect(udap_server).to have_received(:save)
       expect(response.body).to include('new-udap-client')
       expect_response_to_hide_registration_artifacts(response)
+    end
+
+    it 'persists the requested scope when the registration response omits it' do
+      allow(udap_client).to receive(:register_client).and_return(registration_response.except('scope'))
+
+      form_response(
+        :post,
+        '/demo/udap-only/udap-registration',
+        params: registration_params.merge(scope: 'system/Observation.r')
+      )
+
+      expect(udap_server.udap_scope).to eq('system/Observation.r')
     end
 
     it 'rejects direct registration posts when a UDAP client id is already stored' do
@@ -670,6 +689,19 @@ RSpec.describe SafireDemo do
       expect(udap_client).not_to have_received(:register_client)
       expect(registered_udap_server.udap_client_id).to eq('stored-udap-client')
       expect(response.body).to include('cancel the existing registration before registering again')
+    end
+
+    it 'rejects an empty scope before invoking Safire registration' do
+      response = form_response(
+        :post,
+        '/demo/udap-only/udap-registration',
+        params: registration_params.merge(scope: '   ')
+      )
+
+      expect(response.status).to eq(200)
+      expect(udap_client).not_to have_received(:register_client)
+      expect(response.body).to include('Scope')
+      expect(response.body).to include('must describe the access this demo client intends to request')
     end
 
     it 'submits authorization-code metadata with conditional client fields' do
@@ -795,6 +827,7 @@ RSpec.describe SafireDemo do
       expect(registered_udap_server.udap_client_id).to be_nil
       expect(registered_udap_server.udap_client_uri).to be_nil
       expect(registered_udap_server.udap_community).to be_nil
+      expect(registered_udap_server.udap_scope).to be_nil
       expect(registered_udap_server).to have_received(:save)
       expect(response.body).to include('Registration cancelled')
       expect_response_to_hide_registration_artifacts(response)
@@ -857,6 +890,7 @@ RSpec.describe SafireDemo do
       expect(registered_udap_server.udap_client_id).to eq('stored-udap-client')
       expect(registered_udap_server.udap_client_uri).to eq('http://localhost:4567')
       expect(registered_udap_server.udap_community).to eq('https://community.example.org/udap')
+      expect(registered_udap_server.udap_scope).to eq('system/Patient.rs')
       expect(response.body).to include('different client id')
     end
 

--- a/spec/examples/sinatra_app/udap_registration_presenter_spec.rb
+++ b/spec/examples/sinatra_app/udap_registration_presenter_spec.rb
@@ -122,6 +122,18 @@ RSpec.describe UdapRegistrationPresenter do
     expect(presenter.logo_uri).to eq('https://override.example.com/logo.gif')
   end
 
+  it 'leaves scope empty when the server has no configured scopes' do
+    server.scopes = []
+
+    expect(build_presenter.scope).to eq('')
+  end
+
+  it 'preserves a submitted blank scope for validation feedback' do
+    presenter = build_presenter(params: { 'scope' => '   ' })
+
+    expect(presenter.scope).to eq('   ')
+  end
+
   it 'falls back to the generated demo logo URI when no logo env is configured' do
     presenter = build_presenter(env: env.except('UDAP_CLIENT_LOGO_URI'))
 

--- a/spec/integration/udap_dcr_flow_spec.rb
+++ b/spec/integration/udap_dcr_flow_spec.rb
@@ -77,9 +77,9 @@ RSpec.describe 'UDAP Dynamic Client Registration Flow', type: :integration do
       .to_return(status:, body: body.to_json, headers: { 'Content-Type' => 'application/json' })
   end
 
-  def decoded_software_statement
+  def decoded_software_statement(algorithm: 'RS256')
     jwt = JSON.parse(registration_requests.last)['software_statement']
-    JWT.decode(jwt, certificate.public_key, true, algorithms: ['RS256'], verify_expiration: false).first
+    JWT.decode(jwt, certificate.public_key, true, algorithms: [algorithm], verify_expiration: false).first
   end
 
   before do
@@ -127,6 +127,49 @@ RSpec.describe 'UDAP Dynamic Client Registration Flow', type: :integration do
     stub_registration_response(status: 200)
 
     expect(client.register_client(registration_metadata, client_uri:)['client_id']).to eq('udap-client-123')
+  end
+
+  it 'signs with an advertised RSA alternative when non-conformant metadata omits RS256' do
+    stub_udap_discovery(
+      body: udap_metadata.merge('registration_endpoint_jwt_signing_alg_values_supported' => ['RS384'])
+    )
+    stub_registration_response
+    allow(Safire.logger).to receive(:warn)
+
+    client.register_client(registration_metadata, client_uri:)
+
+    expect(decoded_software_statement(algorithm: 'RS384')['scope']).to eq('system/Patient.rs')
+    expect(Safire.logger).to have_received(:warn).with(/RS256.*may proceed/i).once
+  end
+
+  context 'with an EC P-256 signing identity' do
+    let(:private_key) { OpenSSL::PKey::EC.generate('prime256v1') }
+
+    it 'signs with an advertised EC alternative when non-conformant metadata omits RS256' do
+      stub_udap_discovery(
+        body: udap_metadata.merge('registration_endpoint_jwt_signing_alg_values_supported' => ['ES256'])
+      )
+      stub_registration_response
+      allow(Safire.logger).to receive(:warn)
+
+      client.register_client(registration_metadata, client_uri:)
+
+      expect(decoded_software_statement(algorithm: 'ES256')['scope']).to eq('system/Patient.rs')
+      expect(Safire.logger).to have_received(:warn).with(/RS256.*may proceed/i).once
+    end
+  end
+
+  it 'warns and sends an unadvertised wildcard during the v0.4.1 compatibility phase' do
+    stub_udap_discovery(body: udap_metadata.merge('scopes_supported' => ['system/Patient.rs']))
+    stub_registration_response
+    allow(Safire.logger).to receive(:warn)
+
+    client.register_client(registration_metadata.merge(scope: 'system/*.rs'), client_uri:)
+
+    expect(decoded_software_statement['scope']).to eq('system/*.rs')
+    expect(Safire.logger).to have_received(:warn)
+      .with(/wildcard.*not advertised exactly.*v0\.5\.0/i).once
+    expect(WebMock).to have_requested(:post, registration_endpoint)
   end
 
   it 'cancels registration with a signed empty grant_types claim' do

--- a/spec/integration/udap_dcr_flow_spec.rb
+++ b/spec/integration/udap_dcr_flow_spec.rb
@@ -168,7 +168,8 @@ RSpec.describe 'UDAP Dynamic Client Registration Flow', type: :integration do
 
     expect(decoded_software_statement['scope']).to eq('system/*.rs')
     expect(Safire.logger).to have_received(:warn)
-      .with(/wildcard.*not advertised exactly.*v0\.5\.0/i).once
+      .with(/wildcard scope count=1.*no exact advertisement.*v0\.5\.0/i).once
+    expect(Safire.logger).not_to have_received(:warn).with(%r{system/\*\.rs})
     expect(WebMock).to have_requested(:post, registration_endpoint)
   end
 

--- a/spec/safire/protocols/udap_scope_coverage_spec.rb
+++ b/spec/safire/protocols/udap_scope_coverage_spec.rb
@@ -1,0 +1,181 @@
+require 'spec_helper'
+
+RSpec.describe Safire::Protocols::UdapScopeCoverage do
+  subject(:coverage) { described_class.new(advertised_scopes) }
+
+  let(:advertised_scopes) { ['system/*.rs'] }
+
+  describe '.requested_wildcard?' do
+    it 'classifies any literal asterisk as a requested wildcard' do
+      expect(described_class.requested_wildcard?('system/Patient.*')).to be(true)
+      expect(described_class.requested_wildcard?('system/*.rs')).to be(true)
+      expect(described_class.requested_wildcard?('custom:*:read')).to be(true)
+    end
+
+    it 'does not classify lookalike text as a wildcard' do
+      expect(described_class.requested_wildcard?('urn:example:wildcard')).to be(false)
+    end
+  end
+
+  describe '#advertised_exactly?' do
+    it 'uses exact, case-sensitive membership' do
+      expect(coverage.advertised_exactly?('system/*.rs')).to be(true)
+      expect(coverage.advertised_exactly?('system/*.RS')).to be(false)
+    end
+  end
+
+  describe '#uncovered_non_wildcards_for_warning' do
+    it 'accepts exact custom-scope matches without interpreting their syntax' do
+      coverage = described_class.new(['urn:example:read'])
+
+      expect(coverage.uncovered_non_wildcards_for_warning(['urn:example:read'])).to eq([])
+    end
+
+    it 'returns custom scopes that are not advertised exactly' do
+      expect(coverage.uncovered_non_wildcards_for_warning(['urn:example:read']))
+        .to eq(['urn:example:read'])
+    end
+
+    it 'covers specific resources and narrower permissions with an advertised resource wildcard' do
+      requested = %w[system/Patient.rs system/Observation.rs system/Condition.r]
+
+      expect(coverage.uncovered_non_wildcards_for_warning(requested)).to eq([])
+    end
+
+    it 'does not depend on a hard-coded FHIR resource catalog' do
+      expect(coverage.uncovered_non_wildcards_for_warning(['system/CommunityDefinedResource.r'])).to eq([])
+    end
+
+    it 'rejects a mismatched access context' do
+      expect(coverage.uncovered_non_wildcards_for_warning(['patient/Patient.r']))
+        .to eq(['patient/Patient.r'])
+    end
+
+    it 'rejects a mismatched resource when no resource wildcard is advertised' do
+      coverage = described_class.new(['system/Observation.rs'])
+
+      expect(coverage.uncovered_non_wildcards_for_warning(['system/Patient.r']))
+        .to eq(['system/Patient.r'])
+    end
+
+    it 'rejects permissions broader than the advertised set' do
+      expect(coverage.uncovered_non_wildcards_for_warning(['system/Patient.cruds']))
+        .to eq(['system/Patient.cruds'])
+    end
+
+    it 'allows an unconstrained advertisement to cover a constrained request' do
+      requested = 'system/Observation.rs?category=laboratory'
+
+      expect(coverage.uncovered_non_wildcards_for_warning([requested])).to eq([])
+    end
+
+    it 'allows an identical advertised search constraint' do
+      requested = 'system/Observation.rs?category=laboratory'
+      coverage = described_class.new([requested])
+
+      expect(coverage.uncovered_non_wildcards_for_warning([requested])).to eq([])
+    end
+
+    it 'does not let a constrained advertisement cover an unconstrained request' do
+      coverage = described_class.new(['system/Observation.rs?category=laboratory'])
+
+      expect(coverage.uncovered_non_wildcards_for_warning(['system/Observation.rs']))
+        .to eq(['system/Observation.rs'])
+    end
+
+    it 'does not infer relationships between different search constraints' do
+      coverage = described_class.new(['system/Observation.rs?category=laboratory'])
+      requested = 'system/Observation.rs?category=vital-signs'
+
+      expect(coverage.uncovered_non_wildcards_for_warning([requested])).to eq([requested])
+    end
+
+    it 'normalizes advertised SMART v1 read permissions' do
+      coverage = described_class.new(['system/Patient.read'])
+
+      expect(coverage.uncovered_non_wildcards_for_warning(['system/Patient.rs'])).to eq([])
+    end
+
+    it 'normalizes advertised SMART v1 write permissions' do
+      coverage = described_class.new(['system/Patient.write'])
+
+      expect(coverage.uncovered_non_wildcards_for_warning(['system/Patient.cud'])).to eq([])
+    end
+
+    it 'normalizes advertised SMART v1 wildcard permissions for a non-wildcard request' do
+      coverage = described_class.new(['system/Patient.*'])
+
+      expect(coverage.uncovered_non_wildcards_for_warning(['system/Patient.rs'])).to eq([])
+    end
+
+    it 'normalizes a requested SMART v1 read permission when it has no literal wildcard' do
+      coverage = described_class.new(['system/Patient.rs'])
+
+      expect(coverage.uncovered_non_wildcards_for_warning(['system/Patient.read'])).to eq([])
+    end
+
+    it 'treats out-of-order interaction suffixes as unrecognized syntax' do
+      expect(coverage.uncovered_non_wildcards_for_warning(['system/Patient.sr']))
+        .to eq(['system/Patient.sr'])
+    end
+
+    it 'still accepts an exact match for unrecognized interaction syntax' do
+      coverage = described_class.new(['system/Patient.sr'])
+
+      expect(coverage.uncovered_non_wildcards_for_warning(['system/Patient.sr'])).to eq([])
+    end
+
+    it 'uses compatible advertised fragments as a warning-only permission union' do
+      coverage = described_class.new(%w[system/Patient.r system/Patient.s])
+
+      expect(coverage.uncovered_non_wildcards_for_warning(['system/Patient.rs'])).to eq([])
+    end
+
+    it 'does not let an unrelated advertised wildcard suppress a warning' do
+      coverage = described_class.new(['user/*.rs'])
+
+      expect(coverage.uncovered_non_wildcards_for_warning(['system/Patient.r']))
+        .to eq(['system/Patient.r'])
+    end
+
+    it 'deduplicates requested scopes while preserving their original order' do
+      requested = %w[custom:b custom:a custom:b custom:c custom:a]
+
+      expect(coverage.uncovered_non_wildcards_for_warning(requested))
+        .to eq(%w[custom:b custom:a custom:c])
+    end
+
+    it 'rejects requested wildcards so callers must evaluate exact advertisement separately' do
+      expect { coverage.uncovered_non_wildcards_for_warning(['system/Patient.*']) }
+        .to raise_error(ArgumentError, /must not contain wildcard scopes/)
+    end
+
+    [nil, 'system/Patient.rs', ['system/Patient.rs', nil]].each do |value|
+      it "rejects malformed requested scopes #{value.inspect}" do
+        expect { coverage.uncovered_non_wildcards_for_warning(value) }
+          .to raise_error(ArgumentError, /requested_scopes must be an array of strings/)
+      end
+    end
+
+    it 'does not mutate caller-owned arrays or strings' do
+      advertised = ['system/*.rs']
+      requested = ['system/Patient.rs']
+
+      described_class.new(advertised).uncovered_non_wildcards_for_warning(requested)
+
+      expect(advertised).to eq(['system/*.rs'])
+      expect(requested).to eq(['system/Patient.rs'])
+      expect(advertised.first).not_to be_frozen
+      expect(requested.first).not_to be_frozen
+    end
+  end
+
+  describe 'constructor validation' do
+    [nil, 'system/*.rs', ['system/*.rs', nil]].each do |value|
+      it "rejects #{value.inspect}" do
+        expect { described_class.new(value) }
+          .to raise_error(ArgumentError, /advertised_scopes must be an array of strings/)
+      end
+    end
+  end
+end

--- a/spec/safire/protocols/udap_spec.rb
+++ b/spec/safire/protocols/udap_spec.rb
@@ -492,12 +492,13 @@ RSpec.describe Safire::Protocols::Udap do
   describe '#register_client' do
     let(:registration_endpoint) { 'https://fhir.example.com/signed-register' }
     let(:client_uri) { 'https://client.example.com/app' }
+    let(:scope) { 'system/Patient.rs' }
     let(:client_metadata) do
       {
         client_name: 'Example Backend Service',
         contacts: ['mailto:security@example.com'],
         grant_types: ['client_credentials'],
-        scope: 'system/Patient.rs'
+        scope:
       }
     end
     let(:registration_response) do
@@ -525,7 +526,12 @@ RSpec.describe Safire::Protocols::Udap do
         signed_endpoint_claims: registration_signed_claims
       )
     end
-    let(:registration_metadata) { instance_double(Safire::Protocols::UdapRegistrationMetadata) }
+    let(:registration_metadata) do
+      instance_double(
+        Safire::Protocols::UdapRegistrationMetadata,
+        to_h: { 'scope' => client_metadata.fetch(:scope) }
+      )
+    end
     let(:software_statement) { instance_double(Safire::Protocols::UdapSoftwareStatement, to_jwt: 'header.payload.sig') }
 
     def stub_registration_discovery_for_community(community)
@@ -543,6 +549,7 @@ RSpec.describe Safire::Protocols::Udap do
       allow(Safire::Protocols::UdapSignedMetadataValidator).to receive(:new).and_return(registration_validator)
       allow(Safire::Protocols::UdapRegistrationMetadata).to receive(:new).and_return(registration_metadata)
       allow(Safire::Protocols::UdapSoftwareStatement).to receive(:new).and_return(software_statement)
+      allow(Safire.logger).to receive(:warn)
       stub_request(:post, registration_endpoint)
         .to_return(status: 201, body: registration_response.to_json, headers: { 'Content-Type' => 'application/json' })
     end
@@ -591,7 +598,18 @@ RSpec.describe Safire::Protocols::Udap do
         client_metadata,
         operation: :register,
         allow_insecure_localhost: false
+      ).once
+    end
+
+    it 'validates caller metadata before discovery' do
+      allow(Safire::Protocols::UdapRegistrationMetadata).to receive(:new).and_raise(
+        Safire::Errors::ValidationError.new(attribute: :scope, reason: 'must be a non-blank string')
       )
+
+      expect { udap.register_client(client_metadata, client_uri:) }
+        .to raise_error(Safire::Errors::ValidationError, /scope/)
+      expect(WebMock).not_to have_requested(:get, well_known_url)
+      expect(Safire::Protocols::UdapSoftwareStatement).not_to have_received(:new)
     end
 
     context 'when insecure localhost is enabled in config' do
@@ -672,16 +690,16 @@ RSpec.describe Safire::Protocols::Udap do
       end)
     end
 
-    it 'raises DiscoveryError when discovered metadata is structurally non-conformant' do
+    it 'does not gate registration on unrelated structural conformance defects' do
       stub_udap(
         body: registration_discovery_body.merge(
-          'registration_endpoint_jwt_signing_alg_values_supported' => []
+          'udap_versions_supported' => %w[1 2],
+          'token_endpoint_auth_methods_supported' => %w[private_key_jwt client_secret_basic],
+          'grant_types_supported' => %w[client_credentials authorization_code]
         )
       )
 
-      expect { udap.register_client(client_metadata, client_uri:) }
-        .to raise_error(Safire::Errors::DiscoveryError, /structurally conformant/)
-      expect(WebMock).not_to have_requested(:post, registration_endpoint)
+      expect(udap.register_client(client_metadata, client_uri:)).to eq(registration_response)
     end
 
     it 'raises DiscoveryError when metadata omits the required UDAP DCR profile' do
@@ -692,14 +710,25 @@ RSpec.describe Safire::Protocols::Udap do
       )
 
       expect { udap.register_client(client_metadata, client_uri:) }
-        .to raise_error(Safire::Errors::DiscoveryError, /structurally conformant/)
+        .to raise_error(Safire::Errors::DiscoveryError, /does not advertise UDAP Dynamic Client Registration/)
       expect(WebMock).not_to have_requested(:post, registration_endpoint)
     end
 
-    it 'raises DiscoveryError when conformant metadata does not expose usable DCR capability' do
+    it 'raises DiscoveryError when the UDAP profile metadata has an unusable type' do
+      stub_udap(
+        body: registration_discovery_body.merge(
+          'udap_profiles_supported' => 'udap_dcr'
+        )
+      )
+
+      expect { udap.register_client(client_metadata, client_uri:) }
+        .to raise_error(Safire::Errors::DiscoveryError, /does not advertise UDAP Dynamic Client Registration/)
+      expect(WebMock).not_to have_requested(:post, registration_endpoint)
+    end
+
+    it 'raises DiscoveryError when metadata does not expose usable DCR capability' do
       discovered = instance_double(
         Safire::Protocols::UdapMetadata,
-        valid?: true,
         supports_dynamic_registration?: false
       )
       stub_udap
@@ -710,17 +739,164 @@ RSpec.describe Safire::Protocols::Udap do
       expect(WebMock).not_to have_requested(:post, registration_endpoint)
     end
 
-    it 'raises DiscoveryError when the server omits mandatory RS256 registration signing support' do
+    it 'raises DiscoveryError when the authoritative registration endpoint is unusable' do
+      allow(registration_validator).to receive(:signed_endpoint_claims).and_return(
+        registration_signed_claims.merge('registration_endpoint' => 42)
+      )
+
+      expect { udap.register_client(client_metadata, client_uri:) }
+        .to raise_error(Safire::Errors::DiscoveryError, /does not advertise UDAP Dynamic Client Registration/)
+      expect(WebMock).not_to have_requested(:post, registration_endpoint)
+    end
+
+    [nil, [], 'RS256', ['RS256', nil]].each do |algorithms|
+      it "raises DiscoveryError when registration signing algorithms are #{algorithms.inspect}" do
+        stub_udap(
+          body: registration_discovery_body.merge(
+            'registration_endpoint_jwt_signing_alg_values_supported' => algorithms
+          )
+        )
+
+        expect { udap.register_client(client_metadata, client_uri:) }
+          .to raise_error(Safire::Errors::DiscoveryError, /signing algorithm metadata must be a non-empty array/)
+        expect(Safire::Protocols::UdapSoftwareStatement).not_to have_received(:new)
+        expect(WebMock).not_to have_requested(:post, registration_endpoint)
+      end
+    end
+
+    it 'warns and uses a compatible advertised algorithm when RS256 is missing' do
+      stub_udap(
+        body: registration_discovery_body.merge(
+          'registration_endpoint_jwt_signing_alg_values_supported' => ['RS384']
+        )
+      )
+
+      expect(udap.register_client(client_metadata, client_uri:)).to eq(registration_response)
+      expect(Safire.logger).to have_received(:warn).with(/does not advertise.*RS256.*may proceed/i).once
+      expect(Safire::Protocols::UdapSoftwareStatement).to have_received(:new).with(
+        hash_including(supported_algorithms: ['RS384'])
+      )
+    end
+
+    it 'passes an advertised EC alternative to the signing boundary when RS256 is missing' do
+      stub_udap(
+        body: registration_discovery_body.merge(
+          'registration_endpoint_jwt_signing_alg_values_supported' => ['ES256']
+        )
+      )
+
+      expect(udap.register_client(client_metadata, client_uri:)).to eq(registration_response)
+      expect(Safire.logger).to have_received(:warn).with(/does not advertise.*RS256.*may proceed/i).once
+      expect(Safire::Protocols::UdapSoftwareStatement).to have_received(:new).with(
+        hash_including(supported_algorithms: ['ES256'])
+      )
+    end
+
+    it 'preserves ConfigurationError when no advertised algorithm is usable by the signing identity' do
+      error = Safire::Errors::ConfigurationError.new(
+        invalid_attribute: :supported_algorithms,
+        invalid_value: ['ES384'],
+        valid_values: %w[RS256 RS384]
+      )
       stub_udap(
         body: registration_discovery_body.merge(
           'registration_endpoint_jwt_signing_alg_values_supported' => ['ES384']
         )
       )
+      allow(Safire::Protocols::UdapSoftwareStatement).to receive(:new).and_raise(error)
 
       expect { udap.register_client(client_metadata, client_uri:) }
-        .to raise_error(Safire::Errors::DiscoveryError, /RS256/)
-      expect(Safire::Protocols::UdapSoftwareStatement).not_to have_received(:new)
+        .to raise_error(Safire::Errors::ConfigurationError)
       expect(WebMock).not_to have_requested(:post, registration_endpoint)
+    end
+
+    context 'when evaluating requested scopes' do
+      it 'does not warn for a requested wildcard advertised exactly by the server' do
+        stub_udap(
+          body: registration_discovery_body.merge('scopes_supported' => ['system/*.rs'])
+        )
+        client_metadata[:scope] = 'system/*.rs'
+        allow(registration_metadata).to receive(:to_h).and_return('scope' => 'system/*.rs')
+
+        udap.register_client(client_metadata, client_uri:)
+
+        expect(Safire.logger).not_to have_received(:warn)
+      end
+
+      it 'warns distinctly and proceeds for an unadvertised requested wildcard in v0.4.1' do
+        stub_udap(
+          body: registration_discovery_body.merge('scopes_supported' => ['system/Patient.rs'])
+        )
+        client_metadata[:scope] = 'system/*.rs'
+        allow(registration_metadata).to receive(:to_h).and_return('scope' => 'system/*.rs')
+
+        expect(udap.register_client(client_metadata, client_uri:)).to eq(registration_response)
+        expect(Safire.logger).to have_received(:warn)
+          .with(%r{wildcard.*system/\*\.rs.*not advertised exactly.*v0\.5\.0}i).once
+        expect(WebMock).to have_requested(:post, registration_endpoint)
+      end
+
+      it 'requires exact advertisement for a requested v1 permission wildcard' do
+        stub_udap(
+          body: registration_discovery_body.merge('scopes_supported' => ['system/*.cruds'])
+        )
+        client_metadata[:scope] = 'system/Patient.*'
+        allow(registration_metadata).to receive(:to_h).and_return('scope' => 'system/Patient.*')
+
+        expect(udap.register_client(client_metadata, client_uri:)).to eq(registration_response)
+        expect(Safire.logger).to have_received(:warn)
+          .with(%r{wildcard.*system/Patient\.\*.*not advertised exactly}i).once
+      end
+
+      it 'does not warn when advertised FHIR scope coverage proves a non-wildcard request' do
+        udap.register_client(client_metadata, client_uri:)
+
+        expect(Safire.logger).not_to have_received(:warn)
+      end
+
+      it 'aggregates uncovered non-wildcard scopes in deterministic request order' do
+        requested_scope = 'custom:b custom:a custom:b custom:c'
+        client_metadata[:scope] = requested_scope
+        allow(registration_metadata).to receive(:to_h).and_return('scope' => requested_scope)
+
+        expect(udap.register_client(client_metadata, client_uri:)).to eq(registration_response)
+        expect(Safire.logger).to have_received(:warn)
+          .with(/non-wildcard.*custom:b, custom:a, custom:c.*server-side scope negotiation/i).once
+      end
+
+      [nil, [], 'system/*.rs', ['system/*.rs', nil]].each do |advertised_scopes|
+        it "warns and proceeds when scopes_supported is #{advertised_scopes.inspect}" do
+          stub_udap(
+            body: registration_discovery_body.merge('scopes_supported' => advertised_scopes)
+          )
+
+          expect(udap.register_client(client_metadata, client_uri:)).to eq(registration_response)
+          expect(Safire.logger).to have_received(:warn)
+            .with(/cannot confirm.*scope coverage.*scopes_supported.*missing, empty, or malformed/i).once
+        end
+      end
+
+      it 'warns distinctly when a wildcard cannot be checked against malformed scope metadata' do
+        stub_udap(
+          body: registration_discovery_body.merge('scopes_supported' => nil)
+        )
+        client_metadata[:scope] = 'system/*.rs'
+        allow(registration_metadata).to receive(:to_h).and_return('scope' => 'system/*.rs')
+
+        expect(udap.register_client(client_metadata, client_uri:)).to eq(registration_response)
+        expect(Safire.logger).to have_received(:warn)
+          .with(/wildcard.*cannot be confirmed.*scopes_supported.*missing, empty, or malformed.*v0\.5\.0/i).once
+      end
+
+      it 'does not treat wildcard lookalike text as a requested wildcard' do
+        client_metadata[:scope] = 'urn:example:wildcard'
+        allow(registration_metadata).to receive(:to_h).and_return('scope' => 'urn:example:wildcard')
+
+        udap.register_client(client_metadata, client_uri:)
+
+        expect(Safire.logger).to have_received(:warn).with(/non-wildcard.*urn:example:wildcard/i).once
+        expect(Safire.logger).not_to have_received(:warn).with(/requested wildcard/i)
+      end
     end
 
     context 'when the community requires certifications' do
@@ -757,9 +933,38 @@ RSpec.describe Safire::Protocols::Udap do
       end
     end
 
+    it 'treats an explicitly empty certification-requirement array as no requirement' do
+      stub_udap(
+        body: registration_discovery_body.merge('udap_certifications_required' => [])
+      )
+
+      expect(udap.register_client(client_metadata, client_uri:)).to eq(registration_response)
+      expect(Safire::Protocols::UdapSoftwareStatement).to have_received(:new)
+    end
+
+    [
+      'https://policy.example/cert',
+      [nil],
+      { 'certification' => 'https://policy.example/cert' }
+    ].each do |required_certifications|
+      it "raises DiscoveryError when required certification metadata is #{required_certifications.inspect}" do
+        stub_udap(
+          body: registration_discovery_body.merge(
+            'udap_certifications_required' => required_certifications
+          )
+        )
+
+        expect { udap.register_client(client_metadata, client_uri:) }
+          .to raise_error(Safire::Errors::DiscoveryError, /udap_certifications_required.*array of strings/)
+        expect(Safire::Protocols::UdapSoftwareStatement).not_to have_received(:new)
+        expect(WebMock).not_to have_requested(:post, registration_endpoint)
+      end
+    end
+
     it 'raises ValidationError for malformed certification collections' do
       expect { udap.register_client(client_metadata, client_uri:, certifications: ['not-a-jwt']) }
         .to raise_error(Safire::Errors::ValidationError, /compact JWS/)
+      expect(WebMock).not_to have_requested(:get, well_known_url)
       expect(Safire::Protocols::UdapSoftwareStatement).not_to have_received(:new)
     end
 
@@ -864,11 +1069,12 @@ RSpec.describe Safire::Protocols::Udap do
   describe '#cancel_registration' do
     let(:registration_endpoint) { 'https://fhir.example.com/signed-register' }
     let(:client_uri) { 'https://client.example.com/app' }
+    let(:scope) { 'system/Patient.rs' }
     let(:client_metadata) do
       {
         client_name: 'Example Backend Service',
         contacts: ['mailto:security@example.com'],
-        scope: 'system/Patient.rs'
+        scope:
       }
     end
     let(:cancellation_response) do
@@ -896,7 +1102,12 @@ RSpec.describe Safire::Protocols::Udap do
         signed_endpoint_claims: registration_signed_claims
       )
     end
-    let(:registration_metadata) { instance_double(Safire::Protocols::UdapRegistrationMetadata) }
+    let(:registration_metadata) do
+      instance_double(
+        Safire::Protocols::UdapRegistrationMetadata,
+        to_h: { 'scope' => client_metadata.fetch(:scope) }
+      )
+    end
     let(:software_statement) { instance_double(Safire::Protocols::UdapSoftwareStatement, to_jwt: 'header.payload.sig') }
 
     before do
@@ -904,6 +1115,7 @@ RSpec.describe Safire::Protocols::Udap do
       allow(Safire::Protocols::UdapSignedMetadataValidator).to receive(:new).and_return(registration_validator)
       allow(Safire::Protocols::UdapRegistrationMetadata).to receive(:new).and_return(registration_metadata)
       allow(Safire::Protocols::UdapSoftwareStatement).to receive(:new).and_return(software_statement)
+      allow(Safire.logger).to receive(:warn)
       stub_request(:post, registration_endpoint)
         .to_return(status: 202, body: cancellation_response.to_json, headers: { 'Content-Type' => 'application/json' })
     end
@@ -986,6 +1198,19 @@ RSpec.describe Safire::Protocols::Udap do
       expect(WebMock).to(have_requested(:post, registration_endpoint).with do |request|
         JSON.parse(request.body)['certifications'] == certifications
       end)
+    end
+
+    it 'warns but still permits lifecycle cleanup when a cancellation wildcard is no longer advertised' do
+      stub_udap(
+        body: registration_discovery_body.merge('scopes_supported' => ['system/Patient.rs'])
+      )
+      client_metadata[:scope] = 'system/*.rs'
+      allow(registration_metadata).to receive(:to_h).and_return('scope' => 'system/*.rs')
+
+      expect(udap.cancel_registration(client_metadata, client_uri:)).to eq(cancellation_response)
+      expect(Safire.logger).to have_received(:warn)
+        .with(%r{wildcard.*system/\*\.rs.*cancellation.*remains warning-only}i).once
+      expect(WebMock).to have_requested(:post, registration_endpoint)
     end
 
     [

--- a/spec/safire/protocols/udap_spec.rb
+++ b/spec/safire/protocols/udap_spec.rb
@@ -832,7 +832,8 @@ RSpec.describe Safire::Protocols::Udap do
 
         expect(udap.register_client(client_metadata, client_uri:)).to eq(registration_response)
         expect(Safire.logger).to have_received(:warn)
-          .with(%r{wildcard.*system/\*\.rs.*not advertised exactly.*v0\.5\.0}i).once
+          .with(/wildcard scope count=1.*no exact advertisement.*v0\.5\.0/i).once
+        expect(Safire.logger).not_to have_received(:warn).with(%r{system/\*\.rs})
         expect(WebMock).to have_requested(:post, registration_endpoint)
       end
 
@@ -845,7 +846,8 @@ RSpec.describe Safire::Protocols::Udap do
 
         expect(udap.register_client(client_metadata, client_uri:)).to eq(registration_response)
         expect(Safire.logger).to have_received(:warn)
-          .with(%r{wildcard.*system/Patient\.\*.*not advertised exactly}i).once
+          .with(/wildcard scope count=1.*no exact advertisement/i).once
+        expect(Safire.logger).not_to have_received(:warn).with(%r{system/Patient\.\*})
       end
 
       it 'does not warn when advertised FHIR scope coverage proves a non-wildcard request' do
@@ -854,14 +856,19 @@ RSpec.describe Safire::Protocols::Udap do
         expect(Safire.logger).not_to have_received(:warn)
       end
 
-      it 'aggregates uncovered non-wildcard scopes in deterministic request order' do
-        requested_scope = 'custom:b custom:a custom:b custom:c'
+      it 'aggregates uncovered non-wildcard scopes without logging their values' do
+        stub_udap(
+          body: registration_discovery_body.merge('scopes_supported' => ['system/Observation.r'])
+        )
+        constrained_scope = 'system/Observation.rs?patient.identifier=mrn-123'
+        requested_scope = "#{constrained_scope} custom:tenant-a #{constrained_scope} custom:study-c"
         client_metadata[:scope] = requested_scope
         allow(registration_metadata).to receive(:to_h).and_return('scope' => requested_scope)
 
         expect(udap.register_client(client_metadata, client_uri:)).to eq(registration_response)
         expect(Safire.logger).to have_received(:warn)
-          .with(/non-wildcard.*custom:b, custom:a, custom:c.*server-side scope negotiation/i).once
+          .with(/non-wildcard scope count=3.*server-side scope negotiation/i).once
+        expect(Safire.logger).not_to have_received(:warn).with(/mrn-123|tenant-a|study-c/)
       end
 
       [nil, [], 'system/*.rs', ['system/*.rs', nil]].each do |advertised_scopes|
@@ -872,7 +879,8 @@ RSpec.describe Safire::Protocols::Udap do
 
           expect(udap.register_client(client_metadata, client_uri:)).to eq(registration_response)
           expect(Safire.logger).to have_received(:warn)
-            .with(/cannot confirm.*scope coverage.*scopes_supported.*missing, empty, or malformed/i).once
+            .with(/non-wildcard scope count=1.*coverage cannot be confirmed.*missing, empty, or malformed/i).once
+          expect(Safire.logger).not_to have_received(:warn).with(%r{system/Patient\.rs})
         end
       end
 
@@ -885,7 +893,8 @@ RSpec.describe Safire::Protocols::Udap do
 
         expect(udap.register_client(client_metadata, client_uri:)).to eq(registration_response)
         expect(Safire.logger).to have_received(:warn)
-          .with(/wildcard.*cannot be confirmed.*scopes_supported.*missing, empty, or malformed.*v0\.5\.0/i).once
+          .with(/wildcard scope count=1.*cannot be confirmed.*missing, empty, or malformed.*v0\.5\.0/i).once
+        expect(Safire.logger).not_to have_received(:warn).with(%r{system/\*\.rs})
       end
 
       it 'does not treat wildcard lookalike text as a requested wildcard' do
@@ -894,7 +903,8 @@ RSpec.describe Safire::Protocols::Udap do
 
         udap.register_client(client_metadata, client_uri:)
 
-        expect(Safire.logger).to have_received(:warn).with(/non-wildcard.*urn:example:wildcard/i).once
+        expect(Safire.logger).to have_received(:warn).with(/non-wildcard scope count=1/i).once
+        expect(Safire.logger).not_to have_received(:warn).with(/urn:example:wildcard/)
         expect(Safire.logger).not_to have_received(:warn).with(/requested wildcard/i)
       end
     end
@@ -1209,7 +1219,8 @@ RSpec.describe Safire::Protocols::Udap do
 
       expect(udap.cancel_registration(client_metadata, client_uri:)).to eq(cancellation_response)
       expect(Safire.logger).to have_received(:warn)
-        .with(%r{wildcard.*system/\*\.rs.*cancellation.*remains warning-only}i).once
+        .with(/wildcard scope count=1.*cancellation.*remains warning-only/i).once
+      expect(Safire.logger).not_to have_received(:warn).with(%r{system/\*\.rs})
       expect(WebMock).to have_requested(:post, registration_endpoint)
     end
 


### PR DESCRIPTION
## Summary

This PR replaces the blanket UDAP metadata conformance gate in dynamic registration with focused checks for the discovery fields Safire actually needs to complete the requested DCR operation. It validates caller-owned registration metadata before discovery, preserves mandatory signed-metadata trust validation, distinguishes malformed discovery inputs from unsupported client configurations, and introduces warning-only SMART scope coverage diagnostics ahead of the v0.5.0 wildcard enforcement change.

The demo now requires an explicit UDAP registration scope, persists the effective UDAP scope independently from SMART server scopes, and reuses it for cancellation. The documentation, ADRs, troubleshooting guidance, and changelog describe the focused readiness model and migration warnings. The demo Gemfile.lock change is an intentional Bundler refresh of its stale local Safire version entry.

## Verification

- `COVERAGE=true bundle exec rspec` - 1,082 examples, 0 failures; 93.41% line coverage
- `bundle exec rubocop` - 80 files, no offenses
- `bundle exec rspec --tag live` - 13 examples, 0 failures
- `bin/docs` and `bundle exec jekyll build`
- `bundle audit check --update` - no vulnerabilities