### PR TITLE
Deprecate implicit SMART Backend Services scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Deprecated
-
-- SMART Backend Services requests without usable configured or per-call scopes
-  still use `system/*.rs` for v0.4.x compatibility, but now emit a deprecation warning.
-  Configure or pass scopes explicitly before v0.6.0, when missing scopes will
-  raise `ConfigurationError`.
-
 ### Changed
 
 - SMART and UDAP discovery now accept valid raw JSON-object response bodies even
@@ -45,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   outcome from server rejection. Safire never retries registration lifecycle
   requests automatically when the authorization server may already have
   committed them.
+
+### Deprecated
+
+- SMART Backend Services requests without usable configured or per-call scopes
+  still use `system/*.rs` for v0.4.x compatibility, but now emit a deprecation warning.
+  Configure or pass scopes explicitly before v0.6.0, when missing scopes will
+  raise `ConfigurationError`.
 
 ## [0.4.0] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+- SMART Backend Services requests without usable configured or per-call scopes
+  still use `system/*.rs` for v0.4.x compatibility, but now emit a deprecation warning.
+  Configure or pass scopes explicitly before v0.6.0, when missing scopes will
+  raise `ConfigurationError`.
+
 ### Changed
 
 - SMART and UDAP discovery now accept valid raw JSON-object response bodies even

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Safire is a Ruby gem for healthcare client applications that implements [SMART A
 - Confidential Symmetric Client (`client_secret` + HTTP Basic Auth)
 - Confidential Asymmetric Client (`private_key_jwt` with RS384/ES384)
 - POST-Based Authorization
-- Backend Services (`client_credentials` grant, JWT assertion, no user interaction or PKCE; scope defaults to `system/*.rs`)
+- Backend Services (`client_credentials` grant, JWT assertion, no user interaction or PKCE; client-selected scopes)
 
 ### UDAP Security (STU2)
 
@@ -184,6 +184,12 @@ token_data = client.request_backend_token(
 # Validate the token response (flow: :backend_services also checks expires_in)
 client.token_response_valid?(token_data, flow: :backend_services)
 ```
+
+Configure scopes on the client or pass `scopes:` to each Backend Services
+request. The legacy `system/*.rs` fallback is deprecated in v0.4.x and will be
+removed in v0.6.0. Backend Services normally uses `system/` scopes. Safire
+preserves explicit non-system scopes because SMART permits them when context is
+established out of band.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -22,7 +22,7 @@ Feedback, bug reports, and pull requests are welcome via the [issue tracker](htt
 - **POST-Based Authorization** — form-encoded authorization requests
 - **JWT Assertion Builder** — signed JWT assertions with configurable `kid` and expiry
 - **PKCE** — automatic code verifier and challenge generation
-- **Backend Services** — `client_credentials` grant for system-to-system flows; JWT assertion (RS384/ES384); no user interaction, redirect, or PKCE required; scope defaults to `system/*.rs` when not configured
+- **Backend Services** — `client_credentials` grant for system-to-system flows; JWT assertion (RS384/ES384); no user interaction, redirect, or PKCE required; client-selected scopes with a deprecated v0.4.x compatibility fallback
 - **Dynamic Client Registration** — runtime client registration per [RFC 7591](https://www.rfc-editor.org/rfc/rfc7591); endpoint discovered from SMART metadata or supplied explicitly; supports initial access token
 
 ### UDAP Security (STU2 / v2.0.0)
@@ -63,6 +63,9 @@ Feedback, bug reports, and pull requests are welcome via the [issue tracker](htt
 
 ### v0.6.0 — UDAP Authorization Code Flows
 
+- **Explicit SMART Backend Scopes** — remove the deprecated `system/*.rs`
+  fallback; Backend Services requests without configured or per-call scopes
+  raise `ConfigurationError`
 - **Consumer-Facing Authorization** — UDAP authorization code flow with state,
   PKCE, Authentication Tokens, code exchange, and refresh support
 - **Interactive B2B Authorization** — authorization code flow for B2B clients,

--- a/docs/adr/ADR-015-client-role-and-runtime-readiness.md
+++ b/docs/adr/ADR-015-client-role-and-runtime-readiness.md
@@ -88,6 +88,20 @@ may collectively cover a requested permission set. STU2 does not guarantee that
 the server accepts the combined token, so this permissive inference must not be
 reused as a hard-failure decision without a separate normative rule.
 
+SMART Backend Services scope intent remains client-owned. In v0.4.x, Safire
+preserves the historical `system/*.rs` fallback only for compatibility and
+logs a deprecation warning whenever it is used. Callers should configure or
+pass scopes explicitly; absent scopes become a runtime `ConfigurationError` in
+v0.6.0. SMART discovery `scopes_supported` is non-exhaustive and is not used as
+an exact allow-list for token requests.
+
+`system/` scopes are the normal Backend Services context. The SMART IG also
+states that `user/` and `patient/` scopes are not prohibited when context is
+established through out-of-band coordination. Safire therefore preserves and
+submits explicit non-system scopes without warning or rejection. The library
+cannot determine whether the caller completed that external coordination, and
+must not make a permitted healthy path noisy based on missing local evidence.
+
 Scope diagnostics log only the requested scope category and count, never the
 raw token values. SMART v2 scopes may carry FHIR search constraints, and opaque
 custom scopes may encode equally sensitive application context in forms Safire
@@ -106,7 +120,7 @@ This matrix covers the public protocol operations currently implemented by the
 | SMART `authorization_url` | Invalid method; missing client ID, scopes, redirect URI, or usable authorization endpoint | Metadata diagnostics remain explicit | User authorization, launch context, and granted scopes |
 | SMART `request_access_token` | Missing client credentials; unusable token endpoint; OAuth error; malformed token response or missing access token | `token_response_valid?` is caller-invoked | Code acceptance and issued token contents |
 | SMART `refresh_token` | Missing client credentials; unusable token endpoint; OAuth error; malformed token response or missing access token | `token_response_valid?` is caller-invoked | Refresh-token acceptance and issued scope |
-| SMART `request_backend_token` | Missing client ID or signing credentials; unusable token endpoint; OAuth error; malformed token response or missing access token | `token_response_valid?(flow: :backend_services)` is caller-invoked | Client authentication, requested scope, and token issuance |
+| SMART `request_backend_token` | Missing client ID or signing credentials; unusable token endpoint; OAuth error; malformed token response or missing access token | The v0.4.x missing-scope fallback warns; `token_response_valid?(flow: :backend_services)` is caller-invoked | Out-of-band context, client authentication, requested scope, and token issuance |
 | SMART `register_client` | Missing or unsafe registration endpoint; OAuth error; malformed response or missing/invalid client ID | SMART metadata diagnostics remain explicit | Registration policy and issued credentials |
 | SMART `token_response_valid?` | None; this is not an operational gate | Warns and returns `false` for response conformance defects | Caller decides whether a failed diagnostic is acceptable |
 | UDAP `server_metadata` | Transport/HTTP/204 failure; non-object JSON; failed signed-metadata signature, chain, revocation, issuer, time, or endpoint validation | `UdapMetadata#valid?` is caller-invoked | Supported communities, profiles, and capabilities |

--- a/docs/adr/ADR-015-client-role-and-runtime-readiness.md
+++ b/docs/adr/ADR-015-client-role-and-runtime-readiness.md
@@ -95,12 +95,14 @@ pass scopes explicitly; absent scopes become a runtime `ConfigurationError` in
 v0.6.0. SMART discovery `scopes_supported` is non-exhaustive and is not used as
 an exact allow-list for token requests.
 
-`system/` scopes are the normal Backend Services context. The SMART IG also
-states that `user/` and `patient/` scopes are not prohibited when context is
-established through out-of-band coordination. Safire therefore preserves and
-submits explicit non-system scopes without warning or rejection. The library
-cannot determine whether the caller completed that external coordination, and
-must not make a permitted healthy path noisy based on missing local evidence.
+`system/` scopes are the normal Backend Services context. The
+[SMART STU2.2 Backend Services scope requirements](https://hl7.org/fhir/smart-app-launch/STU2.2/backend-services.html#scopes)
+also state that `user/` and `patient/` scopes are not prohibited when context
+is established through out-of-band coordination. Safire therefore preserves
+and submits explicit non-system scopes without warning or rejection. The
+library cannot determine whether the caller completed that external
+coordination, and must not make a permitted healthy path noisy based on missing
+local evidence.
 
 Scope diagnostics log only the requested scope category and count, never the
 raw token values. SMART v2 scopes may carry FHIR search constraints, and opaque

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -51,7 +51,7 @@ flowchart TD
 | `kid` | String | No | — | Key ID matching the public key registered with the server |
 | `jwt_algorithm` | String | No | auto | SMART: `RS384` or `ES384`; UDAP registration: `RS256`, `RS384`, `ES256`, or `ES384`, constrained by the key and server metadata |
 | `jwks_uri` | String | No | — | SMART-only URL to the client's public JWKS, included as `jku` in SMART JWT assertions |
-| `scopes` | Array | No | — | Default scopes for authorization requests |
+| `scopes` | Array | No | — | Default scopes for authorization requests; SMART Backend Services normally uses `system/` scopes and requires explicit values unless passed per request (the v0.4.x fallback is deprecated) |
 | `authorization_endpoint` | String | No | — | Override the discovered authorization endpoint |
 | `token_endpoint` | String | No | — | Override the discovered token endpoint |
 

--- a/docs/smart-on-fhir/backend-services/index.md
+++ b/docs/smart-on-fhir/backend-services/index.md
@@ -19,7 +19,7 @@ System-to-system access token requests using the OAuth 2.0 `client_credentials` 
 
 ## Overview
 
-SMART Backend Services enables autonomous server-to-server FHIR access without involving a user. It is defined in the [SMART App Launch Backend Services](https://hl7.org/fhir/smart-app-launch/backend-services.html) specification.
+SMART Backend Services enables autonomous server-to-server FHIR access without involving a user. It is defined in the [SMART App Launch Backend Services](https://hl7.org/fhir/smart-app-launch/STU2.2/backend-services.html) specification.
 
 Instead of a redirect flow, the client:
 
@@ -46,7 +46,7 @@ Suitable for:
 | **Redirect URI** | Required | Not used |
 | **PKCE** | Required | Not used |
 | **Client auth** | Varies by `client_type:` | JWT assertion always |
-| **Scopes** | `patient/`, `user/`, `openid` | `system/` |
+| **Scopes** | `patient/`, `user/`, `openid` | Normally `system/` |
 | **Refresh token** | Usually issued | Not issued |
 | **`expires_in`** | Recommended | Required |
 
@@ -66,7 +66,9 @@ Backend services use the same RSA or EC key pair infrastructure as the confident
 
 ## Client Setup
 
-`redirect_uri` and `scopes` are optional for backend services clients. If `scopes` is omitted, Safire defaults to `["system/*.rs"]` when `request_backend_token` is called.
+`redirect_uri` is not used for Backend Services. The token request requires
+client-selected scopes, supplied either in `ClientConfig` or through the
+per-call `scopes:` keyword.
 
 ```ruby
 config = Safire::ClientConfig.new(
@@ -74,7 +76,7 @@ config = Safire::ClientConfig.new(
   client_id:   ENV['SMART_CLIENT_ID'],
   private_key: OpenSSL::PKey::RSA.new(ENV['SMART_PRIVATE_KEY_PEM']),
   kid:         ENV['SMART_KEY_ID'],
-  scopes:      ['system/Patient.rs', 'system/Observation.rs']  # optional
+  scopes:      ['system/Patient.rs', 'system/Observation.rs']
 )
 
 client = Safire::Client.new(config)
@@ -82,6 +84,18 @@ client = Safire::Client.new(config)
 
 {: .note }
 > `client_type:` is not used for backend services — `request_backend_token` always authenticates via JWT assertion regardless of `client_type`.
+
+{: .warning }
+> Safire v0.4.x retains a deprecated `system/*.rs` fallback when scopes are
+> absent. It logs a warning and will be removed in v0.6.0, when the same call
+> will raise `ConfigurationError`.
+
+{: .note }
+> Backend Services normally requests `system/` scopes. SMART does not prohibit
+> `user/` or `patient/` scopes when the client and authorization server establish
+> context out of band. Safire submits such explicit scopes unchanged because it
+> cannot verify that external context and the authorization server remains
+> responsible for accepting the request.
 
 ---
 

--- a/docs/smart-on-fhir/backend-services/index.md
+++ b/docs/smart-on-fhir/backend-services/index.md
@@ -91,11 +91,12 @@ client = Safire::Client.new(config)
 > will raise `ConfigurationError`.
 
 {: .note }
-> Backend Services normally requests `system/` scopes. SMART does not prohibit
-> `user/` or `patient/` scopes when the client and authorization server establish
-> context out of band. Safire submits such explicit scopes unchanged because it
-> cannot verify that external context and the authorization server remains
-> responsible for accepting the request.
+> Backend Services normally requests `system/` scopes. The
+> [SMART STU2.2 scope requirements](https://hl7.org/fhir/smart-app-launch/STU2.2/backend-services.html#scopes)
+> do not prohibit `user/` or `patient/` scopes when the client and authorization
+> server establish context out of band. Safire submits such explicit scopes
+> unchanged because it cannot verify that external context and the authorization
+> server remains responsible for accepting the request.
 
 ---
 

--- a/docs/smart-on-fhir/backend-services/token-request.md
+++ b/docs/smart-on-fhir/backend-services/token-request.md
@@ -42,10 +42,11 @@ token_data = client.request_backend_token(scopes: ['system/Patient.rs'])
 > configure scopes or pass `scopes:`; requests without either will raise
 > `ConfigurationError` in v0.6.0.
 
-Use `system/` scopes for the standard Backend Services flow. The SMART IG does
-not prohibit coordinated `user/` or `patient/` scopes, so Safire does not block
-or warn on them. It preserves explicit non-system scopes; the authorization
-server remains responsible for accepting the request.
+Use `system/` scopes for the standard Backend Services flow. The
+[SMART STU2.2 scope requirements](https://hl7.org/fhir/smart-app-launch/STU2.2/backend-services.html#scopes)
+do not prohibit coordinated `user/` or `patient/` scopes, so Safire does not
+block or warn on them. It preserves explicit non-system scopes; the
+authorization server remains responsible for accepting the request.
 
 Safire posts to the token endpoint:
 

--- a/docs/smart-on-fhir/backend-services/token-request.md
+++ b/docs/smart-on-fhir/backend-services/token-request.md
@@ -30,6 +30,23 @@ token_data = client.request_backend_token
 #    }
 ```
 
+The example uses the scopes configured on the client. You can instead pass
+them explicitly:
+
+```ruby
+token_data = client.request_backend_token(scopes: ['system/Patient.rs'])
+```
+
+{: .warning }
+> The v0.4.x compatibility fallback to `system/*.rs` is deprecated. Always
+> configure scopes or pass `scopes:`; requests without either will raise
+> `ConfigurationError` in v0.6.0.
+
+Use `system/` scopes for the standard Backend Services flow. The SMART IG does
+not prohibit coordinated `user/` or `patient/` scopes, so Safire does not block
+or warn on them. It preserves explicit non-system scopes; the authorization
+server remains responsible for accepting the request.
+
 Safire posts to the token endpoint:
 
 ```http
@@ -117,7 +134,7 @@ end
 begin
   token_data = client.request_backend_token
 rescue Safire::Errors::ConfigurationError => e
-  # client_id, private_key, or kid missing — only private_key and kid can be overridden at call time
+  # client_id, private_key, or kid missing. In v0.6.0 this also covers missing scopes.
   Rails.logger.error("Backend services misconfigured: #{e.message}")
   raise
 rescue Safire::Errors::TokenError => e
@@ -193,7 +210,7 @@ Safire includes a live integration spec that exercises the full Backend Services
 | `SAFIRE_LIVE_BACKEND_CLIENT_ID` | Registered backend client ID |
 | `SAFIRE_LIVE_BACKEND_KID` | Key ID matching the registered JWKS |
 | `SAFIRE_LIVE_BACKEND_PRIVATE_KEY_PEM` | PEM-encoded private key |
-| `SAFIRE_LIVE_BACKEND_SCOPES` | Space-separated scopes (optional; default: `system/*.rs`) |
+| `SAFIRE_LIVE_BACKEND_SCOPES` | Space-separated scopes registered for the client |
 | `SAFIRE_LIVE_BACKEND_ALGORITHM` | JWT algorithm (optional; default: `RS384`) |
 
 ```bash

--- a/docs/smart-on-fhir/discovery/capability-checks.md
+++ b/docs/smart-on-fhir/discovery/capability-checks.md
@@ -141,6 +141,7 @@ metadata = client.server_metadata
 
 if metadata.supports_backend_services?
   token_data = client.request_backend_token(
+    scopes:      ['system/Patient.rs'],
     private_key: private_key,
     kid:         kid
   )

--- a/docs/troubleshooting/auth-errors.md
+++ b/docs/troubleshooting/auth-errors.md
@@ -124,7 +124,10 @@ auth_data = client.authorization_url(
 ```
 
 {: .note }
-> **Backend Services:** `request_backend_token` does not raise this error — it defaults to `["system/*.rs"]` when no scopes are configured. Pass `scopes:` to override: `client.request_backend_token(scopes: ['system/Patient.rs'])`.
+> **Backend Services:** In v0.4.x, `request_backend_token` logs a deprecation
+> warning and uses `system/*.rs` when scopes are absent. Configure scopes or
+> pass `scopes:` explicitly now. Starting in v0.6.0, the same missing-scope
+> condition will raise `ConfigurationError`.
 
 ### State mismatch on callback
 

--- a/docs/troubleshooting/client-errors.md
+++ b/docs/troubleshooting/client-errors.md
@@ -267,6 +267,29 @@ Verify the public key registered with the server matches the private key you are
 
 ## Backend Services Errors
 
+### Deprecated implicit scope fallback
+
+SMART requires the Backend Services token request to carry the scopes selected
+by the client. Configure them on `ClientConfig` or pass them per request:
+
+```ruby
+client.request_backend_token(scopes: ['system/Patient.rs'])
+```
+
+Safire v0.4.x temporarily falls back to `system/*.rs` and logs a deprecation
+warning when both sources are absent. This compatibility behavior is removed in
+v0.6.0, when the call will raise `ConfigurationError` instead.
+
+Safire does not treat discovery `scopes_supported` as an exhaustive allow-list.
+The server may support scopes it does not advertise, so explicit client scope
+requests are submitted for server-side authorization.
+
+The usual Backend Services request contains `system/` scopes. If explicit
+non-system scopes are submitted, Safire proceeds without warning because SMART
+permits `user/` and `patient/` scopes when context is coordinated out of band.
+Confirm that coordination and the server's registration policy when diagnosing
+an authorization-server rejection.
+
 ### `ConfigurationError`: Missing `private_key` or `kid`
 
 ```

--- a/examples/sinatra_app/README.md
+++ b/examples/sinatra_app/README.md
@@ -282,11 +282,16 @@ If a SMART server advertises `client_credentials` grant support, the "Backend Se
 
 1. Navigate to a server detail page
 2. Click "Request Backend Token"
-3. Optionally enter custom scopes (defaults to `system/*.rs`)
+3. Review or edit the configured `system/` scopes prefilled from the server configuration
 4. Click "Request Token"
 5. View the access token, expiry, granted scopes, and SMART compliance check result
 
 Requires `ASYMMETRIC_PRIVATE_KEY_PEM` and `ASYMMETRIC_KID` to be configured (same key pair used for confidential asymmetric App Launch).
+The demo rejects an empty scope submission and preserves the requested scopes
+when requesting another token, so it never relies on Safire's deprecated
+implicit Backend Services fallback. It also rejects non-system scopes because
+the demo does not establish the out-of-band user or patient context that SMART
+permits advanced Backend Services integrations to coordinate.
 
 ### UDAP Discovery
 

--- a/examples/sinatra_app/app.rb
+++ b/examples/sinatra_app/app.rb
@@ -377,6 +377,7 @@ class SafireDemo < Sinatra::Base
       return
     end
 
+    @backend_scopes = backend_service_scopes(@server.scopes).join(' ')
     erb :'demo/backend_token'
   end
 
@@ -389,7 +390,14 @@ class SafireDemo < Sinatra::Base
     end
 
     begin
-      scopes = params[:scopes].to_s.strip.empty? ? ['system/*.rs'] : parse_scopes(params[:scopes])
+      @backend_scopes = params[:scopes].to_s.strip
+      scopes = parse_scopes(@backend_scopes)
+      @backend_scope_error = backend_scope_error(scopes)
+      if @backend_scope_error
+        status 422
+        return erb :'demo/backend_token'
+      end
+
       backend_client = build_backend_services_client(@server)
       @token_response = backend_client.request_backend_token(scopes: scopes)
       @valid = backend_client.token_response_valid?(@token_response, flow: :backend_services)
@@ -597,6 +605,21 @@ class SafireDemo < Sinatra::Base
 
   def parse_scopes(scopes_str)
     scopes_str.to_s.split(/[,\s]+/).map(&:strip).reject(&:empty?)
+  end
+
+  def backend_service_scopes(scopes)
+    Array(scopes).select { |scope| backend_service_scope?(scope) }
+  end
+
+  def backend_service_scope?(scope)
+    scope.to_s.start_with?('system/')
+  end
+
+  def backend_scope_error(scopes)
+    return 'Enter at least one scope before requesting a token.' if scopes.empty?
+    return if scopes.all? { |scope| backend_service_scope?(scope) }
+
+    'Enter only system/ scopes. This demo does not establish user or patient context out of band.'
   end
 
   def perform_registration

--- a/examples/sinatra_app/views/demo/backend_token.erb
+++ b/examples/sinatra_app/views/demo/backend_token.erb
@@ -58,6 +58,7 @@
     <div class="form-actions">
       <form action="/demo/<%= @server.id %>/backend-token" method="post" style="display:inline;">
         <%= csrf_field %>
+        <input type="hidden" name="scopes" value="<%= h(@backend_scopes) %>">
         <button type="submit" class="btn btn-primary">Request New Token</button>
       </form>
       <a href="/servers/<%= @server.id %>" class="btn btn-secondary">Back to Server</a>
@@ -72,11 +73,21 @@
     <form action="/demo/<%= @server.id %>/backend-token" method="post" class="demo-form">
       <%= csrf_field %>
       <div class="form-group">
-        <label for="scopes">Scopes <span class="optional">(optional)</span></label>
+        <label for="scopes">Scopes</label>
         <input type="text" id="scopes" name="scopes"
+               value="<%= h(@backend_scopes) %>"
                placeholder="system/Patient.rs system/Observation.rs"
+               required
+               <%= 'aria-invalid="true"' if @backend_scope_error %>
                class="form-input">
-        <p class="form-hint">Space or comma-separated. Defaults to <code>system/*.rs</code> when omitted.</p>
+        <% if @backend_scope_error %>
+          <p class="form-hint" role="alert"><%= h(@backend_scope_error) %></p>
+        <% else %>
+          <p class="form-hint">
+            Space or comma-separated system scopes registered for this client. This demo does not establish
+            out-of-band user or patient context.
+          </p>
+        <% end %>
       </div>
 
       <div class="form-actions">

--- a/lib/safire/client.rb
+++ b/lib/safire/client.rb
@@ -14,8 +14,9 @@ module Safire
   #     required by all authorization flows and validated at call time
   # * :redirect_uri [String] redirect URI registered with the authorization server;
   #     required for app launch, not required for backend services
-  # * :scopes [Array<String>] default scopes; falls back to +["system/*.rs"]+ for
-  #     backend services when not provided
+  # * :scopes [Array<String>] default scopes. SMART Backend Services callers should
+  #     configure or pass scopes explicitly; the v0.4.x +["system/*.rs"]+ fallback is
+  #     deprecated and will be removed in v0.6.0
   # * :client_secret [String, optional] required for confidential_symmetric clients
   # * :private_key [OpenSSL::PKey, String, optional] private key for SMART asymmetric clients,
   #     backend services, and UDAP software-statement signing

--- a/lib/safire/protocols/smart.rb
+++ b/lib/safire/protocols/smart.rb
@@ -187,13 +187,14 @@ module Safire
       # No user interaction, redirect, or PKCE is involved. The client authenticates
       # exclusively via a signed JWT assertion (RS384 or ES384).
       #
-      # @param scopes [Array<String>, nil] scope override; uses configured scopes if nil. For v0.4.x compatibility,
-      #   a blank resolved value emits a deprecation warning and falls back to +["system/*.rs"]+. This fallback
-      #   will be removed in v0.6.0, when missing scopes will raise {Safire::Errors::ConfigurationError}. Explicit
-      #   non-+system/+ scopes are submitted unchanged because SMART permits them when the caller establishes the
-      #   required context out of band.
-      # @param private_key [OpenSSL::PKey] private key for JWT assertion; uses configured key if not provided.
-      #   Required — must be present either in configuration or passed here.
+      # @param scopes [Array<String>, nil] scope override; blank overrides fall back to configured scopes. For
+      #   v0.4.x compatibility, a request without usable per-call or configured scopes emits a deprecation warning
+      #   and falls back to +["system/*.rs"]+. This fallback will be removed in v0.6.0, when missing scopes will
+      #   raise {Safire::Errors::ConfigurationError}. Explicit non-+system/+ scopes are submitted unchanged because
+      #   SMART permits them when the caller establishes the required context out of band.
+      # @param private_key [OpenSSL::PKey::RSA, OpenSSL::PKey::EC, String] private key or PEM string for the JWT
+      #   assertion; uses the configured key if not provided. Required — must be present either in configuration
+      #   or passed here.
       # @param kid [String] key ID for JWT assertion header; uses configured kid if not provided.
       #   Required — must be present either in configuration or passed here.
       # @return [Hash] token response from the authorization server, including:
@@ -202,17 +203,19 @@ module Safire
       #   * "expires_in"  [Integer] lifetime of the access token in seconds (required per Backend Services spec)
       #   * "scope"       [String] authorized scopes (required)
       # @raise [Safire::Errors::ConfigurationError] if +client_id+, +private_key+, or +kid+ are missing
+      # @raise [ArgumentError] if the signing key or JWT assertion configuration is invalid
       # @raise [Safire::Errors::TokenError] if the server returns an error or invalid response
       # @raise [Safire::Errors::NetworkError] on connection failure, timeout, or SSL error
       def request_backend_token(scopes: nil, private_key: self.private_key, kid: self.kid)
-        scopes = resolve_backend_scopes(scopes)
         validate_client_id!
+        assertion_params = jwt_assertion_params(private_key:, kid:)
+        scopes = resolve_backend_scopes(scopes)
 
         Safire.logger.info('Requesting backend services access token (client_credentials grant)...')
 
         response = @http_client.post(
           token_endpoint,
-          body: backend_services_token_params(scopes:, private_key:, kid:),
+          body: backend_services_token_params(scopes:, assertion_params:),
           headers: { content_type: 'application/x-www-form-urlencoded' }
         )
 
@@ -426,20 +429,22 @@ module Safire
         params.merge(client_auth_params(private_key:, kid:))
       end
 
-      def backend_services_token_params(scopes:, private_key:, kid:)
+      def backend_services_token_params(scopes:, assertion_params:)
         # Per SMART Backend Services spec, client identity is conveyed via the JWT
         # iss/sub claims (RFC 7523 §3); client_id is intentionally omitted from the
         # POST body, consistent with the SMART IG reference token request example.
         {
           grant_type: 'client_credentials',
           scope: [scopes].flatten.join(' ')
-        }.merge(jwt_assertion_params(private_key:, kid:))
+        }.merge(assertion_params)
       end
 
       def resolve_backend_scopes(requested_scopes)
-        configured_or_requested = requested_scopes.nil? ? scopes : requested_scopes
-        resolved_scopes = normalize_backend_scopes(configured_or_requested)
-        return resolved_scopes if resolved_scopes.present?
+        requested = normalize_backend_scopes(requested_scopes)
+        return requested if requested.present?
+
+        configured = normalize_backend_scopes(scopes)
+        return configured if configured.present?
 
         Safire.logger.warn(BACKEND_SCOPE_DEPRECATION_WARNING)
         LEGACY_BACKEND_SCOPES

--- a/lib/safire/protocols/smart.rb
+++ b/lib/safire/protocols/smart.rb
@@ -437,11 +437,20 @@ module Safire
       end
 
       def resolve_backend_scopes(requested_scopes)
-        resolved_scopes = requested_scopes.nil? ? scopes : requested_scopes
+        configured_or_requested = requested_scopes.nil? ? scopes : requested_scopes
+        resolved_scopes = normalize_backend_scopes(configured_or_requested)
         return resolved_scopes if resolved_scopes.present?
 
         Safire.logger.warn(BACKEND_SCOPE_DEPRECATION_WARNING)
         LEGACY_BACKEND_SCOPES
+      end
+
+      def normalize_backend_scopes(scopes)
+        [scopes].flatten.filter_map do |scope|
+          next if scope.blank?
+
+          scope.is_a?(String) ? scope.strip : scope
+        end
       end
 
       def client_auth_params(private_key:, kid:)

--- a/lib/safire/protocols/smart.rb
+++ b/lib/safire/protocols/smart.rb
@@ -30,6 +30,12 @@ module Safire
       ].freeze
 
       WELL_KNOWN_PATH = '/.well-known/smart-configuration'.freeze
+      LEGACY_BACKEND_SCOPES = ['system/*.rs'].freeze
+      BACKEND_SCOPE_DEPRECATION_WARNING =
+        '[Safire] SMART Backend Services default scope is deprecated; pass scopes: or configure scopes explicitly. ' \
+        'Requests without scopes will raise ConfigurationError in v0.6.0.'.freeze
+
+      private_constant :LEGACY_BACKEND_SCOPES, :BACKEND_SCOPE_DEPRECATION_WARNING
 
       attr_reader(*ATTRIBUTES)
       attr_accessor :client_type
@@ -176,13 +182,16 @@ module Safire
       # Requests an access token using the client credentials grant (SMART Backend Services).
       #
       # Implements the SMART Backend Services Authorization flow per
-      # https://hl7.org/fhir/smart-app-launch/backend-services.html
+      # https://hl7.org/fhir/smart-app-launch/STU2.2/backend-services.html
       #
       # No user interaction, redirect, or PKCE is involved. The client authenticates
       # exclusively via a signed JWT assertion (RS384 or ES384).
       #
-      # @param scopes [Array<String>, nil] scope override; uses configured scopes if nil,
-      #   falling back to +["system/*.rs"]+ when neither is provided
+      # @param scopes [Array<String>, nil] scope override; uses configured scopes if nil. For v0.4.x compatibility,
+      #   a blank resolved value emits a deprecation warning and falls back to +["system/*.rs"]+. This fallback
+      #   will be removed in v0.6.0, when missing scopes will raise {Safire::Errors::ConfigurationError}. Explicit
+      #   non-+system/+ scopes are submitted unchanged because SMART permits them when the caller establishes the
+      #   required context out of band.
       # @param private_key [OpenSSL::PKey] private key for JWT assertion; uses configured key if not provided.
       #   Required — must be present either in configuration or passed here.
       # @param kid [String] key ID for JWT assertion header; uses configured kid if not provided.
@@ -196,7 +205,7 @@ module Safire
       # @raise [Safire::Errors::TokenError] if the server returns an error or invalid response
       # @raise [Safire::Errors::NetworkError] on connection failure, timeout, or SSL error
       def request_backend_token(scopes: nil, private_key: self.private_key, kid: self.kid)
-        scopes ||= self.scopes.presence || ['system/*.rs']
+        scopes = resolve_backend_scopes(scopes)
         validate_client_id!
 
         Safire.logger.info('Requesting backend services access token (client_credentials grant)...')
@@ -425,6 +434,14 @@ module Safire
           grant_type: 'client_credentials',
           scope: [scopes].flatten.join(' ')
         }.merge(jwt_assertion_params(private_key:, kid:))
+      end
+
+      def resolve_backend_scopes(requested_scopes)
+        resolved_scopes = requested_scopes.nil? ? scopes : requested_scopes
+        return resolved_scopes if resolved_scopes.present?
+
+        Safire.logger.warn(BACKEND_SCOPE_DEPRECATION_WARNING)
+        LEGACY_BACKEND_SCOPES
       end
 
       def client_auth_params(private_key:, kid:)

--- a/spec/examples/sinatra_app/safire_demo_spec.rb
+++ b/spec/examples/sinatra_app/safire_demo_spec.rb
@@ -487,6 +487,29 @@ RSpec.describe SafireDemo do
       }
     end
 
+    it 'prepopulates only configured system scopes' do
+      allow(Safire::Client).to receive(:new).and_return(metadata_client)
+      allow(smart_server).to receive(:scopes).and_return(%w[openid system/Patient.rs profile system/Observation.rs])
+
+      response = response_for(:get, '/demo/smart-only/backend-token')
+
+      expect(response.status).to eq(200)
+      expect(response.body).to include('name="scopes"')
+      expect(response.body).to include('value="system/Patient.rs system/Observation.rs"')
+      expect(response.body).not_to include('value="openid system/Patient.rs profile')
+    end
+
+    it 'leaves the scope input empty when only App Launch scopes are configured' do
+      allow(Safire::Client).to receive(:new).and_return(metadata_client)
+
+      response = response_for(:get, '/demo/smart-only/backend-token')
+
+      expect(response.status).to eq(200)
+      expect(response.body).to include('name="scopes"')
+      expect(response.body).to include('value=""')
+      expect(response.body).not_to include('value="openid profile"')
+    end
+
     it 'requests tokens with a backend-specific confidential asymmetric client' do
       allow(Safire::Client).to receive(:new).and_return(metadata_client, backend_client)
 
@@ -494,6 +517,7 @@ RSpec.describe SafireDemo do
 
       expect(response.status).to eq(200)
       expect(response.body).to include('system-token')
+      expect(response.body).to include('name="scopes" value="system/*.rs"')
       expect(backend_client).to have_received(:request_backend_token).with(scopes: ['system/*.rs'])
       expect(backend_client).to have_received(:token_response_valid?).with(backend_token_response,
                                                                            flow: :backend_services)
@@ -520,6 +544,36 @@ RSpec.describe SafireDemo do
       expect(response.status).to eq(200)
       expect(response.body).not_to include(unsafe_value)
       expect(response.body).to include('&lt;script&gt;alert')
+    end
+
+    it 'rejects an empty scope before constructing a token-request client' do
+      allow(Safire::Client).to receive(:new).and_return(metadata_client)
+
+      response = with_env(
+        'ASYMMETRIC_PRIVATE_KEY_PEM' => 'backend-private-key',
+        'ASYMMETRIC_KID' => 'backend-kid'
+      ) do
+        form_response(:post, '/demo/smart-only/backend-token', params: { scopes: ' , ' })
+      end
+
+      expect(response.status).to eq(422)
+      expect(response.body).to include('Enter at least one scope')
+      expect(Safire::Client).to have_received(:new).once
+    end
+
+    it 'rejects non-system scopes because the demo has no out-of-band context' do
+      allow(Safire::Client).to receive(:new).and_return(metadata_client)
+
+      response = with_env(
+        'ASYMMETRIC_PRIVATE_KEY_PEM' => 'backend-private-key',
+        'ASYMMETRIC_KID' => 'backend-kid'
+      ) do
+        form_response(:post, '/demo/smart-only/backend-token', params: { scopes: 'user/Patient.rs' })
+      end
+
+      expect(response.status).to eq(422)
+      expect(response.body).to include('Enter only system/ scopes')
+      expect(Safire::Client).to have_received(:new).once
     end
   end
 

--- a/spec/integration/backend_services_flow_spec.rb
+++ b/spec/integration/backend_services_flow_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe 'SMART Backend Services End-to-End Flow', type: :integration do
   #
   # Tests the SMART Backend Services (system-to-system) flow per
-  # https://hl7.org/fhir/smart-app-launch/backend-services.html
+  # https://hl7.org/fhir/smart-app-launch/STU2.2/backend-services.html
   #
   # Flow:
   # 1. (Optional) Discovery: Fetch /.well-known/smart-configuration

--- a/spec/integration/backend_services_flow_spec.rb
+++ b/spec/integration/backend_services_flow_spec.rb
@@ -55,9 +55,9 @@ RSpec.describe 'SMART Backend Services End-to-End Flow', type: :integration do
 
   # ---------- Helpers ----------
 
-  def stub_discovery
+  def stub_discovery(metadata: smart_metadata)
     stub_request(:get, "#{base_url}/.well-known/smart-configuration")
-      .to_return(status: 200, body: smart_metadata.to_json,
+      .to_return(status: 200, body: metadata.to_json,
                  headers: { 'Content-Type' => 'application/json' })
   end
 
@@ -165,7 +165,8 @@ RSpec.describe 'SMART Backend Services End-to-End Flow', type: :integration do
       expect(tokens['scope']).to eq('system/Patient.rs')
     end
 
-    it 'defaults to system/*.rs when no scopes are configured' do
+    it 'preserves the deprecated system/*.rs fallback when no scopes are configured' do
+      allow(Safire.logger).to receive(:warn)
       stub_token_post(
         body_matcher: hash_including('scope' => 'system/*.rs'),
         response_body: backend_token_response.merge('scope' => 'system/*.rs')
@@ -175,6 +176,25 @@ RSpec.describe 'SMART Backend Services End-to-End Flow', type: :integration do
 
       expect(WebMock).to have_requested(:post, token_endpoint)
         .with(body: hash_including('scope' => 'system/*.rs'))
+      expect(Safire.logger).to have_received(:warn).once
+    end
+
+    it 'submits an explicit wildcard that is absent from non-exhaustive discovery metadata' do
+      allow(Safire.logger).to receive(:warn)
+      stub_discovery(metadata: smart_metadata.merge('scopes_supported' => ['system/Patient.rs']))
+      stub_token_post(
+        body_matcher: hash_including('scope' => 'system/*.rs'),
+        response_body: backend_token_response.merge('scope' => 'system/*.rs')
+      )
+      config = Safire::ClientConfig.new(
+        backend_config_attrs.except(:token_endpoint).merge(scopes: ['system/*.rs'])
+      )
+
+      Safire::Client.new(config).request_backend_token
+
+      expect(WebMock).to have_requested(:post, token_endpoint)
+        .with(body: hash_including('scope' => 'system/*.rs'))
+      expect(Safire.logger).not_to have_received(:warn)
     end
   end
 

--- a/spec/integration/backend_services_live_spec.rb
+++ b/spec/integration/backend_services_live_spec.rb
@@ -14,9 +14,9 @@ require 'spec_helper'
 #   SAFIRE_LIVE_BACKEND_CLIENT_ID       — registered backend client ID
 #   SAFIRE_LIVE_BACKEND_KID             — key ID matching the registered JWKS
 #   SAFIRE_LIVE_BACKEND_PRIVATE_KEY_PEM — PEM-encoded RSA or EC private key (inline)
+#   SAFIRE_LIVE_BACKEND_SCOPES          — space-separated scopes registered for the client
 #
 # Optional:
-#   SAFIRE_LIVE_BACKEND_SCOPES          — space-separated scopes (default: 'system/*.rs')
 #   SAFIRE_LIVE_BACKEND_ALGORITHM       — JWT algorithm (default: 'RS384')
 #
 RSpec.describe 'SMART Backend Services Flow (Live Server)', :live, type: :integration do
@@ -24,7 +24,7 @@ RSpec.describe 'SMART Backend Services Flow (Live Server)', :live, type: :integr
   let(:client_id)   { ENV.fetch('SAFIRE_LIVE_BACKEND_CLIENT_ID', nil) }
   let(:kid)         { ENV.fetch('SAFIRE_LIVE_BACKEND_KID', nil) }
   let(:algorithm)   { ENV.fetch('SAFIRE_LIVE_BACKEND_ALGORITHM', 'RS384') }
-  let(:scopes)      { ENV.fetch('SAFIRE_LIVE_BACKEND_SCOPES', 'system/*.rs').split }
+  let(:scopes)      { ENV.fetch('SAFIRE_LIVE_BACKEND_SCOPES', nil)&.split }
   let(:private_key) do
     pem = ENV.fetch('SAFIRE_LIVE_BACKEND_PRIVATE_KEY_PEM', nil)
     OpenSSL::PKey.read(pem) if pem
@@ -73,6 +73,7 @@ RSpec.describe 'SMART Backend Services Flow (Live Server)', :live, type: :integr
       skip 'Set SAFIRE_LIVE_BACKEND_CLIENT_ID to run token exchange tests' unless client_id
       skip 'Set SAFIRE_LIVE_BACKEND_KID to run token exchange tests' unless kid
       skip 'Set SAFIRE_LIVE_BACKEND_PRIVATE_KEY_PEM to run token exchange tests' unless private_key
+      skip 'Set SAFIRE_LIVE_BACKEND_SCOPES to run token exchange tests' unless scopes.present?
     end
 
     it 'exchanges a JWT assertion for an access token on a real server' do

--- a/spec/safire/protocols/smart_spec.rb
+++ b/spec/safire/protocols/smart_spec.rb
@@ -920,26 +920,26 @@ RSpec.describe Safire::Protocols::Smart do
     context 'with a blank scope override' do
       before do
         stub_token_post(
-          body_matcher: hash_including('scope' => 'system/*.rs'),
+          body_matcher: hash_including('scope' => 'system/Patient.rs system/Observation.rs'),
           status: 200,
-          body: backend_token_response.merge('scope' => 'system/*.rs')
+          body: backend_token_response
         )
       end
 
-      it 'uses the legacy fallback and warns instead of sending an empty array' do
+      it 'uses configured scopes instead of sending an empty array' do
         described_class.new(backend_config).request_backend_token(scopes: [])
 
         expect(WebMock).to have_requested(:post, config_attrs[:token_endpoint])
-          .with(body: hash_including('scope' => 'system/*.rs'))
-        expect(Safire.logger).to have_received(:warn).with(scope_fallback_warning).once
+          .with(body: hash_including('scope' => 'system/Patient.rs system/Observation.rs'))
+        expect(Safire.logger).not_to have_received(:warn)
       end
 
-      it 'uses the legacy fallback when every requested entry is blank' do
+      it 'uses configured scopes when every requested entry is blank' do
         described_class.new(backend_config).request_backend_token(scopes: [nil, '', '  '])
 
         expect(WebMock).to have_requested(:post, config_attrs[:token_endpoint])
-          .with(body: hash_including('scope' => 'system/*.rs'))
-        expect(Safire.logger).to have_received(:warn).with(scope_fallback_warning).once
+          .with(body: hash_including('scope' => 'system/Patient.rs system/Observation.rs'))
+        expect(Safire.logger).not_to have_received(:warn)
       end
 
       it 'removes blank entries and trims usable requested scopes' do
@@ -1008,29 +1008,60 @@ RSpec.describe Safire::Protocols::Smart do
           .with(body: hash_including('scope' => 'system/*.rs'))
         expect(Safire.logger).to have_received(:warn).with(scope_fallback_warning).once
       end
+
+      it 'uses the legacy fallback when per-call and configured scopes are blank' do
+        stub_token_post(
+          body_matcher: hash_including('scope' => 'system/*.rs'),
+          status: 200,
+          body: backend_token_response.merge('scope' => 'system/*.rs')
+        )
+        cfg = Safire::ClientConfig.new(backend_config_attrs.except(:scopes))
+
+        described_class.new(cfg).request_backend_token(scopes: [nil, '', '  '])
+
+        expect(WebMock).to have_requested(:post, config_attrs[:token_endpoint])
+          .with(body: hash_including('scope' => 'system/*.rs'))
+        expect(Safire.logger).to have_received(:warn).with(scope_fallback_warning).once
+      end
     end
 
     context 'when client_id is not configured' do
       it 'raises ConfigurationError — client_id is required for JWT assertion claims' do
-        cfg = Safire::ClientConfig.new(backend_config_attrs.except(:client_id))
+        cfg = Safire::ClientConfig.new(backend_config_attrs.except(:client_id, :scopes))
+
         expect { described_class.new(cfg).request_backend_token }
           .to raise_error(Safire::Errors::ConfigurationError, /client_id/)
+        expect(Safire.logger).not_to have_received(:warn)
       end
     end
 
     context 'when private_key is missing' do
       it 'raises ConfigurationError' do
-        cfg = Safire::ClientConfig.new(backend_config_attrs.except(:private_key))
+        cfg = Safire::ClientConfig.new(backend_config_attrs.except(:private_key, :scopes))
+
         expect { described_class.new(cfg).request_backend_token }
           .to raise_error(Safire::Errors::ConfigurationError, /private_key/)
+        expect(Safire.logger).not_to have_received(:warn)
       end
     end
 
     context 'when kid is missing' do
       it 'raises ConfigurationError' do
-        cfg = Safire::ClientConfig.new(backend_config_attrs.except(:kid))
+        cfg = Safire::ClientConfig.new(backend_config_attrs.except(:kid, :scopes))
+
         expect { described_class.new(cfg).request_backend_token }
           .to raise_error(Safire::Errors::ConfigurationError, /kid/)
+        expect(Safire.logger).not_to have_received(:warn)
+      end
+    end
+
+    context 'when a per-call private key is malformed' do
+      it 'raises before emitting the scope deprecation warning' do
+        cfg = Safire::ClientConfig.new(backend_config_attrs.except(:scopes))
+
+        expect { described_class.new(cfg).request_backend_token(private_key: 'not a PEM key') }
+          .to raise_error(ArgumentError, /Invalid private key/)
+        expect(Safire.logger).not_to have_received(:warn)
       end
     end
 

--- a/spec/safire/protocols/smart_spec.rb
+++ b/spec/safire/protocols/smart_spec.rb
@@ -797,6 +797,10 @@ RSpec.describe Safire::Protocols::Smart do
   # ---------- Backend Token ----------
 
   describe '#request_backend_token' do
+    let(:scope_fallback_warning) do
+      '[Safire] SMART Backend Services default scope is deprecated; pass scopes: or configure scopes explicitly. ' \
+        'Requests without scopes will raise ConfigurationError in v0.6.0.'
+    end
     let(:backend_token_response) do
       { 'access_token' => 'backend_token_abc', 'token_type' => 'Bearer',
         'expires_in' => 300, 'scope' => 'system/Patient.rs system/Observation.rs' }
@@ -824,6 +828,8 @@ RSpec.describe Safire::Protocols::Smart do
 
     let(:backend_config) { Safire::ClientConfig.new(backend_config_attrs) }
 
+    before { allow(Safire.logger).to receive(:warn) }
+
     context 'with RSA private key and configured scopes' do
       before do
         stub_token_post(body_matcher: backend_assertion_matcher, status: 200, body: backend_token_response)
@@ -845,6 +851,7 @@ RSpec.describe Safire::Protocols::Smart do
             body['client_assertion_type'] == 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer' &&
             body['client_assertion'].present?
         end)
+        expect(Safire.logger).not_to have_received(:warn)
       end
 
       it 'does not include an Authorization header' do
@@ -886,11 +893,48 @@ RSpec.describe Safire::Protocols::Smart do
 
         expect(WebMock).to have_requested(:post, config_attrs[:token_endpoint])
           .with(body: hash_including('scope' => 'system/Patient.rs'))
+        expect(Safire.logger).not_to have_received(:warn)
+      end
+    end
+
+    context 'with non-system scopes supported through out-of-band coordination' do
+      before do
+        stub_token_post(
+          body_matcher: hash_including('scope' => 'user/Patient.rs patient/Observation.rs'),
+          status: 200,
+          body: backend_token_response.merge('scope' => 'user/Patient.rs patient/Observation.rs')
+        )
+      end
+
+      it 'submits the scopes unchanged without treating a permitted coordinated request as non-conformant' do
+        requested_scopes = %w[user/Patient.rs patient/Observation.rs]
+
+        described_class.new(backend_config).request_backend_token(scopes: requested_scopes)
+
+        expect(WebMock).to have_requested(:post, config_attrs[:token_endpoint])
+          .with(body: hash_including('scope' => requested_scopes.join(' ')))
+        expect(Safire.logger).not_to have_received(:warn)
+      end
+    end
+
+    context 'with a blank scope override' do
+      it 'uses the legacy fallback and warns instead of sending an empty scope' do
+        stub_token_post(
+          body_matcher: hash_including('scope' => 'system/*.rs'),
+          status: 200,
+          body: backend_token_response.merge('scope' => 'system/*.rs')
+        )
+
+        described_class.new(backend_config).request_backend_token(scopes: [])
+
+        expect(WebMock).to have_requested(:post, config_attrs[:token_endpoint])
+          .with(body: hash_including('scope' => 'system/*.rs'))
+        expect(Safire.logger).to have_received(:warn).with(scope_fallback_warning).once
       end
     end
 
     context 'when no scopes are configured and none provided' do
-      it 'defaults to system/*.rs scope' do
+      it 'uses the legacy system/*.rs scope and emits the exact deprecation warning' do
         stub_token_post(
           body_matcher: hash_including('scope' => 'system/*.rs'),
           status: 200,
@@ -901,6 +945,29 @@ RSpec.describe Safire::Protocols::Smart do
 
         expect(WebMock).to have_requested(:post, config_attrs[:token_endpoint])
           .with(body: hash_including('scope' => 'system/*.rs'))
+        expect(Safire.logger).to have_received(:warn).with(scope_fallback_warning).once
+      end
+
+      it 'does not include credentials or token values in the warning' do
+        warnings = []
+        allow(Safire.logger).to receive(:warn) { |message| warnings << message }
+        stub_token_post(
+          body_matcher: hash_including('scope' => 'system/*.rs'),
+          status: 200,
+          body: backend_token_response.merge('access_token' => 'sensitive-access-token')
+        )
+        cfg = Safire::ClientConfig.new(backend_config_attrs.except(:scopes))
+
+        described_class.new(cfg).request_backend_token
+
+        expect(warnings).to eq([scope_fallback_warning])
+        expect(warnings.join).not_to include(
+          'backend_client_id',
+          'backend-key-id',
+          rsa_private_key.to_pem,
+          'sensitive-access-token',
+          'client_assertion'
+        )
       end
     end
 

--- a/spec/safire/protocols/smart_spec.rb
+++ b/spec/safire/protocols/smart_spec.rb
@@ -918,18 +918,42 @@ RSpec.describe Safire::Protocols::Smart do
     end
 
     context 'with a blank scope override' do
-      it 'uses the legacy fallback and warns instead of sending an empty scope' do
+      before do
         stub_token_post(
           body_matcher: hash_including('scope' => 'system/*.rs'),
           status: 200,
           body: backend_token_response.merge('scope' => 'system/*.rs')
         )
+      end
 
+      it 'uses the legacy fallback and warns instead of sending an empty array' do
         described_class.new(backend_config).request_backend_token(scopes: [])
 
         expect(WebMock).to have_requested(:post, config_attrs[:token_endpoint])
           .with(body: hash_including('scope' => 'system/*.rs'))
         expect(Safire.logger).to have_received(:warn).with(scope_fallback_warning).once
+      end
+
+      it 'uses the legacy fallback when every requested entry is blank' do
+        described_class.new(backend_config).request_backend_token(scopes: [nil, '', '  '])
+
+        expect(WebMock).to have_requested(:post, config_attrs[:token_endpoint])
+          .with(body: hash_including('scope' => 'system/*.rs'))
+        expect(Safire.logger).to have_received(:warn).with(scope_fallback_warning).once
+      end
+
+      it 'removes blank entries and trims usable requested scopes' do
+        stub_token_post(
+          body_matcher: hash_including('scope' => 'system/Patient.rs'),
+          status: 200,
+          body: backend_token_response.merge('scope' => 'system/Patient.rs')
+        )
+
+        described_class.new(backend_config).request_backend_token(scopes: ['', ' system/Patient.rs ', nil])
+
+        expect(WebMock).to have_requested(:post, config_attrs[:token_endpoint])
+          .with(body: hash_including('scope' => 'system/Patient.rs'))
+        expect(Safire.logger).not_to have_received(:warn)
       end
     end
 
@@ -968,6 +992,21 @@ RSpec.describe Safire::Protocols::Smart do
           'sensitive-access-token',
           'client_assertion'
         )
+      end
+
+      it 'uses the legacy fallback when every configured entry is blank' do
+        stub_token_post(
+          body_matcher: hash_including('scope' => 'system/*.rs'),
+          status: 200,
+          body: backend_token_response.merge('scope' => 'system/*.rs')
+        )
+        cfg = Safire::ClientConfig.new(backend_config_attrs.merge(scopes: ['', '  ']))
+
+        described_class.new(cfg).request_backend_token
+
+        expect(WebMock).to have_requested(:post, config_attrs[:token_endpoint])
+          .with(body: hash_including('scope' => 'system/*.rs'))
+        expect(Safire.logger).to have_received(:warn).with(scope_fallback_warning).once
       end
     end
 


### PR DESCRIPTION
## Summary

This aligns SMART Backend Services token requests with explicit caller scope intent. Safire now warns whenever the legacy `system/*.rs` fallback is used and documents its removal in v0.6.0, while preserving explicit non-system scopes because SMART permits coordinated user or patient context. The demo now prepopulates only configured `system/` scopes and rejects empty or non-system submissions because it does not establish that context out of band. The accompanying API documentation, ADR, troubleshooting guidance, changelog, and roadmap describe the compatibility period and final responsibility boundary.