### PR TITLE
Complete phase 1 client role alignment audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,25 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- SMART and UDAP discovery now accept valid raw JSON-object response bodies even
+- SMART and UDAP discovery now accept usable raw JSON-object response bodies
   when incorrect or missing response content types leave them undecoded by the
-  HTTP adapter. Malformed and non-object JSON continue to raise protocol-specific
-  `DiscoveryError` failures.
-- Shared discovery, registration, and OAuth error parsing now rejects ambiguous
-  symbol/string key collisions, recursive structures, and non-JSON-compatible
-  adapter-provided Hash values instead of risking silent normalization or
-  unexpected type errors. Valid response behavior is unchanged.
-- UDAP Dynamic Client Registration now validates and snapshots caller metadata
+  HTTP adapter. Shared discovery, registration, and OAuth error handling treats
+  malformed or non-object JSON plus ambiguous, recursive, or non-JSON-compatible
+  adapter-provided Hashes as unusable instead of risking silent normalization
+  or unexpected type errors.
+- SMART metadata diagnostics now validate array-valued field shapes. Capability
+  and signing-algorithm helpers treat malformed list advertisements as
+  unsupported instead of applying scalar substring semantics or raising an
+  unexpected type error. Authorization and token operations now also apply the
+  configured HTTPS/localhost policy to endpoints obtained through SMART
+  discovery before using them.
+- UDAP Dynamic Client Registration now validates and snapshots caller input
   before discovery, then gates only on trusted DCR profile, endpoint, algorithm,
-  and certification-requirement values. Unrelated discovery conformance defects
-  remain available through `UdapMetadata#valid?` without blocking an otherwise
-  usable registration request.
-- UDAP registration warns when a server omits the STU2 `RS256` baseline and can
-  negotiate another advertised, supported, key-compatible algorithm. In the
-  v0.4.1 compatibility phase, missing or insufficient `scopes_supported`
-  metadata produces aggregated warnings while registration, modification, and
-  lifecycle-safe cancellation continue; exact wildcard advertisement becomes a
-  registration requirement in v0.5.0.
+  certification, and scope values needed by the request. Missing RS256
+  advertisement and unconfirmed scope support produce value-free warnings when
+  an otherwise usable request can proceed; unrelated metadata conformance
+  defects remain available through `UdapMetadata#valid?`. In v0.4.1,
+  unadvertised wildcards still proceed after warning; registration and
+  modification require exact advertisement in v0.5.0, while wildcard scope
+  compatibility remains warning-only during cancellation.
 - UDAP authorization-code registration now rejects only locally provable
   `logo_uri` defects. Usable HTTPS URLs whose PNG, JPG/JPEG, or GIF format
   cannot be inferred from the path are accepted with a value-free warning;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unsupported instead of applying scalar substring semantics or raising an
   unexpected type error. Authorization and token operations now also apply the
   configured HTTPS/localhost policy to endpoints obtained through SMART
-  discovery before using them.
+  discovery before using them. OAuth authorization, token, registration, and
+  redirect endpoint URIs are rejected when they contain fragment components.
 - UDAP Dynamic Client Registration now validates and snapshots caller input
   before discovery, then gates only on trusted DCR profile, endpoint, algorithm,
   certification, and scope values needed by the request. Missing RS256

--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ cancellation = udap_client.cancel_registration(
 )
 ```
 
+UDAP registration uses the trusted fields needed for that workflow rather than
+turning the full `UdapMetadata#valid?` conformance diagnostic into an automatic
+gate. In v0.4.1, an unadvertised requested wildcard produces a warning and is
+still submitted; v0.5.0 will require exact wildcard advertisement for
+registration and modification while keeping wildcard scope drift warning-only
+during cancellation.
+
 UDAP JWT client authentication and Tiered OAuth are planned. See [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md) for details.
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,6 +55,10 @@ Feedback, bug reports, and pull requests are welcome via the [issue tracker](htt
 
 ### v0.5.0 — UDAP JWT Client Authentication and B2B Authorization
 
+- **UDAP Registration Wildcard Enforcement** — require exact
+  `scopes_supported` advertisement for requested wildcard scopes during new
+  registration and modification after the v0.4.1 warning period; cancellation
+  remains warning-only so metadata drift cannot strand an existing registration
 - **UDAP Authentication Tokens** — certificate-backed JWT client authentication
   for token endpoint requests, using authoritative signed discovery metadata
 - **B2B Client Credentials** — headless system-to-system authorization with the

--- a/docs/adr/ADR-007-https-only-redirects-and-localhost-exception.md
+++ b/docs/adr/ADR-007-https-only-redirects-and-localhost-exception.md
@@ -30,7 +30,7 @@ security boundary and can hide production misconfiguration.
 For client configuration and HTTP redirects, HTTPS is enforced at **two layers**.
 Both layers use the same explicit local-development opt-in:
 
-**Layer 1 — `ClientConfig` URI validation:** all URI attributes (`base_url`, `redirect_uri`, `issuer`, `authorization_endpoint`, `token_endpoint`, `jwks_uri`) must use `https://`, except when `allow_insecure_localhost: true` is configured and the host is `localhost` or `127.0.0.1`.
+**Layer 1 — `ClientConfig` URI validation:** all URI attributes (`base_url`, `redirect_uri`, `issuer`, `authorization_endpoint`, `token_endpoint`, `jwks_uri`) must use `https://`, except when `allow_insecure_localhost: true` is configured and the host is `localhost` or `127.0.0.1`. OAuth redirect, authorization, and token endpoint URIs must not contain a fragment component, as required by RFC 6749 Sections 3.1 and 3.2.
 
 **Layer 2 — `HttpsOnlyRedirects` Faraday middleware:** intercepts every 3xx response before `faraday-follow_redirects` follows it. If the redirect target is not HTTPS, and the local-development exception is not enabled for a loopback host, a `Safire::Errors::NetworkError` is raised immediately rather than following the redirect.
 
@@ -57,9 +57,9 @@ runtime concern.
 UDAP registration metadata applies the same secure default to its registration
 URI fields. The UDAP Security STU2 registration profile requires
 `redirect_uris` and `logo_uri` to use HTTPS.
-`URIValidation#strict_https_uri?` provides that default predicate, while
-`URIValidation#localhost_http_uri?` identifies the only local HTTP shape that
-can be accepted when a caller explicitly opts into development mode.
+`URIValidation#classify_uri` provides the shared HTTPS and fragment policy.
+UDAP redirect URIs reject fragment components; the rule is not applied to the
+presentation-oriented `logo_uri` field.
 
 `UdapRegistrationMetadata` uses the same explicit option name for non-TLS local
 redirect and logo URIs. It accepts only HTTP on `localhost` or `127.0.0.1`,

--- a/docs/adr/ADR-008-warn-return-false-for-compliance-validation.md
+++ b/docs/adr/ADR-008-warn-return-false-for-compliance-validation.md
@@ -15,7 +15,10 @@ nav_order: 8
 
 Safire performs two different kinds of checks:
 
-1. **Configuration checks** — validating that the caller has provided a usable configuration (required attributes present, URIs well-formed and HTTPS). These run at construction time and represent programming errors if they fail.
+1. **Configuration checks** — validating that the caller has provided usable
+   configuration (required attributes present, URIs well-formed and HTTPS).
+   General checks run at construction time; flow-specific requirements run at
+   the operation boundary. They represent caller-correctable errors if they fail.
 
 2. **Compliance checks** — validating that a remote server's response conforms to the SMART App Launch 2.2.0 specification. These run at runtime and represent server behaviour, not caller behaviour.
 
@@ -58,12 +61,16 @@ end
 ```
 
 These methods:
+
 - Never raise an exception
 - Log one warning per violation (not a single combined message) so each issue is individually observable
-- Return `true` only when fully compliant; `false` as soon as any violation is found
+- Return `true` only when fully compliant and `false` when any violation is found
 - Are **user-callable** — they are not invoked automatically by `authorization_url` or `server_metadata`; callers opt in to compliance checking
 
-Configuration validation (`ClientConfig#validate!`, `Smart#validate!`) raises `ConfigurationError` — these are programming errors that must be fixed before the gem can function.
+Configuration validation in `ClientConfig` and protocol workflow-readiness
+checks raise typed Safire errors. These are caller-correctable failures or
+conditions that make the requested operation unsafe, impossible, or
+unconfirmed; ADR-015 owns the detailed boundary.
 
 ---
 

--- a/docs/adr/ADR-011-udap-stu2-discovery-conformance.md
+++ b/docs/adr/ADR-011-udap-stu2-discovery-conformance.md
@@ -66,10 +66,11 @@ semantics.
   algorithm (`alg`), required claim presence, and signature are not validated here — these are
   deferred to the cryptographic validator
 - endpoint URL fields (`token_endpoint`, `registration_endpoint`, conditionally
-  `authorization_endpoint`) must be absolute HTTPS URLs; plain HTTP is accepted only when
-  `allow_insecure_localhost: true` is configured and the host is `localhost` or `127.0.0.1`
-  to support development without TLS — any other scheme on those hosts (e.g. `ftp://localhost`)
-  is rejected; this exception does not apply in production
+  `authorization_endpoint`) must be absolute HTTPS URLs without fragment components; plain HTTP
+  is accepted only when `allow_insecure_localhost: true` is configured and the host is `localhost`
+  or `127.0.0.1` to support development without TLS — any other scheme on those hosts (e.g.
+  `ftp://localhost`) is rejected; this exception does not apply in production and does not relax
+  the fragment prohibition
 - `authorization_endpoint` is conditionally required when `grant_types_supported` includes
   `"authorization_code"`
 - `"udap_authz"` is conditionally required in `udap_profiles_supported` when `grant_types_supported`

