### PR TITLE
Align UDAP DCR request and response semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Safire does not dereference caller-supplied logo URLs during validation.
 - UDAP registration returns metadata only for completed `200`/`201` outcomes;
   `202 Accepted` is reported as pending rather than treated as completed.
-  Cancellation errors now distinguish an unconfirmed outcome from server
-  rejection. Safire never retries a registration lifecycle request
-  automatically when the authorization server may already have committed it.
+  Cancellation error messages now more clearly distinguish an unconfirmed
+  outcome from server rejection. Safire never retries registration lifecycle
+  requests automatically when the authorization server may already have
+  committed them.
 
 ## [0.4.0] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   metadata produces aggregated warnings while registration, modification, and
   lifecycle-safe cancellation continue; exact wildcard advertisement becomes a
   registration requirement in v0.5.0.
+- UDAP authorization-code registration now rejects only locally provable
+  `logo_uri` defects. Usable HTTPS URLs whose PNG, JPG/JPEG, or GIF format
+  cannot be inferred from the path are accepted with a value-free warning;
+  Safire does not dereference caller-supplied logo URLs during validation.
+- UDAP registration returns metadata only for completed `200`/`201` outcomes;
+  `202 Accepted` is reported as pending rather than treated as completed.
+  Cancellation errors now distinguish an unconfirmed outcome from server
+  rejection. Safire never retries a registration lifecycle request
+  automatically when the authorization server may already have committed it.
 
 ## [0.4.0] - 2026-08-07
 

--- a/docs/adr/ADR-013-udap-registration-request-model.md
+++ b/docs/adr/ADR-013-udap-registration-request-model.md
@@ -62,6 +62,18 @@ Unknown and duplicate grant values are rejected. `redirect_uris`, `logo_uri`,
 and generated `response_types: ["code"]` apply only to authorization-code
 registration. Redirect and logo URIs require absolute HTTPS by default.
 
+The STU2 logo requirement has two different validation boundaries. Safire can
+prove locally that `logo_uri` is an absolute HTTPS URI, so malformed, relative,
+and insecure public values fail before signing. Safire cannot prove that the
+remote representation is PNG, JPG/JPEG, or GIF from a URI path alone. Familiar
+image suffixes remain a quiet heuristic; other usable URI paths produce a
+value-free warning and remain the caller's responsibility.
+
+Safire does not dereference `logo_uri` during validation. Fetching an untrusted
+caller-supplied URI would introduce SSRF, latency, redirect, and remote
+availability concerns into construction of an otherwise local value object,
+without reliably proving what the authorization server will later retrieve.
+
 For local development without TLS, callers may explicitly pass
 `allow_insecure_localhost: true`. This permits HTTP only on `localhost` and
 `127.0.0.1`; remote HTTP remains invalid. Safire warns only when the exception
@@ -104,6 +116,8 @@ regular expression.
 - Protocol-owned claims cannot be shadowed through caller input.
 - Plain HTTP remains impossible for remote hosts; local HTTP requires a literal
   boolean opt-in and produces a warning.
+- Logo media type remains a caller obligation when it cannot be established
+  from the URI path; Safire reports that uncertainty without fetching the URI.
 - Extension metadata remains forward-compatible without permitting arbitrary
   Ruby objects into a JWT payload.
 - Metadata validation remains independent of software-statement signing and the

--- a/docs/troubleshooting/client-errors.md
+++ b/docs/troubleshooting/client-errors.md
@@ -139,13 +139,24 @@ rescue Safire::Errors::RegistrationError => e
 end
 ```
 
-Either response is a server-side protocol error and should not be treated as a
-successful registration.
+Either response is unusable as a confirmed registration. Safire does not retry
+automatically: the authorization server may already have committed a
+registration or modification before returning a response Safire cannot safely
+consume. Use the server's registration-management mechanism or operator portal
+before submitting another request.
+
+UDAP assigns completed registration meanings to `201 Created` and the
+update-style `200 OK` response. Safire returns registration metadata only for
+those outcomes. A `202 Accepted` response means processing is pending under
+HTTP semantics and does not establish completion, even when its body contains a
+valid-looking `client_id`. Safire raises `RegistrationError` with
+`e.status == 202`; callers remain responsible for any server-specific status or
+management workflow.
 
 ### `RegistrationError`: UDAP cancellation response does not confirm cancellation
 
 ```