--- a/docs/adr/ADR-011-udap-stu2-discovery-conformance.md
+++ b/docs/adr/ADR-011-udap-stu2-discovery-conformance.md
@@ -108,6 +108,7 @@ semantics.
 
 **Trade-offs:**
 
-- A structurally valid `UdapMetadata` object is not automatically cryptographically validated;
-  callers that require full STU2 conformance must also perform cryptographic validation of the
-  `signed_metadata` JWT after structural validation passes
+- A directly constructed `UdapMetadata` object is not automatically
+  cryptographically validated. `Safire::Client#server_metadata` validates
+  `signed_metadata` before returning the entity; callers that construct an
+  entity themselves must establish that trust separately.

--- a/docs/adr/ADR-013-udap-registration-request-model.md
+++ b/docs/adr/ADR-013-udap-registration-request-model.md
@@ -60,7 +60,8 @@ Registration accepts exactly one primary grant:
 
 Unknown and duplicate grant values are rejected. `redirect_uris`, `logo_uri`,
 and generated `response_types: ["code"]` apply only to authorization-code
-registration. Redirect and logo URIs require absolute HTTPS by default.
+registration. Redirect and logo URIs require absolute HTTPS by default, and
+redirect URIs must not contain fragment components.
 
 The STU2 logo requirement has two different validation boundaries. Safire can
 prove locally that `logo_uri` is an absolute HTTPS URI, so malformed, relative,

--- a/docs/adr/ADR-015-client-role-and-runtime-readiness.md
+++ b/docs/adr/ADR-015-client-role-and-runtime-readiness.md
@@ -76,9 +76,10 @@ discovery failure.
 
 SMART discovery preserves metadata for inspection, but an operation validates
 its discovered authorization or token endpoint against Safire's HTTPS policy
-before use. This focused runtime stop protects authorization data and client
-credentials without promoting unrelated metadata defects into discovery
-failures.
+and rejects fragment components before use. This focused runtime stop protects
+authorization data and client credentials while enforcing the OAuth endpoint
+shape the operation consumes, without promoting unrelated metadata defects into
+discovery failures.
 
 UDAP DCR uses focused readiness rather than calling `UdapMetadata#valid?` as an
 operational gate. Safire requires trusted discovery, an advertised `udap_dcr`

--- a/docs/adr/ADR-015-client-role-and-runtime-readiness.md
+++ b/docs/adr/ADR-015-client-role-and-runtime-readiness.md
@@ -68,6 +68,18 @@ Parsing a valid raw JSON object allows interoperability when an HTTP adapter did
 not decode the body because the server sent an incorrect or missing content
 type. Safire's tolerance does not make that server response conformant.
 
+Metadata capability helpers type-check list-shaped advertisements before using
+membership semantics. A malformed list cannot assert a SMART capability or
+raise an unexpected type error. The complete structural assessment remains the
+caller's explicit `SmartMetadata#valid?` diagnostic rather than an automatic
+discovery failure.
+
+SMART discovery preserves metadata for inspection, but an operation validates
+its discovered authorization or token endpoint against Safire's HTTPS policy
+before use. This focused runtime stop protects authorization data and client
+credentials without promoting unrelated metadata defects into discovery
+failures.
+
 UDAP DCR uses focused readiness rather than calling `UdapMetadata#valid?` as an
 operational gate. Safire requires trusted discovery, an advertised `udap_dcr`
 profile, a usable authoritative registration endpoint, usable registration
@@ -111,28 +123,66 @@ cannot safely redact. Count-and-category logging preserves the operational and
 migration signal without copying caller-controlled authorization details into
 application logs.
 
+The classifications below were checked against the published
+[SMART App Launch STU2.2 conformance and discovery rules](https://hl7.org/fhir/smart-app-launch/STU2.2/conformance.html),
+[SMART App Launch workflow](https://hl7.org/fhir/smart-app-launch/STU2.2/app-launch.html),
+[SMART Backend Services profile](https://hl7.org/fhir/smart-app-launch/STU2.2/backend-services.html),
+[RFC 7591 Dynamic Client Registration](https://www.rfc-editor.org/rfc/rfc7591),
+[UDAP Security STU2 discovery](https://hl7.org/fhir/us/udap-security/STU2/discovery.html),
+and [UDAP Security STU2 registration](https://hl7.org/fhir/us/udap-security/STU2/registration.html).
+
 ## Operation Matrix
 
 This matrix covers the public protocol operations currently implemented by the
 `Safire::Client` facade.
 
-| Protocol operation | Runtime hard failures | Warning or explicit diagnostic | Server-owned decision |
-|--------------------|-----------------------|--------------------------------|-----------------------|
-| SMART `server_metadata` | Transport/HTTP failure or a body that cannot be used as a JSON object | `SmartMetadata#valid?` is caller-invoked | Advertised capabilities |
-| SMART `authorization_url` | Invalid method; missing client ID, scopes, redirect URI, or usable authorization endpoint | Metadata diagnostics remain explicit | User authorization, launch context, and granted scopes |
-| SMART `request_access_token` | Missing client credentials; unusable token endpoint; OAuth error; malformed token response or missing access token | `token_response_valid?` is caller-invoked | Code acceptance and issued token contents |
-| SMART `refresh_token` | Missing client credentials; unusable token endpoint; OAuth error; malformed token response or missing access token | `token_response_valid?` is caller-invoked | Refresh-token acceptance and issued scope |
-| SMART `request_backend_token` | Missing client ID or signing credentials; unusable token endpoint; OAuth error; malformed token response or missing access token | The v0.4.x missing-scope fallback warns; `token_response_valid?(flow: :backend_services)` is caller-invoked | Out-of-band context, client authentication, requested scope, and token issuance |
-| SMART `register_client` | Missing or unsafe registration endpoint; OAuth error; malformed response or missing/invalid client ID | SMART metadata diagnostics remain explicit | Registration policy and issued credentials |
-| SMART `token_response_valid?` | None; this is not an operational gate | Warns and returns `false` for response conformance defects | Caller decides whether a failed diagnostic is acceptable |
-| UDAP `server_metadata` | Transport/HTTP/204 failure; non-object JSON; failed signed-metadata signature, chain, revocation, issuer, time, or endpoint validation | `UdapMetadata#valid?` is caller-invoked | Supported communities, profiles, and capabilities |
-| UDAP `register_client` | Untrusted discovery; unusable DCR profile, endpoint, algorithm, or certification-requirement metadata; invalid client metadata, signing identity, or response; server rejection | Missing RS256 and unconfirmed scope support warn; `UdapMetadata#valid?` remains caller-invoked | Registration policy, scope and certification acceptance, and issued client ID |
-| UDAP `cancel_registration` | The registration gates above plus a response that does not positively confirm the client ID and empty grants | Scope compatibility remains warning-only for lifecycle-safe cleanup; `UdapMetadata#valid?` remains caller-invoked | Cancellation policy and confirmation response |
+| Operation | Client obligation | Required capability or input | Runtime hard failure | Runtime warning or negotiation | Explicit diagnostic | Server-owned decision |
+|-----------|-------------------|------------------------------|----------------------|--------------------------------|---------------------|-----------------------|
+| SMART `server_metadata` | Request and consume the well-known JSON object over a protected connection | FHIR base URL | Transport or HTTP failure; unusable JSON-object body | None | Caller may invoke `SmartMetadata#valid?` | Advertised endpoints and capabilities |
+| SMART `authorization_url` | Supply client ID, redirect URI, scopes, and launch context as applicable; Safire adds state and S256 PKCE | Usable authorization endpoint; caller selects GET or POST | Invalid request method; missing client ID, scopes, or redirect URI; missing, malformed, or insecure endpoint | None | Metadata capability helpers and `SmartMetadata#valid?` remain caller-invoked | User authorization, launch context, accepted request method, and granted scopes |
+| SMART `request_access_token` | Supply the authorization code, matching PKCE verifier, redirect URI, and client credentials required by the configured client type | Usable token endpoint | Missing credentials; invalid JWT assertion configuration; missing, malformed, or insecure endpoint; transport, OAuth, unusable response, or missing access-token failure | None | Caller may invoke `token_response_valid?` | Code acceptance and issued token contents |
+| SMART `refresh_token` | Supply the refresh token and authenticate the client; any requested scopes must not exceed the original grant | Usable token endpoint | Missing credentials; invalid JWT assertion configuration; missing, malformed, or insecure endpoint; transport, OAuth, unusable response, or missing access-token failure | None | Caller may invoke `token_response_valid?` | Refresh-token acceptance and issued scope |
+| SMART `request_backend_token` | Supply client ID, a registered signing identity, and explicit scope intent | Usable token endpoint and pre-authorized asymmetric client registration | Missing identity or signing credentials; invalid JWT assertion configuration; missing, malformed, or insecure endpoint; transport, OAuth, unusable response, or missing access-token failure | The v0.4.x legacy scope fallback warns; explicit scopes remain subject to server negotiation | Caller may invoke `token_response_valid?(flow: :backend_services)` | Out-of-band context, client authentication, requested scope, and token issuance |
+| SMART `register_client` | Supply RFC 7591 client metadata and any required initial access token | Explicit or discovered HTTPS registration endpoint | Missing or unsafe endpoint; transport or OAuth failure; unusable response or missing/invalid client ID | None | Discovery capability helpers and `SmartMetadata#valid?` remain caller-invoked | Registration policy, accepted metadata, and issued credentials |
+| SMART `token_response_valid?` | Choose whether to require the optional conformance diagnostic | Token-response Hash and selected flow | None; this method is not an operational gate | Logs each diagnosed response defect and returns `false` | This method is the explicit diagnostic | Caller decides how to handle a failed diagnostic |
+| UDAP `server_metadata` | Supply the intended community and production trust/revocation policy; validate signed metadata before any later workflow | UDAP well-known endpoint and a trusted signed-metadata chain | Transport, HTTP, or 204 outcome; unusable JSON object; failed signature, chain, revocation, issuer, time, or endpoint validation | None | Caller may invoke `UdapMetadata#valid?` or explicitly re-run `signed_metadata_valid?` | Community-specific profiles and capabilities |
+| UDAP `register_client` | Supply conformant metadata, client URI, certifications when required, and a matching private key/certificate chain | Trusted discovery; `udap_dcr`; authoritative registration endpoint; usable algorithm and certification-requirement metadata | Unsafe or unusable readiness data; invalid caller metadata or signing identity; transport or server rejection; pending or malformed completion response | Missing RS256 advertisement and unconfirmed scope support warn in v0.4.1 | Caller may invoke `UdapMetadata#valid?`; it is not a blanket gate | Registration policy, scope and certification acceptance, effective metadata, and issued client ID |
+| UDAP `cancel_registration` | Supply the same stable client URI and trust-community identity; preserve local state until cancellation is confirmed | Registration readiness above and an existing registration to remove | Registration hard failures above; any response that does not provide final 2xx body confirmation with the client ID and empty grants | Scope compatibility and malformed scope advertisements remain warning-only so cleanup can proceed | Caller may invoke `UdapMetadata#valid?`; it is not a blanket gate | Cancellation policy and the confirmation response |
 
 SMART cancellation and UDAP authorization, token, refresh, backend-token, and
 token-response operations are not implemented. They raise
 `NotImplementedError` through the shared protocol contract rather than implying
 runtime support.
+
+### Rules for Future Operations
+
+Every new public protocol operation must update the matrix and apply these
+questions in order:
+
+1. Which normative actor owns the requirement: client, authorization server,
+   resource server, or trust community?
+2. Does a failure prevent Safire from constructing a conformant request,
+   selecting a trusted endpoint, protecting credentials, or confirming the
+   operation's result? If so, fail before signing or network activity whenever
+   the condition is locally knowable.
+3. Can Safire still send a safe, conformant request while the server remains
+   authoritative for policy or negotiation? If so, preserve the request and use
+   a warning only when it gives the caller actionable information.
+4. Is the check broad server conformance rather than operation readiness? Keep
+   it in an explicit diagnostic and do not call it automatically.
+5. Is untrusted response data consumed by the operation? Validate its type and
+   shape before use, and translate failure into the protocol-specific Safire
+   error rather than leaking a Ruby implementation exception.
+6. Does an error prove rejection, or only an unavailable, malformed, pending,
+   or otherwise unconfirmed outcome? Use only the strongest description the
+   evidence supports.
+7. Does the implementation invent client intent, retry a possibly committed
+   operation, or log caller credentials or authorization details? If so, stop
+   and require an explicit, documented policy instead.
+
+Shared helpers may encode mechanism, such as JSON-object parsing or
+warning-only UDAP scope coverage, but must not silently promote a diagnostic
+inference into a hard-failure rule for another workflow.
 
 ## Consequences
 

--- a/docs/configuration/client-setup.md
+++ b/docs/configuration/client-setup.md
@@ -211,6 +211,8 @@ raises `Safire::Errors::ConfigurationError` for invalid configuration URIs:
 
 - URIs must be well-formed (scheme + host required)
 - URIs must use `https` — required for SMART App Launch and UDAP discovery
+- OAuth `redirect_uri`, `authorization_endpoint`, and `token_endpoint` values
+  must not contain a fragment component
 - **Development exception:** `http` loopback URIs (`localhost` and `127.0.0.1`)
   are permitted only when `allow_insecure_localhost: true` is configured
 

--- a/docs/smart-on-fhir/discovery/capability-checks.md
+++ b/docs/smart-on-fhir/discovery/capability-checks.md
@@ -20,7 +20,13 @@ nav_order: 2
 
 ## Full Checks (`supports_*?`)
 
-These methods verify both the capability flag **and** any required associated fields. Use them to confirm the server is fully ready for a given mode.
+These methods verify both the capability flag **and** the presence of any
+required associated fields. They do not replace the HTTPS validation Safire
+performs when an operation uses a discovered endpoint.
+
+List-valued advertisements must use their documented array shape. A malformed
+scalar or an array containing non-string entries is treated as unsupported;
+call `valid?` to log the corresponding structural diagnostic.
 
 ```ruby
 # Launch modes — requires capability flag AND authorization_endpoint present

--- a/docs/smart-on-fhir/discovery/index.md
+++ b/docs/smart-on-fhir/discovery/index.md
@@ -56,8 +56,9 @@ valid JSON arrays, scalars, booleans, or `null` raise `DiscoveryError`.
 
 Discovery readers preserve advertised endpoint values for inspection. Before
 an authorization or token operation uses a discovered endpoint, Safire requires
-an absolute HTTPS URI. HTTP loopback endpoints are accepted only with the
-explicit `allow_insecure_localhost: true` development policy.
+an absolute HTTPS URI without a fragment component. HTTP loopback endpoints are
+accepted only with the explicit `allow_insecure_localhost: true` development
+policy; the fragment prohibition still applies.
 
 ---
 

--- a/docs/smart-on-fhir/discovery/index.md
+++ b/docs/smart-on-fhir/discovery/index.md
@@ -42,13 +42,22 @@ metadata = client.server_metadata
 # => #<Safire::Protocols::SmartMetadata ...>
 ```
 
-`server_metadata` returns a `Safire::Protocols::SmartMetadata` object with typed accessors for all fields. See [Metadata Fields and Validation]({% link smart-on-fhir/discovery/metadata.md %}) for the full field reference and validation rules.
+`server_metadata` returns a `Safire::Protocols::SmartMetadata` object with
+readers for all fields. Values retain the shapes sent by the server; use
+`valid?` for the explicit structural diagnostic. See
+[Metadata Fields and Validation]({% link smart-on-fhir/discovery/metadata.md %})
+for the full field reference and validation rules.
 
 Safire accepts either an already parsed Hash or a raw JSON-object body. This
 keeps discovery usable when a server sends valid JSON with an incorrect or
 missing content type and Faraday therefore leaves the body as a String. The
 server response is still non-conformant at the HTTP layer. Malformed JSON and
 valid JSON arrays, scalars, booleans, or `null` raise `DiscoveryError`.
+
+Discovery readers preserve advertised endpoint values for inspection. Before
+an authorization or token operation uses a discovered endpoint, Safire requires
+an absolute HTTPS URI. HTTP loopback endpoints are accepted only with the
+explicit `allow_insecure_localhost: true` development policy.
 
 ---
 

--- a/docs/smart-on-fhir/discovery/metadata.md
+++ b/docs/smart-on-fhir/discovery/metadata.md
@@ -20,7 +20,10 @@ nav_order: 1
 
 ## Field Reference
 
-`server_metadata` returns a `Safire::Protocols::SmartMetadata` object. All fields are accessible as typed readers.
+`server_metadata` returns a `Safire::Protocols::SmartMetadata` object. All
+fields are accessible through readers and retain the representation sent by the
+server. The types below describe the expected SMART metadata shapes; call
+`valid?` to diagnose malformed values.
 
 ### Always Required
 
@@ -85,7 +88,10 @@ metadata.user_access_brand_identifier      # => "example-brand"
 
 ## Validation
 
-`valid?` checks conformance with SMART App Launch 2.2.0 and logs a warning for each violation. It never raises — deciding whether to block on non-compliant metadata is the caller's responsibility.
+`valid?` checks Safire's selected SMART App Launch 2.2.0 structural diagnostics
+and logs a warning for each violation. It is not a complete server certification
+suite and never raises. Deciding whether to block on a failed diagnostic is the
+caller's responsibility.
 
 ```ruby
 if metadata.valid?
@@ -99,13 +105,21 @@ end
 **What `valid?` checks:**
 - All always-required fields are present
 - Conditional fields present when their capability is advertised
+- Array-valued fields are arrays containing values of the documented type
 - `code_challenge_methods_supported` includes `'S256'` (SHALL per SMART 2.2.0)
 - `code_challenge_methods_supported` does not include `'plain'` (SHALL NOT per SMART 2.2.0)
+
+Discovery does not fail solely because a usable JSON object contains a
+structurally nonconformant field. `valid?` reports that defect explicitly.
+Capability and algorithm helpers treat malformed list advertisements as
+unsupported rather than using scalar substring matching or raising an
+unexpected type error.
 
 Example warning output:
 
 ```
 WARN: SMART metadata non-compliance: required field 'authorization_endpoint' is missing
+WARN: SMART metadata non-compliance: field 'capabilities' must be an array containing only strings
 WARN: SMART metadata non-compliance: 'S256' is missing from code_challenge_methods_supported (SMART App Launch 2.2.0 requires S256)
 WARN: SMART metadata non-compliance: 'plain' is present in code_challenge_methods_supported (SMART App Launch 2.2.0 prohibits plain)
 ```

--- a/docs/troubleshooting/auth-errors.md
+++ b/docs/troubleshooting/auth-errors.md
@@ -78,6 +78,11 @@ Missing metadata fields are handled separately from body parsing.
 explicit structural diagnostic. An authorization or token operation raises only
 when an endpoint or capability required by that operation is unavailable.
 
+A discovered `authorization_endpoint` or `token_endpoint` must also be an
+absolute HTTPS URI before Safire uses it. An invalid or insecure discovered
+endpoint raises `DiscoveryError`; HTTP loopback endpoints are accepted only
+with the explicit `allow_insecure_localhost: true` development policy.
+
 ---
 
 ## Authorization Errors

--- a/docs/troubleshooting/auth-errors.md
+++ b/docs/troubleshooting/auth-errors.md
@@ -79,9 +79,10 @@ explicit structural diagnostic. An authorization or token operation raises only
 when an endpoint or capability required by that operation is unavailable.
 
 A discovered `authorization_endpoint` or `token_endpoint` must also be an
-absolute HTTPS URI before Safire uses it. An invalid or insecure discovered
-endpoint raises `DiscoveryError`; HTTP loopback endpoints are accepted only
-with the explicit `allow_insecure_localhost: true` development policy.
+absolute HTTPS URI without a fragment component before Safire uses it. An
+invalid or insecure discovered endpoint raises `DiscoveryError`; HTTP loopback
+endpoints are accepted only with the explicit `allow_insecure_localhost: true`
+development policy.
 
 ---
 

--- a/docs/troubleshooting/client-errors.md
+++ b/docs/troubleshooting/client-errors.md
@@ -177,11 +177,12 @@ cancellation['grant_types'] # => []
 
 A non-`2xx` response does not confirm cancellation; inspect any preserved OAuth
 error code and description to determine whether the server explicitly rejected
-the request. If a final `2xx` response omits `grant_types`, returns a non-array
-value, or returns a non-empty array, the outcome is unconfirmed rather than
-rejected. Safire does not retry automatically; preserve the stored registration
-state and inspect the authorization server before retrying or discarding the
-`client_id`.
+the request. A non-`2xx` response without an OAuth error is reported as an
+unconfirmed outcome; Safire does not infer rejection from status alone. If a
+final `2xx` response omits `grant_types`, returns a non-array value, or returns a
+non-empty array, the outcome is also unconfirmed rather than rejected. Safire
+does not retry automatically; preserve the stored registration state and
+inspect the authorization server before retrying or discarding the `client_id`.
 
 ---
 

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -32,7 +32,7 @@ Safire raises typed errors so you can handle each failure category separately:
 | `Safire::Errors::DiscoveryError` | SMART or UDAP metadata discovery failed (HTTP error, invalid JSON, missing SMART `token_endpoint` when required, or UDAP `signed_metadata` validation failure) |
 | `Safire::Errors::ValidationError` | Caller-controlled input is invalid before a request is sent, such as UDAP registration metadata or certification JWT shape |
 | `Safire::Errors::CertificateError` | UDAP `x5c` certificate data could not be parsed or the configured UDAP client certificate chain cannot support signing |
-| `Safire::Errors::RegistrationError` | Dynamic Client Registration failed (server error, 2xx response with a missing or invalid `client_id`, or UDAP cancellation response without an empty `grant_types` array) |
+| `Safire::Errors::RegistrationError` | Dynamic Client Registration was rejected or not confirmed (server error, pending UDAP registration, unusable response, or UDAP cancellation without final 2xx body confirmation) |
 | `Safire::Errors::TokenError` | Token exchange or refresh failed (OAuth error, missing fields) |
 | `Safire::Errors::NetworkError` | Transport-level failure (connection refused, timeout, blocked redirect) |
 
@@ -68,6 +68,15 @@ response content type prevents Faraday from decoding the body. That tolerance
 does not make the server response conformant. Malformed JSON, JSON arrays or
 scalars, and adapter-provided Hashes with ambiguous normalized keys, cycles, or
 non-JSON-compatible values are treated as unusable JSON-object responses.
+
+A usable JSON object with malformed SMART field types is still returned for
+interoperability. `SmartMetadata#valid?` logs the structural defects and returns
+`false`; capability helpers treat malformed list advertisements as unsupported
+instead of raising.
+
+Authorization and token operations raise `DiscoveryError` before use when a
+discovered endpoint is malformed or violates the HTTPS policy. HTTP loopback
+endpoints require `allow_insecure_localhost: true` and remain development-only.
 
 ```ruby
 begin

--- a/docs/udap.md
+++ b/docs/udap.md
@@ -141,10 +141,13 @@ an existing metadata object against another trust policy. Metadata returned by
 
 ## Dynamic Client Registration
 
-UDAP DCR is discovery-bound. Safire validates discovery metadata, signs
-caller-controlled registration metadata into a short-lived X.509-backed
-`software_statement`, and POSTs the fixed UDAP envelope to the authoritative
-signed `registration_endpoint`.
+UDAP DCR is discovery-bound. Safire validates `signed_metadata` and the focused
+profile, endpoint, algorithm, certification, and scope values needed by the
+request; full structural conformance remains available through the explicit
+`UdapMetadata#valid?` diagnostic. Safire then signs caller-controlled
+registration metadata into a short-lived X.509-backed `software_statement` and
+POSTs the fixed UDAP envelope to the authoritative signed
+`registration_endpoint`.
 
 ```ruby
 client = Safire::Client.new(

--- a/docs/udap/dynamic-client-registration/index.md
+++ b/docs/udap/dynamic-client-registration/index.md
@@ -194,7 +194,7 @@ the software statement.
 | `Safire::Errors::ValidationError` | Caller metadata or certification input is invalid before signing |
 | `Safire::Errors::ConfigurationError` | Signing configuration or algorithm selection is missing or incompatible |
 | `Safire::Errors::CertificateError` | The client key, certificate chain, validity period, ordering, or URI SAN cannot support signing |
-| `Safire::Errors::RegistrationError` | The server rejects the request or returns a malformed lifecycle response |
+| `Safire::Errors::RegistrationError` | The server rejects the request or does not return a usable response that confirms the lifecycle outcome |
 | `Safire::Errors::NetworkError` | The request fails at the transport layer |
 
 Continue with [Software Statements]({% link udap/dynamic-client-registration/software-statement.md %})

--- a/docs/udap/dynamic-client-registration/lifecycle.md
+++ b/docs/udap/dynamic-client-registration/lifecycle.md
@@ -108,12 +108,13 @@ Unlike registration, Safire does not require a specific success status such as
 successful `2xx`. UDAP Security STU2 confirms cancellation through the response
 body: the response must contain a non-blank string `client_id` and an empty
 `grant_types` array. A final non-`2xx` status raises
-`Safire::Errors::RegistrationError` and preserves any OAuth error returned by
-the server. A final `2xx` response with a non-empty, missing, or non-array
-`grant_types` value also raises `RegistrationError`, but in that case the
-cancellation outcome is unconfirmed rather than rejected. Applications should
-preserve their local registration state and inspect the authorization server
-before retrying or discarding the stored `client_id`.
+`Safire::Errors::RegistrationError`. Safire preserves an OAuth error when the
+server supplies one; otherwise it reports only that the response did not
+confirm cancellation. A final `2xx` response with a non-empty, missing, or
+non-array `grant_types` value also raises `RegistrationError`, but in that case
+the cancellation outcome is unconfirmed rather than rejected. Applications
+should preserve their local registration state and inspect the authorization
+server before retrying or discarding the stored `client_id`.
 
 ## Error Boundaries
 
@@ -125,7 +126,7 @@ Both lifecycle methods raise the same Safire error families:
 | `Safire::Errors::ValidationError` | Caller metadata or `certifications:` failed local validation before signing |
 | `Safire::Errors::ConfigurationError` | Signing configuration is missing or incompatible |
 | `Safire::Errors::CertificateError` | The private key, certificate chain, validity period, or `client_uri` SAN check failed |
-| `Safire::Errors::RegistrationError` | The registration endpoint returned an OAuth error, an unconfirmed pending outcome, or a malformed completed response |
+| `Safire::Errors::RegistrationError` | The registration endpoint returned an OAuth error or did not provide a usable response that confirms the lifecycle outcome |
 | `Safire::Errors::NetworkError` | The request failed at the transport layer |
 
 OAuth-style server errors preserve the server's `error` and

--- a/docs/udap/dynamic-client-registration/registration-metadata.md
+++ b/docs/udap/dynamic-client-registration/registration-metadata.md
@@ -52,7 +52,7 @@ and `to_h` returns a defensive copy.
 | `contacts` | Required non-empty array of absolute URI strings, including at least one valid `mailto:` email address |
 | `grant_types` | Required for registration; must match one supported grant profile |
 | `scope` | Required non-blank, space-delimited OAuth scope string |
-| `redirect_uris` | Required only with `authorization_code`; every value uses HTTPS by default |
+| `redirect_uris` | Required only with `authorization_code`; every value uses HTTPS by default and contains no fragment component |
 | `logo_uri` | Required only with `authorization_code`; uses HTTPS by default, and the caller must ensure it references PNG, JPEG/JPG, or GIF content (not locally verifiable by Safire) |
 | `response_types` | Generated as `["code"]` for `authorization_code` |
 | `token_endpoint_auth_method` | Generated as `"private_key_jwt"` |
@@ -98,7 +98,8 @@ cancellation.to_h['grant_types'] # => []
 
 ## URI and Ownership Rules
 
-UDAP Security STU2 requires HTTPS for `redirect_uris` and `logo_uri`. Safire
+UDAP Security STU2 requires HTTPS for `redirect_uris` and `logo_uri`; OAuth
+redirect URIs must not contain fragment components. Safire
 enforces that requirement by default. For an HTTP loopback service used only in
 local development, applications may explicitly enable the narrow exception:
 

--- a/lib/safire/client_config.rb
+++ b/lib/safire/client_config.rb
@@ -107,7 +107,9 @@ module Safire
     SENSITIVE_ATTRIBUTES = %i[client_secret private_key certificate_chain].freeze
     URI_ATTRS = %i[base_url redirect_uri issuer authorization_endpoint token_endpoint jwks_uri].freeze
     OPTIONAL_URI_ATTRS = %i[redirect_uri authorization_endpoint token_endpoint jwks_uri].freeze
-    private_constant :CERTIFICATE_CHAIN_ENTRY_TYPES, :SENSITIVE_ATTRIBUTES, :URI_ATTRS, :OPTIONAL_URI_ATTRS
+    FRAGMENTLESS_URI_ATTRS = %i[redirect_uri authorization_endpoint token_endpoint].freeze
+    private_constant :CERTIFICATE_CHAIN_ENTRY_TYPES, :SENSITIVE_ATTRIBUTES, :URI_ATTRS, :OPTIONAL_URI_ATTRS,
+                     :FRAGMENTLESS_URI_ATTRS
 
     # @api private
     def inspect
@@ -215,8 +217,12 @@ module Safire
         value = send(attr)
         next if value.nil? && OPTIONAL_URI_ATTRS.include?(attr)
 
-        case classify_uri(value, allow_insecure_localhost:)
-        when :invalid   then invalid_uris << attr
+        case classify_uri(
+          value,
+          allow_insecure_localhost:,
+          allow_fragment: !FRAGMENTLESS_URI_ATTRS.include?(attr)
+        )
+        when :invalid, :fragment then invalid_uris << attr
         when :non_https then non_https_uris << attr
         end
       end

--- a/lib/safire/protocols/smart.rb
+++ b/lib/safire/protocols/smart.rb
@@ -50,7 +50,7 @@ module Safire
       end
 
       def authorization_endpoint
-        @authorization_endpoint ||= server_metadata.authorization_endpoint
+        @authorization_endpoint ||= discovered_authorization_endpoint
       end
 
       def token_endpoint
@@ -70,7 +70,7 @@ module Safire
       # @return [Safire::Protocols::SmartMetadata]
       #   Parsed SMART configuration metadata object.
       # @raise [Safire::Errors::DiscoveryError]
-      #   If the discovery request fails or the response is not a valid JSON object.
+      #   If the discovery request fails or the response is not a usable JSON object.
       def server_metadata
         return @server_metadata if @server_metadata
 
@@ -98,8 +98,10 @@ module Safire
       #   * :params [Hash] (POST only) authorization parameters to submit as the request body
       # @raise [Errors::ConfigurationError] if method is invalid, +client_id+/scopes are missing,
       #   or +redirect_uri+ / +authorization_endpoint+ are not configured or resolvable via discovery
+      # @raise [Errors::DiscoveryError] if a discovered +authorization_endpoint+ is not a usable
+      #   HTTPS URI; HTTP loopback endpoints require the explicit development policy
       def authorization_url(launch: nil, custom_scopes: nil, method: :get)
-        method = method.to_sym
+        method = method.to_sym if method.is_a?(String)
         custom_scopes ||= scopes
         validate_authorization_method(method)
         validate_client_id!
@@ -132,6 +134,7 @@ module Safire
       # @raise [Safire::Errors::ConfigurationError] if +client_id+ is missing,
       #   or if +private_key+/+kid+ are absent for +:confidential_asymmetric+
       # @raise [Safire::Errors::TokenError] if the request fails or response is invalid.
+      # @raise [Safire::Errors::DiscoveryError] if a discovered +token_endpoint+ is missing or unusable.
       # @raise [Safire::Errors::NetworkError] on connection failure, timeout, or SSL error.
       def request_access_token(code:, code_verifier:, client_secret: self.client_secret,
                                private_key: self.private_key, kid: self.kid)
@@ -162,6 +165,7 @@ module Safire
       # @raise [Safire::Errors::ConfigurationError] if +client_id+ is missing,
       #   or if +private_key+/+kid+ are absent for +:confidential_asymmetric+
       # @raise [Safire::Errors::TokenError] if the refresh request fails or the response is invalid.
+      # @raise [Safire::Errors::DiscoveryError] if a discovered +token_endpoint+ is missing or unusable.
       # @raise [Safire::Errors::NetworkError] on connection failure, timeout, or SSL error.
       def refresh_token(refresh_token:, scopes: nil, client_secret: self.client_secret,
                         private_key: self.private_key, kid: self.kid)
@@ -205,6 +209,7 @@ module Safire
       # @raise [Safire::Errors::ConfigurationError] if +client_id+, +private_key+, or +kid+ are missing
       # @raise [ArgumentError] if the signing key or JWT assertion configuration is invalid
       # @raise [Safire::Errors::TokenError] if the server returns an error or invalid response
+      # @raise [Safire::Errors::DiscoveryError] if a discovered +token_endpoint+ is missing or unusable
       # @raise [Safire::Errors::NetworkError] on connection failure, timeout, or SSL error
       def request_backend_token(scopes: nil, private_key: self.private_key, kid: self.kid)
         validate_client_id!
@@ -522,11 +527,34 @@ module Safire
 
       def discovered_token_endpoint
         endpoint = server_metadata.token_endpoint
-        return endpoint if endpoint.present?
+        return validate_discovered_endpoint!(endpoint, :token_endpoint) unless endpoint.nil?
 
         raise Errors::DiscoveryError.new(
           endpoint: well_known_endpoint,
           error_description: "response missing required field 'token_endpoint'"
+        )
+      end
+
+      def discovered_authorization_endpoint
+        endpoint = server_metadata.authorization_endpoint
+        return if endpoint.nil?
+
+        validate_discovered_endpoint!(endpoint, :authorization_endpoint)
+      end
+
+      def validate_discovered_endpoint!(endpoint, attribute)
+        error_description = case classify_uri(endpoint, allow_insecure_localhost:)
+                            when :invalid
+                              "response field '#{attribute}' must be an absolute URI"
+                            when :non_https
+                              "response field '#{attribute}' must use HTTPS"
+                            else
+                              return endpoint
+                            end
+
+        raise Errors::DiscoveryError.new(
+          endpoint: well_known_endpoint,
+          error_description:
         )
       end
 

--- a/lib/safire/protocols/smart.rb
+++ b/lib/safire/protocols/smart.rb
@@ -543,9 +543,11 @@ module Safire
       end
 
       def validate_discovered_endpoint!(endpoint, attribute)
-        error_description = case classify_uri(endpoint, allow_insecure_localhost:)
+        error_description = case classify_uri(endpoint, allow_insecure_localhost:, allow_fragment: false)
                             when :invalid
                               "response field '#{attribute}' must be an absolute URI"
+                            when :fragment
+                              "response field '#{attribute}' must not include a fragment"
                             when :non_https
                               "response field '#{attribute}' must use HTTPS"
                             else
@@ -571,8 +573,9 @@ module Safire
       end
 
       def validate_registration_endpoint_https!(endpoint)
-        case classify_uri(endpoint, allow_insecure_localhost:)
-        when :invalid   then raise Errors::ConfigurationError.new(invalid_uri_attributes: [:registration_endpoint])
+        case classify_uri(endpoint, allow_insecure_localhost:, allow_fragment: false)
+        when :invalid, :fragment
+          raise Errors::ConfigurationError.new(invalid_uri_attributes: [:registration_endpoint])
         when :non_https then raise Errors::ConfigurationError.new(non_https_uri_attributes: [:registration_endpoint])
         end
       end

--- a/lib/safire/protocols/smart_metadata.rb
+++ b/lib/safire/protocols/smart_metadata.rb
@@ -74,6 +74,18 @@ module Safire
 
       ATTRIBUTES = (REQUIRED_ATTRIBUTES | OPTIONAL_ATTRIBUTES).freeze
 
+      ARRAY_ATTRIBUTE_ELEMENT_TYPES = {
+        grant_types_supported: String,
+        token_endpoint_auth_methods_supported: String,
+        token_endpoint_auth_signing_alg_values_supported: String,
+        associated_endpoints: Hash,
+        scopes_supported: String,
+        response_types_supported: String,
+        capabilities: String,
+        code_challenge_methods_supported: String
+      }.freeze
+      private_constant :ARRAY_ATTRIBUTE_ELEMENT_TYPES
+
       # Supported asymmetric signing algorithms (required by SMART spec)
       SUPPORTED_ASYMMETRIC_ALGORITHMS = %w[RS384 ES384].freeze
 
@@ -83,17 +95,19 @@ module Safire
         super(metadata, ATTRIBUTES)
       end
 
-      # Checks whether the server's SMART metadata is valid according to SMART App Launch 2.2.0.
+      # Runs Safire's selected SMART App Launch 2.2.0 structural diagnostics.
       #
       # This is a user-callable helper. Safire performs discovery without automatically
       # asserting server compliance — it is the caller's responsibility to invoke this
-      # method when they wish to verify conformance.
+      # method when they wish to inspect these conformance signals. This helper is
+      # not a complete server certification suite.
       #
       # Checks performed:
       # - All required fields are present
       #   (token_endpoint, grant_types_supported, capabilities, code_challenge_methods_supported)
       # - Conditional fields present when their capability is advertised
       #   (issuer + jwks_uri for sso-openid-connect; authorization_endpoint for launch types)
+      # - Array-valued fields are arrays containing values of the documented type
       # - `code_challenge_methods_supported` includes 'S256'
       #   (SMART App Launch 2.2.0, §Conformance — SHALL be included)
       # - `code_challenge_methods_supported` does NOT include 'plain'
@@ -112,9 +126,10 @@ module Safire
           Safire.logger.warn("SMART metadata non-compliance: required field '#{attr}' is missing")
         end
 
+        array_fields_valid = validate_array_fields!
         pkce_valid = validate_pkce_methods!
 
-        missing_attrs.empty? && pkce_valid
+        missing_attrs.empty? && array_fields_valid && pkce_valid
       end
 
       # Launch type support checks - requires both capability and authorization_endpoint
@@ -139,16 +154,14 @@ module Safire
       # @return [Boolean] true if server has capability and auth methods not advertised or includes client_secret_basic
       def supports_symmetric_auth?
         capability?('client-confidential-symmetric') &&
-          (token_endpoint_auth_methods_supported.blank? ||
-           token_endpoint_auth_methods_supported.include?('client_secret_basic'))
+          auth_method_supported?('client_secret_basic')
       end
 
       # Checks if the server supports the SMART Backend Services workflow.
       # @return [Boolean] true if the server advertises the client_credentials grant type
       #   and supports private_key_jwt authentication (via {#supports_asymmetric_auth?})
       def supports_backend_services?
-        grant_types_supported.present? &&
-          grant_types_supported.include?('client_credentials') &&
+        array_includes?(:grant_types_supported, 'client_credentials') &&
           supports_asymmetric_auth?
       end
 
@@ -157,8 +170,7 @@ module Safire
       #   and has supported algorithms
       def supports_asymmetric_auth?
         capability?('client-confidential-asymmetric') &&
-          (token_endpoint_auth_methods_supported.blank? ||
-           token_endpoint_auth_methods_supported.include?('private_key_jwt')) &&
+          auth_method_supported?('private_key_jwt') &&
           asymmetric_signing_algorithms_supported.any?
       end
 
@@ -166,8 +178,11 @@ module Safire
       # If the server doesn't advertise algorithms, assumes it supports the required ones (RS384, ES384).
       # @return [Array<String>] list of supported algorithms
       def asymmetric_signing_algorithms_supported
-        server_algs = token_endpoint_auth_signing_alg_values_supported.presence
-        (server_algs || SUPPORTED_ASYMMETRIC_ALGORITHMS) & SUPPORTED_ASYMMETRIC_ALGORITHMS
+        server_algs = token_endpoint_auth_signing_alg_values_supported
+        return SUPPORTED_ASYMMETRIC_ALGORITHMS.dup if server_algs.nil? || server_algs == []
+        return [] unless array_of?(server_algs, String)
+
+        server_algs & SUPPORTED_ASYMMETRIC_ALGORITHMS
       end
 
       # Feature support checks
@@ -203,7 +218,39 @@ module Safire
       private
 
       def capability?(name)
-        capabilities&.include?(name)
+        array_includes?(:capabilities, name)
+      end
+
+      def array_includes?(attribute, value)
+        values = public_send(attribute)
+        array_of?(values, String) && values.include?(value)
+      end
+
+      def auth_method_supported?(method)
+        methods = token_endpoint_auth_methods_supported
+        methods.nil? || methods == [] || array_includes?(:token_endpoint_auth_methods_supported, method)
+      end
+
+      def validate_array_fields!
+        valid = true
+
+        ARRAY_ATTRIBUTE_ELEMENT_TYPES.each do |attribute, element_type|
+          value = public_send(attribute)
+          next if value.nil?
+          next if array_of?(value, element_type)
+
+          Safire.logger.warn(
+            "SMART metadata non-compliance: field '#{attribute}' must be an array containing only " \
+            "#{element_type == Hash ? 'objects' : 'strings'}"
+          )
+          valid = false
+        end
+
+        valid
+      end
+
+      def array_of?(value, element_type)
+        value.is_a?(Array) && value.all?(element_type)
       end
 
       def issuer_and_jwks_uri_required?
@@ -220,10 +267,9 @@ module Safire
       #
       # @return [Boolean] true if both conditions are satisfied
       def validate_pkce_methods!
-        methods = code_challenge_methods_supported
         valid = true
 
-        unless methods&.include?('S256')
+        unless array_includes?(:code_challenge_methods_supported, 'S256')
           Safire.logger.warn(
             "SMART metadata non-compliance: 'S256' is missing from code_challenge_methods_supported " \
             '(SMART App Launch 2.2.0 requires S256)'
@@ -231,7 +277,7 @@ module Safire
           valid = false
         end
 
-        if methods&.include?('plain')
+        if array_includes?(:code_challenge_methods_supported, 'plain')
           Safire.logger.warn(
             "SMART metadata non-compliance: 'plain' is present in code_challenge_methods_supported " \
             '(SMART App Launch 2.2.0 prohibits plain)'

--- a/lib/safire/protocols/udap.rb
+++ b/lib/safire/protocols/udap.rb
@@ -464,7 +464,7 @@ module Safire
 
         raise Errors::RegistrationError.new(
           status: response.status,
-          error_description: 'unexpected cancellation response status'
+          error_description: 'cancellation response did not confirm cancellation: expected a final 2xx status'
         )
       end
 

--- a/lib/safire/protocols/udap_metadata.rb
+++ b/lib/safire/protocols/udap_metadata.rb
@@ -105,7 +105,7 @@ module Safire
       # - +udap_profiles_supported+ includes +"udap_dcr"+ and +"udap_authn"+
       # - +token_endpoint_auth_methods_supported+ must equal <tt>["private_key_jwt"]</tt> exactly (STU2 fixed value)
       # - +scopes_supported+, +grant_types_supported+, and both signing algorithm arrays each have at least one element
-      # - +token_endpoint+ and +registration_endpoint+ are absolute HTTPS URLs
+      # - +token_endpoint+ and +registration_endpoint+ are absolute HTTPS URLs without fragments
       #   (or localhost HTTP URLs when explicitly enabled for development);
       #   +authorization_endpoint+ is validated by the same rule when present
       # - +signed_metadata+ is a compact-JWS string (three base64url-encoded dot-separated segments);
@@ -314,7 +314,9 @@ module Safire
         attrs = STRING_URL_ATTRIBUTES.dup
         attrs << :authorization_endpoint unless authorization_endpoint.nil?
         invalid = attrs.reject { |attr| valid_endpoint_url?(public_send(attr)) }
-        invalid.each { |attr| warn_noncompliance("#{attr} must be an absolute HTTPS URL") }
+        invalid.each do |attr|
+          warn_noncompliance("#{attr} must be an absolute HTTPS URL without a fragment component")
+        end
         invalid.empty?
       end
 
@@ -331,7 +333,11 @@ module Safire
       end
 
       def valid_endpoint_url?(value)
-        value.is_a?(String) && classify_uri(value, allow_insecure_localhost: @allow_insecure_localhost).nil?
+        value.is_a?(String) && classify_uri(
+          value,
+          allow_insecure_localhost: @allow_insecure_localhost,
+          allow_fragment: false
+        ).nil?
       end
 
       def conditional_presence_valid?

--- a/lib/safire/protocols/udap_registration_metadata.rb
+++ b/lib/safire/protocols/udap_registration_metadata.rb
@@ -199,9 +199,9 @@ module Safire
         unless string_array?(redirects) && redirects.any?
           fail_validation!(:redirect_uris, 'must be a non-empty array of strings')
         end
-        return if redirects.all? { |redirect| allowed_registration_uri?(redirect) }
+        return if redirects.all? { |redirect| allowed_registration_uri?(redirect, allow_fragment: false) }
 
-        fail_validation!(:redirect_uris, 'must contain only absolute HTTPS URIs')
+        fail_validation!(:redirect_uris, 'must contain only absolute HTTPS URIs without fragment components')
       end
 
       def validate_logo_uri!(metadata)
@@ -251,9 +251,12 @@ module Safire
         @operation == :register
       end
 
-      def allowed_registration_uri?(value)
-        strict_https_uri?(value) ||
-          (@allow_insecure_localhost && localhost_http_uri?(value))
+      def allowed_registration_uri?(value, allow_fragment: true)
+        classify_uri(
+          value,
+          allow_insecure_localhost: @allow_insecure_localhost,
+          allow_fragment:
+        ).nil?
       end
 
       def emit_diagnostics(metadata)

--- a/lib/safire/protocols/udap_signed_metadata_validator.rb
+++ b/lib/safire/protocols/udap_signed_metadata_validator.rb
@@ -323,7 +323,7 @@ module Safire
           next unless payload.key?(claim)
           next if valid_endpoint_url?(payload[claim], allow_insecure_localhost:)
 
-          log_failure("'#{claim}' must be an absolute HTTPS URL")
+          log_failure("'#{claim}' must be an absolute HTTPS URL without a fragment component")
           valid = false
         end
         valid
@@ -334,7 +334,7 @@ module Safire
       end
 
       def valid_endpoint_url?(value, allow_insecure_localhost:)
-        value.is_a?(String) && classify_uri(value, allow_insecure_localhost:).nil?
+        value.is_a?(String) && classify_uri(value, allow_insecure_localhost:, allow_fragment: false).nil?
       end
 
       def normalize_base_url(base_url)

--- a/lib/safire/uri_validation.rb
+++ b/lib/safire/uri_validation.rb
@@ -22,10 +22,12 @@ module Safire
     # 127.0.0.1 only when +allow_insecure_localhost+ is +true+. Any other scheme
     # (including non-HTTP schemes on localhost) returns +:non_https+.
     #
-    # @param value [String, nil] the URI string to classify
+    # @param value [Object] the URI value to classify
     # @param allow_insecure_localhost [Boolean] whether HTTP loopback URIs are accepted
     # @return [:invalid, :non_https, nil]
     def classify_uri(value, allow_insecure_localhost: false)
+      return :invalid unless value.is_a?(String)
+
       uri = Addressable::URI.parse(value)
       return :invalid unless parsed_uri_absolute?(uri)
       return if allowed_uri?(uri, allow_insecure_localhost:)

--- a/lib/safire/uri_validation.rb
+++ b/lib/safire/uri_validation.rb
@@ -24,15 +24,17 @@ module Safire
     #
     # @param value [Object] the URI value to classify
     # @param allow_insecure_localhost [Boolean] whether HTTP loopback URIs are accepted
-    # @return [:invalid, :non_https, nil]
-    def classify_uri(value, allow_insecure_localhost: false)
+    # @param allow_fragment [Boolean] whether a URI fragment component is accepted
+    # @return [:invalid, :fragment, :non_https, nil]
+    def classify_uri(value, allow_insecure_localhost: false, allow_fragment: true)
       return :invalid unless value.is_a?(String)
 
       uri = Addressable::URI.parse(value)
       return :invalid unless parsed_uri_absolute?(uri)
-      return if allowed_uri?(uri, allow_insecure_localhost:)
+      return :non_https unless allowed_uri?(uri, allow_insecure_localhost:)
+      return :fragment if !allow_fragment && !uri.fragment.nil?
 
-      :non_https
+      nil
     rescue Addressable::URI::InvalidURIError
       :invalid
     end

--- a/spec/safire/client_config_spec.rb
+++ b/spec/safire/client_config_spec.rb
@@ -72,6 +72,21 @@ RSpec.describe Safire::ClientConfig do
   # ---------- HTTPS enforcement ----------
 
   describe 'HTTPS enforcement' do
+    %i[redirect_uri authorization_endpoint token_endpoint].each do |attribute|
+      it "rejects a fragment in #{attribute}" do
+        value = "https://example.com/#{attribute}#fragment"
+
+        expect { described_class.new(valid_attrs.merge(attribute => value)) }
+          .to raise_error(Safire::Errors::ConfigurationError, /invalid URIs.*#{attribute}/)
+      end
+    end
+
+    it 'does not apply the OAuth endpoint fragment rule to a generic JWKS URI' do
+      config = described_class.new(valid_attrs.merge(jwks_uri: 'https://example.com/jwks.json#key-set'))
+
+      expect(config.jwks_uri).to eq('https://example.com/jwks.json#key-set')
+    end
+
     context 'when base_url uses HTTP on a non-localhost host' do
       it 'raises ConfigurationError' do
         expect { described_class.new(valid_attrs.merge(base_url: 'http://fhir.example.com')) }

--- a/spec/safire/client_config_spec.rb
+++ b/spec/safire/client_config_spec.rb
@@ -58,6 +58,11 @@ RSpec.describe Safire::ClientConfig do
         .to raise_error(Safire::Errors::ConfigurationError, /invalid URIs/)
     end
 
+    it 'raises ConfigurationError when a URI value is not a string' do
+      expect { described_class.new(valid_attrs.merge(base_url: 123)) }
+        .to raise_error(Safire::Errors::ConfigurationError, /invalid URIs.*base_url/)
+    end
+
     it 'raises ConfigurationError when redirect_uri has no host' do
       expect { described_class.new(valid_attrs.merge(redirect_uri: 'justpath')) }
         .to raise_error(Safire::Errors::ConfigurationError, /invalid URIs/)

--- a/spec/safire/protocols/smart_metadata_spec.rb
+++ b/spec/safire/protocols/smart_metadata_spec.rb
@@ -86,6 +86,86 @@ RSpec.describe Safire::Protocols::SmartMetadata do
         expect(Safire.logger).to have_received(:warn).with(/'S256' is missing from code_challenge_methods_supported/)
       end
     end
+
+    it 'warns and returns false for malformed array-valued metadata without raising' do
+      malformed = {
+        'grant_types_supported' => 'client_credentials',
+        'token_endpoint_auth_methods_supported' => 'private_key_jwt',
+        'token_endpoint_auth_signing_alg_values_supported' => 'RS384',
+        'associated_endpoints' => {},
+        'scopes_supported' => 'system/*.rs',
+        'response_types_supported' => 'code',
+        'capabilities' => 'client-confidential-asymmetric',
+        'code_challenge_methods_supported' => 'S256'
+      }
+      metadata = described_class.new(full_metadata.merge(malformed))
+      result = nil
+
+      expect { result = metadata.valid? }.not_to raise_error
+      expect(result).to be(false)
+      malformed.each_key do |attribute|
+        expect(Safire.logger).to have_received(:warn).with(/'#{attribute}'.*array/)
+      end
+    end
+
+    it 'warns and returns false when array-valued metadata contains malformed elements' do
+      data = full_metadata.merge(
+        'capabilities' => ['client-public', nil],
+        'associated_endpoints' => [{ 'url' => 'https://fhir.example.com' }, 'not-an-object']
+      )
+      metadata = described_class.new(data)
+
+      expect(metadata.valid?).to be(false)
+      expect(Safire.logger).to have_received(:warn).with(/'capabilities'.*array.*strings/)
+      expect(Safire.logger).to have_received(:warn).with(/'associated_endpoints'.*array.*objects/)
+    end
+  end
+
+  describe 'malformed capability metadata' do
+    it 'does not treat scalar capability and grant strings as advertised values' do
+      data = full_metadata.merge(
+        'capabilities' => 'client-public client-confidential-asymmetric authorize-post',
+        'grant_types_supported' => 'client_credentials'
+      )
+      metadata = described_class.new(data)
+
+      expect(metadata.supports_public_auth?).to be(false)
+      expect(metadata.supports_post_based_authorization?).to be(false)
+      expect(metadata.supports_backend_services?).to be(false)
+    end
+
+    it 'does not treat scalar authentication methods as advertised values' do
+      data = full_metadata.merge(
+        'token_endpoint_auth_methods_supported' => 'client_secret_basic private_key_jwt'
+      )
+      metadata = described_class.new(data)
+
+      expect(metadata.supports_symmetric_auth?).to be(false)
+      expect(metadata.supports_asymmetric_auth?).to be(false)
+    end
+
+    it 'returns no asymmetric algorithm intersection for a scalar advertisement' do
+      data = full_metadata.merge('token_endpoint_auth_signing_alg_values_supported' => 'RS384')
+      metadata = described_class.new(data)
+      algorithms = nil
+
+      expect { algorithms = metadata.asymmetric_signing_algorithms_supported }.not_to raise_error
+      expect(algorithms).to eq([])
+    end
+
+    it 'does not assert capabilities from arrays containing malformed elements' do
+      data = full_metadata.merge(
+        'capabilities' => ['client-public', nil],
+        'grant_types_supported' => ['client_credentials', nil],
+        'token_endpoint_auth_methods_supported' => ['private_key_jwt', nil],
+        'token_endpoint_auth_signing_alg_values_supported' => ['RS384', nil]
+      )
+      metadata = described_class.new(data)
+
+      expect(metadata.supports_public_auth?).to be(false)
+      expect(metadata.supports_backend_services?).to be(false)
+      expect(metadata.asymmetric_signing_algorithms_supported).to eq([])
+    end
   end
 
   describe '#supports_ehr_launch?' do

--- a/spec/safire/protocols/smart_spec.rb
+++ b/spec/safire/protocols/smart_spec.rb
@@ -359,6 +359,14 @@ RSpec.describe Safire::Protocols::Smart do
           .to raise_error(Safire::Errors::DiscoveryError, /token_endpoint.*absolute URI/)
       end
 
+      it 'rejects an endpoint containing a fragment' do
+        cfg = Safire::ClientConfig.new(config_attrs.except(:token_endpoint))
+        stub_well_known(body: smart_metadata_body.merge('token_endpoint' => 'https://auth.example.com/token#part'))
+
+        expect { described_class.new(cfg).token_endpoint }
+          .to raise_error(Safire::Errors::DiscoveryError, /token_endpoint.*must not include a fragment/)
+      end
+
       it 'allows an HTTP loopback endpoint only with the explicit development policy' do
         cfg = Safire::ClientConfig.new(
           config_attrs.except(:token_endpoint).merge(allow_insecure_localhost: true)
@@ -538,6 +546,18 @@ RSpec.describe Safire::Protocols::Smart do
 
         expect { described_class.new(cfg).authorization_url }
           .to raise_error(Safire::Errors::DiscoveryError, /authorization_endpoint.*absolute URI/)
+      end
+
+      it 'rejects an endpoint containing a fragment' do
+        cfg = Safire::ClientConfig.new(config_attrs.except(:authorization_endpoint))
+        stub_well_known(
+          body: smart_metadata_body.merge(
+            'authorization_endpoint' => 'https://auth.example.com/authorize#part'
+          )
+        )
+
+        expect { described_class.new(cfg).authorization_url }
+          .to raise_error(Safire::Errors::DiscoveryError, /authorization_endpoint.*must not include a fragment/)
       end
     end
   end
@@ -1392,6 +1412,20 @@ RSpec.describe Safire::Protocols::Smart do
       it 'raises ConfigurationError' do
         expect { described_class.new(no_client_id_config).register_client(client_metadata) }
           .to raise_error(Safire::Errors::ConfigurationError, /registration_endpoint/)
+      end
+    end
+
+    context 'when discovered registration_endpoint contains a fragment' do
+      let(:fragment_metadata) do
+        smart_metadata_body.merge('registration_endpoint' => 'https://fhir.example.com/register#part')
+      end
+
+      before { stub_well_known(body: fragment_metadata) }
+
+      it 'raises ConfigurationError without posting registration metadata' do
+        expect { described_class.new(no_client_id_config).register_client(client_metadata) }
+          .to raise_error(Safire::Errors::ConfigurationError, /registration_endpoint/)
+        expect(WebMock).not_to have_requested(:post, %r{/register})
       end
     end
 

--- a/spec/safire/protocols/smart_spec.rb
+++ b/spec/safire/protocols/smart_spec.rb
@@ -340,6 +340,34 @@ RSpec.describe Safire::Protocols::Smart do
           .to raise_error(Safire::Errors::DiscoveryError, /token_endpoint/)
       end
     end
+
+    context 'when a discovered token_endpoint is unusable' do
+      it 'rejects a non-HTTPS endpoint without making a token request' do
+        cfg = Safire::ClientConfig.new(config_attrs.except(:token_endpoint))
+        stub_well_known(body: smart_metadata_body.merge('token_endpoint' => 'http://auth.example.com/token'))
+
+        expect { described_class.new(cfg).token_endpoint }
+          .to raise_error(Safire::Errors::DiscoveryError, /token_endpoint.*HTTPS/)
+        expect(WebMock).not_to have_requested(:post, 'http://auth.example.com/token')
+      end
+
+      it 'rejects a non-string endpoint with a typed discovery error' do
+        cfg = Safire::ClientConfig.new(config_attrs.except(:token_endpoint))
+        stub_well_known(body: smart_metadata_body.merge('token_endpoint' => 123))
+
+        expect { described_class.new(cfg).token_endpoint }
+          .to raise_error(Safire::Errors::DiscoveryError, /token_endpoint.*absolute URI/)
+      end
+
+      it 'allows an HTTP loopback endpoint only with the explicit development policy' do
+        cfg = Safire::ClientConfig.new(
+          config_attrs.except(:token_endpoint).merge(allow_insecure_localhost: true)
+        )
+        stub_well_known(body: smart_metadata_body.merge('token_endpoint' => 'http://localhost:9000/token'))
+
+        expect(described_class.new(cfg).token_endpoint).to eq('http://localhost:9000/token')
+      end
+    end
   end
 
   # ---------- Authorization URL ----------
@@ -461,6 +489,11 @@ RSpec.describe Safire::Protocols::Smart do
         expect { described_class.new(config).authorization_url(method: :patch) }
           .to raise_error(Safire::Errors::ConfigurationError, /method/)
       end
+
+      it 'raises ConfigurationError for a non-symbolizable value' do
+        expect { described_class.new(config).authorization_url(method: 123) }
+          .to raise_error(Safire::Errors::ConfigurationError, /method/)
+      end
     end
 
     context 'when redirect_uri is not configured' do
@@ -485,6 +518,26 @@ RSpec.describe Safire::Protocols::Smart do
         stub_well_known(body: smart_metadata_body.except('authorization_endpoint'))
         expect { described_class.new(cfg).authorization_url }
           .to raise_error(Safire::Errors::ConfigurationError, /authorization_endpoint/)
+      end
+    end
+
+    context 'when a discovered authorization_endpoint is unusable' do
+      it 'rejects a non-HTTPS endpoint before building an authorization request' do
+        cfg = Safire::ClientConfig.new(config_attrs.except(:authorization_endpoint))
+        stub_well_known(
+          body: smart_metadata_body.merge('authorization_endpoint' => 'http://auth.example.com/authorize')
+        )
+
+        expect { described_class.new(cfg).authorization_url }
+          .to raise_error(Safire::Errors::DiscoveryError, /authorization_endpoint.*HTTPS/)
+      end
+
+      it 'rejects a non-string endpoint with a typed discovery error' do
+        cfg = Safire::ClientConfig.new(config_attrs.except(:authorization_endpoint))
+        stub_well_known(body: smart_metadata_body.merge('authorization_endpoint' => 123))
+
+        expect { described_class.new(cfg).authorization_url }
+          .to raise_error(Safire::Errors::DiscoveryError, /authorization_endpoint.*absolute URI/)
       end
     end
   end

--- a/spec/safire/protocols/udap_metadata_spec.rb
+++ b/spec/safire/protocols/udap_metadata_spec.rb
@@ -192,6 +192,13 @@ RSpec.describe Safire::Protocols::UdapMetadata do
           expect(m.valid?).to be(false)
           expect(Safire.logger).to have_received(:warn).with(/#{field} must be an absolute HTTPS URL/)
         end
+
+        it "returns false and logs a warning when #{field} contains a fragment" do
+          m = described_class.new(full_metadata.merge(field => 'https://fhir.example.com/endpoint#part'))
+
+          expect(m.valid?).to be(false)
+          expect(Safire.logger).to have_received(:warn).with(/#{field} must be an absolute HTTPS URL/)
+        end
       end
     end
 
@@ -223,6 +230,15 @@ RSpec.describe Safire::Protocols::UdapMetadata do
     context 'when authorization_endpoint is present but not an absolute HTTPS URL' do
       it 'returns false and logs a warning' do
         m = described_class.new(full_metadata.merge('authorization_endpoint' => 'http://fhir.example.com/auth'))
+
+        expect(m.valid?).to be(false)
+        expect(Safire.logger).to have_received(:warn).with(/authorization_endpoint must be an absolute HTTPS URL/)
+      end
+
+      it 'returns false when the endpoint contains a fragment' do
+        m = described_class.new(
+          full_metadata.merge('authorization_endpoint' => 'https://fhir.example.com/auth#part')
+        )
 
         expect(m.valid?).to be(false)
         expect(Safire.logger).to have_received(:warn).with(/authorization_endpoint must be an absolute HTTPS URL/)

--- a/spec/safire/protocols/udap_registration_metadata_spec.rb
+++ b/spec/safire/protocols/udap_registration_metadata_spec.rb
@@ -287,6 +287,12 @@ RSpec.describe Safire::Protocols::UdapRegistrationMetadata do
       expect_validation_error(:redirect_uris, 'absolute HTTPS URI') { metadata }
     end
 
+    it 'rejects a redirect URI containing a fragment' do
+      input[:redirect_uris] = ['https://app.example.com/callback#part']
+
+      expect_validation_error(:redirect_uris, 'absolute HTTPS URI') { metadata }
+    end
+
     it 'rejects HTTP localhost by default' do
       input[:redirect_uris] = ['http://localhost/callback']
 
@@ -315,6 +321,12 @@ RSpec.describe Safire::Protocols::UdapRegistrationMetadata do
       input[:logo_uri] = 'https://exa mple.com/logo.png'
 
       expect_validation_error(:logo_uri, 'absolute HTTPS URI') { metadata }
+    end
+
+    it 'does not apply the OAuth redirect fragment rule to logo_uri' do
+      input[:logo_uri] = 'https://app.example.com/logo.png#dark'
+
+      expect(metadata.to_h['logo_uri']).to eq(input[:logo_uri])
     end
 
     %w[png jpg jpeg gif].each do |extension|

--- a/spec/safire/protocols/udap_signed_metadata_validator_spec.rb
+++ b/spec/safire/protocols/udap_signed_metadata_validator_spec.rb
@@ -542,6 +542,17 @@ RSpec.describe Safire::Protocols::UdapSignedMetadataValidator do
       end
     end
 
+    context 'when an endpoint claim contains a fragment' do
+      let(:jwt) { build_udap_jwt(valid_payload.merge('token_endpoint' => "#{base_url}/token#part")) }
+
+      it 'returns nil and logs a warning' do
+        result = validator.signed_endpoint_claims(base_url:, verify_chain: false)
+
+        expect(result).to be_nil
+        expect(Safire.logger).to have_received(:warn).with(/token_endpoint.*HTTPS URL/)
+      end
+    end
+
     context 'when endpoint claims use HTTP localhost' do
       let(:jwt) do
         build_udap_jwt(

--- a/spec/safire/protocols/udap_spec.rb
+++ b/spec/safire/protocols/udap_spec.rb
@@ -1297,9 +1297,14 @@ RSpec.describe Safire::Protocols::Udap do
           )
       end
 
-      it 'raises RegistrationError even when the body confirms cancellation' do
-        expect { udap.cancel_registration(client_metadata, client_uri:) }
-          .to raise_error(Safire::Errors::RegistrationError, /unexpected cancellation response status/)
+      it 'reports an unconfirmed cancellation even when the body looks usable' do
+        error = capture_error(Safire::Errors::RegistrationError) do
+          udap.cancel_registration(client_metadata, client_uri:)
+        end
+
+        expect(error.status).to eq(304)
+        expect(error.error_description)
+          .to eq('cancellation response did not confirm cancellation: expected a final 2xx status')
       end
     end
 

--- a/spec/safire/uri_validation_spec.rb
+++ b/spec/safire/uri_validation_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe Safire::URIValidation do
       expect(host.classify_uri('https://example.com/path')).to be_nil
     end
 
+    it 'allows fragments unless the caller forbids them' do
+      expect(host.classify_uri('https://example.com/path#section')).to be_nil
+    end
+
+    it 'returns :fragment when a fragment is forbidden' do
+      expect(host.classify_uri('https://example.com/path#section', allow_fragment: false)).to eq(:fragment)
+    end
+
+    it 'treats an empty fragment component as a fragment' do
+      expect(host.classify_uri('https://example.com/path#', allow_fragment: false)).to eq(:fragment)
+    end
+
     it 'returns :non_https for HTTP on a remote host' do
       expect(host.classify_uri('http://example.com/path')).to eq(:non_https)
     end

--- a/spec/safire/uri_validation_spec.rb
+++ b/spec/safire/uri_validation_spec.rb
@@ -61,6 +61,11 @@ RSpec.describe Safire::URIValidation do
     it 'returns :invalid for a malformed URI' do
       expect(host.classify_uri('https://exa mple.com')).to eq(:invalid)
     end
+
+    it 'returns :invalid for a non-string value without raising' do
+      expect { host.classify_uri(123) }.not_to raise_error
+      expect(host.classify_uri(123)).to eq(:invalid)
+    end
   end
 
   describe '#strict_https_uri?' do


### PR DESCRIPTION
## Summary

This completes the phase-one client-role alignment audit across Safire's implemented SMART and UDAP workflows. It hardens SMART metadata capability checks against malformed list values, enforces the HTTPS/localhost policy before using authorization and token endpoints obtained from unsigned SMART discovery, and clarifies UDAP cancellation errors so unconfirmed outcomes are not described as server rejection.

The documentation now defines the runtime boundary method by method: client obligations, operation readiness, warning and negotiation behavior, explicit diagnostics, and server-owned decisions. It also consolidates the unreleased v0.4.1 notes and records the v0.5.0 UDAP wildcard-enforcement handoff.

## Design note

Malformed or insecure authorization and token endpoints learned from SMART discovery raise `DiscoveryError` because the unusable value came from server metadata. SMART registration endpoint validation retains its established `ConfigurationError` contract from earlier releases. Both paths fail before network use; preserving the existing registration error class avoids a breaking rescue-contract change without weakening the security boundary.