-Safire::Errors::RegistrationError: Client registration failed — HTTP 202 — cancellation response must include an empty grant_types array
+Safire::Errors::RegistrationError: Client registration failed — HTTP 202 — cancellation response did not confirm cancellation: expected an empty grant_types array
 ```
 
 UDAP registration cancellation is confirmed by the response body, not by a
@@ -164,9 +175,13 @@ cancellation = udap_client.cancel_registration(
 cancellation['grant_types'] # => []
 ```
 
-If the response status is not `2xx`, or if the body omits `grant_types`, returns
-a non-array value, or returns a non-empty array, treat it as a failed
-cancellation and investigate the authorization server response.
+A non-`2xx` response does not confirm cancellation; inspect any preserved OAuth
+error code and description to determine whether the server explicitly rejected
+the request. If a final `2xx` response omits `grant_types`, returns a non-array
+value, or returns a non-empty array, the outcome is unconfirmed rather than
+rejected. Safire does not retry automatically; preserve the stored registration
+state and inspect the authorization server before retrying or discarding the
+`client_id`.
 
 ---
 

--- a/docs/udap/dynamic-client-registration/lifecycle.md
+++ b/docs/udap/dynamic-client-registration/lifecycle.md
@@ -37,9 +37,22 @@ registration = client.register_client(
 )
 ```
 
-Safire accepts new-registration `201 Created` responses and update-style `200`
-responses. Either response must be a JSON object with a non-blank string
-`client_id`.
+UDAP defines `201 Created` for completed new registration and an update-style
+`200 OK` response for modification. Safire returns registration metadata only
+for those completed outcomes, and either response must be a JSON object with a
+non-blank string `client_id`.
+
+Safire submits each registration or modification request once. It does not
+automatically retry after an unusable `200` or `201` response because the
+authorization server may already have committed the operation even though
+Safire cannot safely consume its response. Use the server's registration
+management mechanism or operator portal before submitting another request. A
+`202 Accepted` response represents pending processing under HTTP semantics,
+even when its body contains a valid-looking `client_id`. Safire reports that
+unconfirmed outcome through `RegistrationError` with `status == 202`; the
+application decides whether and how to use a server-specific status or
+management mechanism. Safire does not claim that STU2 requires clients to
+reject `202` responses.
 
 The authorization server identifies the registration from the software
 statement's client URI (`iss`) and certificate trust-community context, not from
@@ -94,8 +107,13 @@ Unlike registration, Safire does not require a specific success status such as
 `200` or `201` for cancellation, but the final HTTP response must still be a
 successful `2xx`. UDAP Security STU2 confirms cancellation through the response
 body: the response must contain a non-blank string `client_id` and an empty
-`grant_types` array. A final non-`2xx` status, or a non-empty, missing, or
-non-array `grant_types` value, raises `Safire::Errors::RegistrationError`.
+`grant_types` array. A final non-`2xx` status raises
+`Safire::Errors::RegistrationError` and preserves any OAuth error returned by
+the server. A final `2xx` response with a non-empty, missing, or non-array
+`grant_types` value also raises `RegistrationError`, but in that case the
+cancellation outcome is unconfirmed rather than rejected. Applications should
+preserve their local registration state and inspect the authorization server
+before retrying or discarding the stored `client_id`.
 
 ## Error Boundaries
 
@@ -107,7 +125,7 @@ Both lifecycle methods raise the same Safire error families:
 | `Safire::Errors::ValidationError` | Caller metadata or `certifications:` failed local validation before signing |
 | `Safire::Errors::ConfigurationError` | Signing configuration is missing or incompatible |
 | `Safire::Errors::CertificateError` | The private key, certificate chain, validity period, or `client_uri` SAN check failed |
-| `Safire::Errors::RegistrationError` | The registration endpoint returned an OAuth error response or a malformed success response |
+| `Safire::Errors::RegistrationError` | The registration endpoint returned an OAuth error, an unconfirmed pending outcome, or a malformed completed response |
 | `Safire::Errors::NetworkError` | The request failed at the transport layer |
 
 OAuth-style server errors preserve the server's `error` and

--- a/docs/udap/dynamic-client-registration/registration-metadata.md
+++ b/docs/udap/dynamic-client-registration/registration-metadata.md
@@ -53,7 +53,7 @@ and `to_h` returns a defensive copy.
 | `grant_types` | Required for registration; must match one supported grant profile |
 | `scope` | Required non-blank, space-delimited OAuth scope string |
 | `redirect_uris` | Required only with `authorization_code`; every value uses HTTPS by default |
-| `logo_uri` | Required only with `authorization_code`; uses HTTPS by default and references PNG, JPEG/JPG, or GIF content by path |
+| `logo_uri` | Required only with `authorization_code`; uses HTTPS by default and must reference PNG, JPEG/JPG, or GIF content |
 | `response_types` | Generated as `["code"]` for `authorization_code` |
 | `token_endpoint_auth_method` | Generated as `"private_key_jwt"` |
 
@@ -119,6 +119,16 @@ metadata = Safire::Protocols::UdapRegistrationMetadata.new(
 This option permits HTTP only on `localhost` and `127.0.0.1`, logs a warning
 when exercised, and produces non-conformant metadata that must not be used in
 production. Safire does not infer the application environment.
+
+Safire treats `.png`, `.jpg`, `.jpeg`, and `.gif` path suffixes as a quiet
+signal that a logo URI is shaped as expected. Extensionless, query-driven, and
+other usable URI paths are accepted with a warning because a path cannot prove
+the remote representation's media type. The warning does not include the URI.
+
+Safire does not fetch `logo_uri` during validation. Doing so would expose local
+metadata construction to SSRF, redirects, network latency, and remote
+availability. The caller remains responsible for ensuring that the URI
+actually resolves to PNG, JPG/JPEG, or GIF content as required by STU2.
 
 Callers cannot supply protocol-owned values:
 

--- a/docs/udap/dynamic-client-registration/registration-metadata.md
+++ b/docs/udap/dynamic-client-registration/registration-metadata.md
@@ -53,7 +53,7 @@ and `to_h` returns a defensive copy.
 | `grant_types` | Required for registration; must match one supported grant profile |
 | `scope` | Required non-blank, space-delimited OAuth scope string |
 | `redirect_uris` | Required only with `authorization_code`; every value uses HTTPS by default |
-| `logo_uri` | Required only with `authorization_code`; uses HTTPS by default and must reference PNG, JPEG/JPG, or GIF content |
+| `logo_uri` | Required only with `authorization_code`; uses HTTPS by default, and the caller must ensure it references PNG, JPEG/JPG, or GIF content (not locally verifiable by Safire) |
 | `response_types` | Generated as `["code"]` for `authorization_code` |
 | `token_endpoint_auth_method` | Generated as `"private_key_jwt"` |
 

--- a/lib/safire/protocols/udap.rb
+++ b/lib/safire/protocols/udap.rb
@@ -124,7 +124,8 @@ module Safire
       # @raise [Safire::Errors::ValidationError] when caller metadata or certifications are invalid
       # @raise [Safire::Errors::ConfigurationError] when signing configuration is missing or incompatible
       # @raise [Safire::Errors::CertificateError] when the client certificate chain cannot support signing
-      # @raise [Safire::Errors::RegistrationError] when the server rejects registration or returns malformed success
+      # @raise [Safire::Errors::RegistrationError] when the server rejects registration,
+      #   returns an unconfirmed pending outcome, or returns a malformed completed response
       # @raise [Safire::Errors::NetworkError] on connection failure, timeout, SSL error,
       #   or a redirect to a non-HTTPS URL
       def register_client(metadata, client_uri:, community: nil, certifications: nil, trusted_anchors: [],
@@ -434,9 +435,16 @@ module Safire
       def validate_registration_response_status!(response)
         return if SUCCESSFUL_REGISTRATION_STATUSES.include?(response.status)
 
+        description =
+          if response.status == 202
+            'registration response did not confirm completion: HTTP 202 indicates pending processing'
+          else
+            'registration response did not confirm completion: expected HTTP 200 or 201'
+          end
+
         raise Errors::RegistrationError.new(
           status: response.status,
-          error_description: 'unexpected registration response status'
+          error_description: description
         )
       end
 
@@ -447,7 +455,7 @@ module Safire
 
         raise Errors::RegistrationError.new(
           status: response.status,
-          error_description: 'cancellation response must include an empty grant_types array'
+          error_description: 'cancellation response did not confirm cancellation: expected an empty grant_types array'
         )
       end
 

--- a/lib/safire/protocols/udap_registration_metadata.rb
+++ b/lib/safire/protocols/udap_registration_metadata.rb
@@ -3,10 +3,11 @@ require_relative '../uri_validation'
 
 module Safire
   module Protocols
-    # Validates and normalizes caller-controlled UDAP Dynamic Client
-    # Registration metadata before a software statement is signed.
+    # Validates and normalizes locally provable properties of caller-controlled
+    # UDAP Dynamic Client Registration metadata before a software statement is
+    # signed.
     #
-    # The object enforces the registration metadata rules from
+    # The object enforces locally provable registration metadata rules from
     # [UDAP Security STU2](https://hl7.org/fhir/us/udap-security/STU2/registration.html).
     # It preserves JSON-compatible RFC 7591 extension metadata while preventing
     # callers from overriding JWT claims, request envelope fields, or fixed
@@ -79,8 +80,8 @@ module Safire
       # @param allow_insecure_localhost [Boolean] permit HTTP redirect and logo
       #   URIs only on +localhost+ or +127.0.0.1+ for local development; this
       #   produces non-conformant UDAP registration metadata
-      # @raise [Safire::Errors::ValidationError] when input violates the STU2
-      #   registration metadata contract
+      # @raise [Safire::Errors::ValidationError] when input violates a locally
+      #   provable STU2 registration metadata requirement
       def initialize(input, operation: :register, allow_insecure_localhost: false)
         @operation = validate_operation(operation)
         @allow_insecure_localhost = validate_localhost_policy(allow_insecure_localhost)
@@ -95,7 +96,7 @@ module Safire
         validate_extensions!(normalized)
         generate_protocol_fields!(normalized)
         @metadata = deep_freeze(normalized)
-        warn_if_insecure_localhost_used(@metadata)
+        emit_diagnostics(@metadata)
         freeze
       end
 
@@ -208,9 +209,6 @@ module Safire
 
         logo_uri = metadata['logo_uri']
         fail_validation!(:logo_uri, 'must be an absolute HTTPS URI') unless allowed_registration_uri?(logo_uri)
-        return if image_uri?(logo_uri)
-
-        fail_validation!(:logo_uri, 'must reference a PNG, JPEG, JPG, or GIF resource')
       end
 
       def validate_authorization_fields_absent!(metadata)
@@ -258,6 +256,21 @@ module Safire
           (@allow_insecure_localhost && localhost_http_uri?(value))
       end
 
+      def emit_diagnostics(metadata)
+        warn_if_logo_format_unverifiable(metadata)
+        warn_if_insecure_localhost_used(metadata)
+      end
+
+      def warn_if_logo_format_unverifiable(metadata)
+        logo_uri = metadata['logo_uri']
+        return unless logo_uri && !recognized_image_path?(logo_uri)
+
+        Safire.logger.warn(
+          '[UDAP] logo_uri image format cannot be verified locally from its URI path; ' \
+          'the caller must ensure it references PNG, JPEG/JPG, or GIF content'
+        )
+      end
+
       def warn_if_insecure_localhost_used(metadata)
         return unless @allow_insecure_localhost
 
@@ -301,7 +314,7 @@ module Safire
         false
       end
 
-      def image_uri?(value)
+      def recognized_image_path?(value)
         path = Addressable::URI.parse(value).path.to_s
         IMAGE_PATH_PATTERN.match?(path)
       rescue Addressable::URI::InvalidURIError

--- a/lib/safire/protocols/udap_registration_metadata.rb
+++ b/lib/safire/protocols/udap_registration_metadata.rb
@@ -263,7 +263,7 @@ module Safire
 
       def warn_if_logo_format_unverifiable(metadata)
         logo_uri = metadata['logo_uri']
-        return unless logo_uri && !recognized_image_path?(logo_uri)
+        return unless logo_uri.is_a?(String) && !recognized_image_path?(logo_uri)
 
         Safire.logger.warn(
           '[UDAP] logo_uri image format cannot be verified locally from its URI path; ' \

--- a/spec/examples/sinatra_app/safire_demo_spec.rb
+++ b/spec/examples/sinatra_app/safire_demo_spec.rb
@@ -894,6 +894,31 @@ RSpec.describe SafireDemo do
       expect(response.body).to include('different client id')
     end
 
+    it 'preserves stored state when the server does not confirm cancellation' do
+      allow(udap_client).to receive(:cancel_registration).and_raise(
+        Safire::Errors::RegistrationError.new(
+          status: 202,
+          error_description: 'cancellation response did not confirm cancellation: expected an empty grant_types array'
+        )
+      )
+
+      response = form_response(
+        :post,
+        '/demo/registered-udap/udap-registration/cancel',
+        params: registration_params,
+        env: { 'HTTP_HOST' => 'localhost:4567' }
+      )
+
+      expect(response.status).to eq(200)
+      expect(registered_udap_server.udap_client_id).to eq('stored-udap-client')
+      expect(registered_udap_server.udap_client_uri).to eq('http://localhost:4567')
+      expect(registered_udap_server.udap_community).to eq('https://community.example.org/udap')
+      expect(registered_udap_server.udap_scope).to eq('system/Patient.rs')
+      expect(registered_udap_server).not_to have_received(:save)
+      expect(response.body).to include('did not confirm cancellation')
+      expect(response.body).not_to include('Registration cancelled.')
+    end
+
     it 'rejects registration and cancellation posts without a CSRF token' do
       registration = response_for(:post, '/demo/udap-only/udap-registration')
       cancellation = response_for(:post, '/demo/registered-udap/udap-registration/cancel')

--- a/spec/integration/udap_dcr_flow_spec.rb
+++ b/spec/integration/udap_dcr_flow_spec.rb
@@ -129,6 +129,24 @@ RSpec.describe 'UDAP Dynamic Client Registration Flow', type: :integration do
     expect(client.register_client(registration_metadata, client_uri:)['client_id']).to eq('udap-client-123')
   end
 
+  it 'reports a 202 registration as pending after exactly one POST even when its body looks usable' do
+    stub_udap_discovery
+    stub_registration_response(status: 202)
+
+    expect { client.register_client(registration_metadata, client_uri:) }
+      .to raise_error(Safire::Errors::RegistrationError, /did not confirm completion.*pending processing/)
+    expect(registration_requests.length).to eq(1)
+  end
+
+  it 'does not retry when a successful response cannot identify the committed registration' do
+    stub_udap_discovery
+    stub_registration_response(status: 201, body: { 'client_name' => 'Example Backend Service' })
+
+    expect { client.register_client(registration_metadata, client_uri:) }
+      .to raise_error(Safire::Errors::RegistrationError, /missing client_id/)
+    expect(registration_requests.length).to eq(1)
+  end
+
   it 'signs with an advertised RSA alternative when non-conformant metadata omits RS256' do
     stub_udap_discovery(
       body: udap_metadata.merge('registration_endpoint_jwt_signing_alg_values_supported' => ['RS384'])
@@ -218,7 +236,7 @@ RSpec.describe 'UDAP Dynamic Client Registration Flow', type: :integration do
     stub_registration_response(body: { 'client_id' => 'udap-client-123', 'grant_types' => ['client_credentials'] })
 
     expect { client.cancel_registration(cancellation_metadata, client_uri:) }
-      .to raise_error(Safire::Errors::RegistrationError, /empty grant_types/)
+      .to raise_error(Safire::Errors::RegistrationError, /did not confirm cancellation.*empty grant_types/)
   end
 
   it 'raises DiscoveryError before POST when the server does not advertise UDAP DCR' do

--- a/spec/safire/protocols/udap_registration_metadata_spec.rb
+++ b/spec/safire/protocols/udap_registration_metadata_spec.rb
@@ -261,6 +261,8 @@ RSpec.describe Safire::Protocols::UdapRegistrationMetadata do
   end
 
   describe 'authorization-code metadata' do
+    before { allow(Safire.logger).to receive(:warn) }
+
     it 'requires redirect_uris' do
       input.delete(:redirect_uris)
 
@@ -303,16 +305,41 @@ RSpec.describe Safire::Protocols::UdapRegistrationMetadata do
       expect_validation_error(:logo_uri, 'absolute HTTPS URI') { metadata }
     end
 
-    it 'requires a supported image extension' do
-      input[:logo_uri] = 'https://app.example.com/logo.svg'
+    it 'rejects a relative logo URI' do
+      input[:logo_uri] = '/logo.png'
 
-      expect_validation_error(:logo_uri, 'PNG, JPEG, JPG, or GIF') { metadata }
+      expect_validation_error(:logo_uri, 'absolute HTTPS URI') { metadata }
     end
 
-    it 'accepts a case-insensitive image extension before a query string' do
-      input[:logo_uri] = 'https://app.example.com/logo.JPEG?version=2'
+    it 'rejects a malformed logo URI' do
+      input[:logo_uri] = 'https://exa mple.com/logo.png'
 
-      expect(metadata.to_h['logo_uri']).to eq(input[:logo_uri])
+      expect_validation_error(:logo_uri, 'absolute HTTPS URI') { metadata }
+    end
+
+    %w[png jpg jpeg gif].each do |extension|
+      it "accepts a #{extension.upcase} path suffix without a format warning" do
+        input[:logo_uri] = "https://app.example.com/logo.#{extension.upcase}?version=2"
+
+        expect(metadata.to_h['logo_uri']).to eq(input[:logo_uri])
+        expect(Safire.logger).not_to have_received(:warn)
+      end
+    end
+
+    [
+      'https://app.example.com/logo',
+      'https://app.example.com/logo?format=png',
+      'https://app.example.com/logo.svg'
+    ].each do |logo_uri|
+      it "accepts #{logo_uri} with a value-free format warning" do
+        warnings = []
+        allow(Safire.logger).to receive(:warn) { |message| warnings << message }
+        input[:logo_uri] = logo_uri
+
+        expect(metadata.to_h['logo_uri']).to eq(logo_uri)
+        expect(warnings).to contain_exactly(match(/logo_uri.*format.*cannot be verified locally/i))
+        expect(warnings.join).not_to include(logo_uri)
+      end
     end
   end
 

--- a/spec/safire/protocols/udap_registration_metadata_spec.rb
+++ b/spec/safire/protocols/udap_registration_metadata_spec.rb
@@ -467,6 +467,15 @@ RSpec.describe Safire::Protocols::UdapRegistrationMetadata do
       expect(metadata.to_h).not_to include('redirect_uris', 'logo_uri', 'response_types')
     end
 
+    it 'discards a non-string logo_uri before emitting diagnostics' do
+      allow(Safire.logger).to receive(:warn)
+      input[:logo_uri] = [nil]
+
+      expect { metadata }.not_to raise_error
+      expect(metadata.to_h).not_to include('logo_uri')
+      expect(Safire.logger).not_to have_received(:warn)
+    end
+
     it 'rejects caller-supplied grant_types' do
       input[:grant_types] = []
 

--- a/spec/safire/protocols/udap_spec.rb
+++ b/spec/safire/protocols/udap_spec.rb
@@ -993,7 +993,7 @@ RSpec.describe Safire::Protocols::Udap do
       end
     end
 
-    context 'when the server returns an unsupported 2xx response' do
+    context 'when the server returns a pending 202 response' do
       before do
         stub_request(:post, registration_endpoint)
           .to_return(
@@ -1003,9 +1003,14 @@ RSpec.describe Safire::Protocols::Udap do
           )
       end
 
-      it 'raises RegistrationError before parsing the body as a successful registration' do
-        expect { udap.register_client(client_metadata, client_uri:) }
-          .to raise_error(Safire::Errors::RegistrationError, /unexpected registration response status/)
+      it 'reports an unconfirmed pending outcome without treating the body as completed registration' do
+        error = capture_error(Safire::Errors::RegistrationError) do
+          udap.register_client(client_metadata, client_uri:)
+        end
+
+        expect(error.status).to eq(202)
+        expect(error.error_description).to match(/did not confirm completion.*pending processing/)
+        expect(WebMock).to have_requested(:post, registration_endpoint).once
       end
     end
 
@@ -1049,16 +1054,19 @@ RSpec.describe Safire::Protocols::Udap do
       end
     end
 
-    context 'when the success response is malformed' do
-      before do
-        stub_request(:post, registration_endpoint)
-          .to_return(status: 201, body: { 'client_name' => 'Example' }.to_json,
-                     headers: { 'Content-Type' => 'application/json' })
-      end
+    [200, 201].each do |status|
+      context "when a #{status} success response is malformed" do
+        before do
+          stub_request(:post, registration_endpoint)
+            .to_return(status:, body: { 'client_name' => 'Example' }.to_json,
+                       headers: { 'Content-Type' => 'application/json' })
+        end
 
-      it 'raises RegistrationError before returning the response' do
-        expect { udap.register_client(client_metadata, client_uri:) }
-          .to raise_error(Safire::Errors::RegistrationError, /missing client_id/)
+        it 'raises RegistrationError after exactly one request' do
+          expect { udap.register_client(client_metadata, client_uri:) }
+            .to raise_error(Safire::Errors::RegistrationError, /missing client_id/)
+          expect(WebMock).to have_requested(:post, registration_endpoint).once
+        end
       end
     end
 
@@ -1239,9 +1247,12 @@ RSpec.describe Safire::Protocols::Udap do
             )
         end
 
-        it 'raises RegistrationError' do
+        it 'reports that the cancellation outcome is unconfirmed' do
           expect { udap.cancel_registration(client_metadata, client_uri:) }
-            .to raise_error(Safire::Errors::RegistrationError, /empty grant_types/)
+            .to raise_error(
+              Safire::Errors::RegistrationError,
+              /cancellation response did not confirm cancellation.*empty grant_types/
+            )
         end
       end
     end

--- a/spec/safire/protocols/udap_spec.rb
+++ b/spec/safire/protocols/udap_spec.rb
@@ -1014,6 +1014,23 @@ RSpec.describe Safire::Protocols::Udap do
       end
     end
 
+    context 'when the server returns another unconfirmed 2xx response' do
+      before do
+        stub_request(:post, registration_endpoint)
+          .to_return(status: 204)
+      end
+
+      it 'reports the completed response statuses expected by the high-level API' do
+        error = capture_error(Safire::Errors::RegistrationError) do
+          udap.register_client(client_metadata, client_uri:)
+        end
+
+        expect(error.status).to eq(204)
+        expect(error.error_description).to match(/did not confirm completion.*HTTP 200 or 201/)
+        expect(WebMock).to have_requested(:post, registration_endpoint).once
+      end
+    end
+
     context 'when the server returns a UDAP registration error' do
       before do
         stub_request(:post, registration_endpoint).to_return(


### PR DESCRIPTION
## Summary

This aligns UDAP Dynamic Client Registration with Safire's client-side responsibilities. It keeps locally provable logo URI requirements strict while accepting usable HTTPS paths whose remote image format cannot be established locally, issuing a value-free warning instead of dereferencing untrusted URLs. It also makes registration lifecycle outcomes explicit: only completed 200/201 responses return registration metadata, 202 responses are exposed as pending through RegistrationError, unusable completed responses are never retried automatically, and cancellation distinguishes server rejection from an unconfirmed outcome. The ADR, lifecycle and metadata guides, troubleshooting documentation, and changelog now describe those boundaries consistently.