### PR TITLE
Enforce UDAP wildcard scope advertisement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** UDAP Dynamic Client Registration and modification now enforce
+  the UDAP Security STU2 rule that a wildcard scope may be requested only when
+  it is advertised. A requested scope token containing a literal `*` raises
+  `ValidationError` unless it appears exactly in `scopes_supported`, and raises
+  `DiscoveryError` when `scopes_supported` provides no usable scope strings
+  while a wildcard must be evaluated. Usable advertised entries are still
+  honored when a malformed sibling entry is present. This replaces the v0.4.1
+  deprecation warning. The scope check stays warning-only during cancellation,
+  so scope-advertisement drift alone cannot block credential cleanup, and
+  non-wildcard scopes remain subject to server-side negotiation with at most a
+  value-free warning.
+
 ## [0.4.1] - 2026-08-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ cancellation = udap_client.cancel_registration(
 
 UDAP registration uses the trusted fields needed for that workflow rather than
 turning the full `UdapMetadata#valid?` conformance diagnostic into an automatic
-gate. In v0.4.1, an unadvertised requested wildcard produces a warning and is
-still submitted; v0.5.0 will require exact wildcard advertisement for
-registration and modification while keeping wildcard scope drift warning-only
-during cancellation.
+gate. Registration and modification require a requested wildcard scope to be
+advertised exactly in `scopes_supported`, as UDAP Security STU2 requires;
+during cancellation that check stays warning-only, so scope-advertisement
+drift alone never blocks cleanup.
 
 UDAP JWT client authentication and Tiered OAuth are planned. See [ROADMAP.md](https://github.com/vanessuniq/safire/blob/main/ROADMAP.md) for details.
 

--- a/docs/adr/ADR-013-udap-registration-request-model.md
+++ b/docs/adr/ADR-013-udap-registration-request-model.md
@@ -46,6 +46,13 @@ or other network activity. Scope diagnostics and software-statement signing
 consume the same immutable instance; Safire does not independently normalize
 the caller's raw Hash at multiple stages.
 
+The value object validates the `scope` string's local shape only.
+Discovery-bound scope policy lives in `Protocols::Udap`: registration and
+modification reject a requested wildcard that is not advertised exactly in the
+server's `scopes_supported` metadata, while that check stays warning-only for
+cancellation so scope-advertisement drift alone cannot block cleanup (see
+ADR-015).
+
 Top-level string and symbol keys are normalized to strings. Supplying both forms
 of one key is rejected rather than allowing insertion order to decide which
 value is signed. The value object and its canonical internal hash are frozen,

--- a/docs/adr/ADR-015-client-role-and-runtime-readiness.md
+++ b/docs/adr/ADR-015-client-role-and-runtime-readiness.md
@@ -87,14 +87,26 @@ profile, a usable authoritative registration endpoint, usable registration
 algorithm metadata, and type-safe certification requirements. Other structural
 conformance checks remain available through the explicit `valid?` diagnostic.
 
-In v0.4.1, requested UDAP registration scopes are diagnostic only. Requested
-tokens containing a literal `*` are classified first and compared by exact
-membership in `scopes_supported`; narrower recognized SMART FHIR scopes may be
-covered by broader advertised scopes. Unrecognized syntax uses exact membership.
-Missing, malformed, or insufficient advertisements produce separate aggregated
-warnings while the server remains authoritative for negotiation. Registration
-and modification move to exact wildcard enforcement in v0.5.0; cancellation
-remains warning-only so an existing registration can still be removed.
+UDAP registration scope handling classifies requested tokens containing a
+literal `*` first and compares them by exact membership in `scopes_supported`;
+narrower recognized SMART FHIR scopes may be covered by broader advertised
+scopes, and unrecognized syntax uses exact membership. Registration and
+modification enforce the STU2 rule that a wildcard scope may be requested only
+when it is advertised: an unadvertised requested wildcard raises
+`ValidationError`, and `scopes_supported` that provides no usable non-blank
+scope strings raises `DiscoveryError` when a wildcard must be evaluated.
+Malformed sibling entries do not discard usable advertisements; callers can
+invoke `UdapMetadata#valid?` to diagnose the structural defect. Cancellation
+keeps both conditions warning-only. That is Safire's lifecycle-safety policy,
+not a stated STU2 exception: STU2 applies its scope-negotiation rules to
+registration requests generally and cancellation is expressed as one, but an
+empty `grant_types` request removes access rather than seeking it, and failing
+it over advertisement drift could strand an orphaned registration. Only
+scope-advertisement drift receives this treatment; trust, capability, signing,
+transport, and confirmation failures still stop cancellation. Non-wildcard
+scopes are never rejected locally: unlisted or unconfirmed tokens produce one
+aggregated value-free warning while the server remains authoritative for
+negotiation.
 
 For warning suppression only, compatible advertised FHIR permission fragments
 may collectively cover a requested permission set. STU2 does not guarantee that
@@ -147,8 +159,8 @@ This matrix covers the public protocol operations currently implemented by the
 | SMART `register_client` | Supply RFC 7591 client metadata and any required initial access token | Explicit or discovered HTTPS registration endpoint | Missing or unsafe endpoint; transport or OAuth failure; unusable response or missing/invalid client ID | None | Discovery capability helpers and `SmartMetadata#valid?` remain caller-invoked | Registration policy, accepted metadata, and issued credentials |
 | SMART `token_response_valid?` | Choose whether to require the optional conformance diagnostic | Token-response Hash and selected flow | None; this method is not an operational gate | Logs each diagnosed response defect and returns `false` | This method is the explicit diagnostic | Caller decides how to handle a failed diagnostic |
 | UDAP `server_metadata` | Supply the intended community and production trust/revocation policy; validate signed metadata before any later workflow | UDAP well-known endpoint and a trusted signed-metadata chain | Transport, HTTP, or 204 outcome; unusable JSON object; failed signature, chain, revocation, issuer, time, or endpoint validation | None | Caller may invoke `UdapMetadata#valid?` or explicitly re-run `signed_metadata_valid?` | Community-specific profiles and capabilities |
-| UDAP `register_client` | Supply conformant metadata, client URI, certifications when required, and a matching private key/certificate chain | Trusted discovery; `udap_dcr`; authoritative registration endpoint; usable algorithm and certification-requirement metadata | Unsafe or unusable readiness data; invalid caller metadata or signing identity; transport or server rejection; pending or malformed completion response | Missing RS256 advertisement and unconfirmed scope support warn in v0.4.1 | Caller may invoke `UdapMetadata#valid?`; it is not a blanket gate | Registration policy, scope and certification acceptance, effective metadata, and issued client ID |
-| UDAP `cancel_registration` | Supply the same stable client URI and trust-community identity; preserve local state until cancellation is confirmed | Registration readiness above and an existing registration to remove | Registration hard failures above; any response that does not provide final 2xx body confirmation with the client ID and empty grants | Scope compatibility and malformed scope advertisements remain warning-only so cleanup can proceed | Caller may invoke `UdapMetadata#valid?`; it is not a blanket gate | Cancellation policy and the confirmation response |
+| UDAP `register_client` | Supply conformant metadata, client URI, certifications when required, a matching private key/certificate chain, and only advertised wildcard scopes | Trusted discovery; `udap_dcr`; authoritative registration endpoint; usable algorithm and certification-requirement metadata; usable `scopes_supported` when a wildcard is requested | Unsafe or unusable readiness data; unadvertised requested wildcard scope; invalid caller metadata or signing identity; transport or server rejection; pending or malformed completion response | Missing RS256 advertisement and unconfirmed non-wildcard scope coverage warn | Caller may invoke `UdapMetadata#valid?`; it is not a blanket gate | Registration policy, scope and certification acceptance, effective metadata, and issued client ID |
+| UDAP `cancel_registration` | Supply the same stable client URI and trust-community identity; preserve local state until cancellation is confirmed | Registration readiness above and an existing registration to remove | Registration hard failures above except scope-advertisement enforcement; any response that does not provide final 2xx body confirmation with the client ID and empty grants | Scope compatibility and malformed scope advertisements remain warning-only so cleanup can proceed | Caller may invoke `UdapMetadata#valid?`; it is not a blanket gate | Cancellation policy and the confirmation response |
 
 SMART cancellation and UDAP authorization, token, refresh, backend-token, and
 token-response operations are not implemented. They raise

--- a/docs/troubleshooting/client-errors.md
+++ b/docs/troubleshooting/client-errors.md
@@ -52,12 +52,21 @@ registration = udap_client.register_client(
 
 A missing `RS256` advertisement produces a warning because STU2 requires that
 server baseline, but Safire can proceed with another advertised, supported,
-key-compatible algorithm. Missing, malformed, or insufficient
-`scopes_supported` also warns in v0.4.1 instead of blocking DCR. Requested
-wildcards are checked by exact membership; narrower non-wildcard SMART FHIR
-scopes may be covered by broader advertised scopes. Registration and
-modification will reject unadvertised wildcard requests in v0.5.0, while
-cancellation remains warning-only.
+key-compatible algorithm.
+
+Scope handling depends on what the request needs from `scopes_supported`.
+Registration and modification reject an unadvertised requested wildcard with
+`ValidationError`, because STU2 permits requesting a wildcard only when it is
+advertised. When a wildcard is requested but `scopes_supported` provides no
+usable scope strings, Safire raises `DiscoveryError`: it is obligated to
+evaluate the wildcard and the server's advertisement makes that impossible. A
+malformed entry beside usable ones does not trigger this; Safire decides
+against the usable entries and leaves the defect to `UdapMetadata#valid?`. The
+same unusable metadata only warns when every requested scope is non-wildcard,
+because no client-side rule depends on the advertisement there and the
+authorization server remains free to grant or reject the request. Cancellation
+warns and proceeds in every scope case, so scope-advertisement drift alone
+never blocks cleanup.
 
 ### `ValidationError`: UDAP registration metadata or certifications are invalid
 

--- a/docs/udap/dynamic-client-registration/index.md
+++ b/docs/udap/dynamic-client-registration/index.md
@@ -105,15 +105,22 @@ same `client_uri` and trust community requests modification. The authorization
 server may preserve the existing `client_id` or issue a replacement; use the
 identifier returned by the latest accepted response.
 
-In v0.4.1, Safire warns but still submits when a requested wildcard scope is not
-advertised exactly in `scopes_supported`. Non-wildcard SMART FHIR scopes are
-quiet when a broader advertised scope covers them; any remaining unconfirmed
-tokens produce one warning. Scope warnings report only the scope category and
-count because constrained SMART scopes and opaque custom scopes may contain
-sensitive values that do not belong in application logs. Missing or malformed
-scope metadata also warns rather than blocks. Registration and modification
-will require exact wildcard advertisement in v0.5.0, while the authorization
-server remains responsible for the scopes it grants.
+A requested scope token containing a literal `*` is a wildcard and must appear
+exactly in `scopes_supported`: UDAP Security STU2 permits requesting a wildcard
+scope only when it is advertised. Registration and modification raise
+`ValidationError` for an unadvertised wildcard, and `DiscoveryError` when
+`scopes_supported` provides no usable scope strings while a wildcard must be
+evaluated. Usable advertised entries are honored even when a malformed sibling
+entry is present; the sibling remains a `UdapMetadata#valid?` diagnostic.
+Cancellation warns and proceeds in both situations, so scope-advertisement
+drift alone cannot strand an existing registration.
+
+Non-wildcard SMART FHIR scopes are quiet when a broader advertised scope covers
+them; any remaining unconfirmed tokens produce one warning and are submitted,
+leaving the final scope decision to the authorization server. Scope warnings
+report only the scope category and count because constrained SMART scopes and
+opaque custom scopes may contain sensitive values that do not belong in
+application logs.
 
 ## Communities and Certifications
 
@@ -166,7 +173,8 @@ Safire performs the following sequence for every registration lifecycle call:
 1. Validates and snapshots caller metadata and certification input.
 2. Discovers and cryptographically validates community-scoped UDAP metadata.
 3. Checks the focused DCR profile, endpoint, algorithm, and certification fields.
-4. Reports scope-advertisement uncertainty according to the release policy above.
+4. Enforces exact wildcard advertisement for registration and modification,
+   and warns about remaining scope uncertainty as described above.
 5. Signs a fresh five-minute software statement with a fresh `jti`.
 6. POSTs the fixed UDAP request envelope to the authoritative signed endpoint.
 7. Parses the RFC 7591-shaped response into a string-keyed `Hash`.
@@ -190,8 +198,8 @@ the software statement.
 
 | Error | When raised |
 |-------|-------------|
-| `Safire::Errors::DiscoveryError` | Discovery or `signed_metadata` validation fails, or a DCR profile, endpoint, algorithm, or certification-requirement value cannot be used safely |
-| `Safire::Errors::ValidationError` | Caller metadata or certification input is invalid before signing |
+| `Safire::Errors::DiscoveryError` | Discovery or `signed_metadata` validation fails; a DCR profile, endpoint, algorithm, or certification-requirement value cannot be used safely; or `scopes_supported` provides no usable scope strings while a requested wildcard must be evaluated |
+| `Safire::Errors::ValidationError` | Caller metadata or certification input is invalid before signing, or a requested wildcard scope is not advertised exactly in `scopes_supported` |
 | `Safire::Errors::ConfigurationError` | Signing configuration or algorithm selection is missing or incompatible |
 | `Safire::Errors::CertificateError` | The client key, certificate chain, validity period, ordering, or URI SAN cannot support signing |
 | `Safire::Errors::RegistrationError` | The server rejects the request or does not return a usable response that confirms the lifecycle outcome |

--- a/lib/safire/protocols/udap.rb
+++ b/lib/safire/protocols/udap.rb
@@ -28,8 +28,11 @@ module Safire
       MANDATORY_REGISTRATION_ALGORITHM = 'RS256'.freeze
       REGISTER_ACTION = 'Registering client via UDAP Dynamic Client Registration...'.freeze
       CANCEL_ACTION = 'Cancelling client registration via UDAP Dynamic Client Registration...'.freeze
+      CANCELLATION_SCOPE_LIFECYCLE =
+        'cancellation proceeds and remains warning-only so existing access can be removed'.freeze
       private_constant :REGISTRATION_HEADERS, :SUCCESSFUL_REGISTRATION_STATUSES, :SUCCESSFUL_CANCELLATION_STATUSES,
-                       :MANDATORY_REGISTRATION_ALGORITHM, :REGISTER_ACTION, :CANCEL_ACTION
+                       :MANDATORY_REGISTRATION_ALGORITHM, :REGISTER_ACTION, :CANCEL_ACTION,
+                       :CANCELLATION_SCOPE_LIFECYCLE
 
       def initialize(config)
         @base_url = config.base_url
@@ -102,6 +105,12 @@ module Safire
       # and update-style 200 responses as long as the response is a JSON object with
       # a non-blank string +client_id+.
       #
+      # A requested scope token containing a literal +*+ is treated as a wildcard
+      # and must appear exactly in the server's +scopes_supported+ metadata; UDAP
+      # Security STU2 permits requesting a wildcard scope only when it is
+      # advertised. Non-wildcard scopes remain subject to server-side negotiation
+      # and produce at most a value-free warning.
+      #
       # @param metadata [Hash] caller-controlled UDAP registration metadata
       # @param client_uri [String] exact URI used as +iss+ and +sub+ and required
       #   to appear as a URI SAN in the leaf certificate
@@ -120,8 +129,11 @@ module Safire
       # @param jwt_algorithm [String, nil] optional explicit registration signing algorithm
       # @return [Hash] registration response from the authorization server
       # @raise [Safire::Errors::DiscoveryError] when UDAP discovery is unavailable or
-      #   untrusted, or required DCR capability metadata cannot be used safely
-      # @raise [Safire::Errors::ValidationError] when caller metadata or certifications are invalid
+      #   untrusted, required DCR capability metadata cannot be used safely, or
+      #   +scopes_supported+ provides no usable scope strings while a requested
+      #   wildcard scope must be evaluated
+      # @raise [Safire::Errors::ValidationError] when caller metadata or certifications are
+      #   invalid, or a requested wildcard scope is not advertised exactly in +scopes_supported+
       # @raise [Safire::Errors::ConfigurationError] when signing configuration is missing or incompatible
       # @raise [Safire::Errors::CertificateError] when the client certificate chain cannot support signing
       # @raise [Safire::Errors::RegistrationError] when the server rejects registration,
@@ -163,6 +175,12 @@ module Safire
       #
       # STU2 defines cancellation confirmation by the successful response body:
       # +client_id+ must be present and +grant_types+ must be an empty array.
+      #
+      # Unlike registration, cancellation never fails on scope-advertisement
+      # drift: a registered wildcard the server no longer advertises produces a
+      # warning while cleanup proceeds, so scope-advertisement drift alone
+      # cannot strand an existing registration. Other failures, such as trust,
+      # capability, signing, transport, or confirmation problems, still raise.
       #
       # @param metadata [Hash] identifying UDAP client metadata; omit +grant_types+
       # @param client_uri [String] exact URI used as +iss+ and +sub+ and required
@@ -235,7 +253,7 @@ module Safire
           community:, trusted_anchors:, crls:, revocation_checker:, verify_chain:
         )
         validate_required_certifications!(certifications, discovered, community:)
-        validate_registration_scopes!(registration_metadata, discovered, operation:)
+        validate_registration_scopes!(registration_metadata, discovered, operation:, community:)
         software_statement = build_software_statement(
           registration_metadata,
           discovered,
@@ -304,17 +322,17 @@ module Safire
         )
       end
 
-      def validate_registration_scopes!(registration_metadata, discovered, operation:)
+      def validate_registration_scopes!(registration_metadata, discovered, operation:, community:)
         wildcards, non_wildcards = registration_scope_groups(registration_metadata)
-        advertised = discovered.scopes_supported
+        advertised = usable_advertised_scopes(discovered.scopes_supported)
 
-        unless usable_scope_advertisement?(advertised)
-          return warn_unconfirmed_scopes(wildcards, non_wildcards, operation:)
+        if advertised.blank?
+          return handle_unusable_scope_advertisement(wildcards, non_wildcards, operation:, community:)
         end
 
         coverage = UdapScopeCoverage.new(advertised)
         unadvertised_wildcards = wildcards.reject { |scope| coverage.advertised_exactly?(scope) }
-        warn_unadvertised_wildcards(unadvertised_wildcards, operation:)
+        handle_unadvertised_wildcards(unadvertised_wildcards, operation:)
         uncovered = coverage.uncovered_non_wildcards_for_warning(non_wildcards)
         warn_uncovered_non_wildcards(uncovered)
       end
@@ -324,61 +342,90 @@ module Safire
         requested.partition { |scope| UdapScopeCoverage.requested_wildcard?(scope) }
       end
 
-      def warn_unconfirmed_scopes(wildcards, non_wildcards, operation:)
-        warn_unconfirmed_wildcards(wildcards, operation:)
+      # A malformed sibling entry is a server-conformance defect for
+      # `UdapMetadata#valid?` to diagnose; it does not prevent Safire from
+      # deciding against the usable entries.
+      def usable_advertised_scopes(scopes)
+        return unless scopes.is_a?(Array)
+
+        scopes.select { |scope| scope.is_a?(String) && scope.present? }
+      end
+
+      # Registration and modification SHALL NOT request a wildcard scope the
+      # server cannot be shown to advertise; cancellation removes access, so
+      # scope-advertisement drift stays warning-only there (see ADR-015).
+      def handle_unusable_scope_advertisement(wildcards, non_wildcards, operation:, community:)
+        if wildcards.any? && operation == :register
+          registration_discovery_error!(
+            'scopes_supported must be an array containing at least one usable scope string ' \
+            'to evaluate requested wildcard scopes',
+            community
+          )
+        end
+
+        warn_cancellation_unconfirmed_wildcards(wildcards)
         warn_unconfirmed_non_wildcards(non_wildcards)
       end
 
-      def usable_scope_advertisement?(scopes)
-        scopes.is_a?(Array) && scopes.any? && scopes.all? { |scope| scope.is_a?(String) && scope.present? }
-      end
-
-      def warn_unadvertised_wildcards(scopes, operation:)
+      def handle_unadvertised_wildcards(scopes, operation:)
         return if scopes.empty?
+        return warn_cancellation_unadvertised_wildcards(scopes) if operation == :cancel
 
-        Safire.logger.warn(
-          "[UDAP] #{scope_warning_summary(scopes, 'wildcard')}; no exact advertisement in " \
-          "scopes_supported; #{scope_warning_lifecycle(operation)}"
+        raise Errors::ValidationError.new(
+          attribute: :scope,
+          reason: "#{scope_summary(scopes, 'wildcard')} not advertised exactly in scopes_supported " \
+                  '(UDAP Security STU2 permits requesting a wildcard scope only when it is advertised)'
         )
       end
 
-      def warn_unconfirmed_wildcards(scopes, operation:)
-        return if scopes.empty?
+      def warn_cancellation_unadvertised_wildcards(scopes)
+        emit_scope_diagnostic(
+          scopes,
+          category: 'wildcard',
+          detail: 'no exact advertisement in scopes_supported',
+          lifecycle: CANCELLATION_SCOPE_LIFECYCLE
+        )
+      end
 
-        Safire.logger.warn(
-          "[UDAP] #{scope_warning_summary(scopes, 'wildcard')}; exact advertisement cannot be confirmed " \
-          "because scopes_supported is missing, empty, or malformed; #{scope_warning_lifecycle(operation)}"
+      def warn_cancellation_unconfirmed_wildcards(scopes)
+        emit_scope_diagnostic(
+          scopes,
+          category: 'wildcard',
+          detail: 'exact advertisement cannot be confirmed because scopes_supported provides no usable scope strings',
+          lifecycle: CANCELLATION_SCOPE_LIFECYCLE
         )
       end
 
       def warn_uncovered_non_wildcards(scopes)
-        return if scopes.empty?
-
-        Safire.logger.warn(
-          "[UDAP] #{scope_warning_summary(scopes, 'non-wildcard')}; coverage is not listed or locally proven " \
-          'by scopes_supported; proceeding with server-side scope negotiation'
+        emit_scope_diagnostic(
+          scopes,
+          category: 'non-wildcard',
+          detail: 'coverage is not listed or locally proven by scopes_supported; ' \
+                  'proceeding with server-side scope negotiation'
         )
       end
 
       def warn_unconfirmed_non_wildcards(scopes)
-        return if scopes.empty?
-
-        Safire.logger.warn(
-          "[UDAP] #{scope_warning_summary(scopes, 'non-wildcard')}; coverage cannot be confirmed because " \
-          'scopes_supported is missing, empty, or malformed; proceeding with server-side scope negotiation'
+        emit_scope_diagnostic(
+          scopes,
+          category: 'non-wildcard',
+          detail: 'coverage cannot be confirmed because scopes_supported provides no usable scope strings; ' \
+                  'proceeding with server-side scope negotiation'
         )
       end
 
-      def scope_warning_summary(scopes, category)
-        "requested #{category} scope count=#{scopes.length}"
+      # Value-free by design: reports category and deduplicated count, never raw
+      # requested scope values, which can carry sensitive search constraints.
+      def emit_scope_diagnostic(scopes, category:, detail:, lifecycle: nil)
+        return if scopes.empty?
+
+        message = "[UDAP] #{scope_summary(scopes, category)}; #{detail}"
+        message = "#{message}; #{lifecycle}" if lifecycle
+        Safire.logger.warn(message)
       end
 
-      def scope_warning_lifecycle(operation)
-        if operation == :cancel
-          return 'cancellation proceeds and remains warning-only so existing access can be removed'
-        end
-
-        'registration proceeds in v0.4.1, but registration and modification will fail in v0.5.0'
+      def scope_summary(scopes, category)
+        "requested #{category} scope count=#{scopes.length}"
       end
 
       def normalize_certifications!(certifications)

--- a/spec/integration/udap_dcr_flow_spec.rb
+++ b/spec/integration/udap_dcr_flow_spec.rb
@@ -177,18 +177,41 @@ RSpec.describe 'UDAP Dynamic Client Registration Flow', type: :integration do
     end
   end
 
-  it 'warns and sends an unadvertised wildcard during the v0.4.1 compatibility phase' do
+  it 'rejects an unadvertised wildcard registration before signing or POSTing' do
     stub_udap_discovery(body: udap_metadata.merge('scopes_supported' => ['system/Patient.rs']))
+    stub_registration_response
+    allow(Safire.logger).to receive(:warn)
+
+    expect { client.register_client(registration_metadata.merge(scope: 'system/*.rs'), client_uri:) }
+      .to raise_error(Safire::Errors::ValidationError, /wildcard scope count=1.*not advertised exactly/i)
+    expect(registration_requests).to be_empty
+  end
+
+  it 'registers an exactly advertised wildcard without warning' do
+    stub_udap_discovery
     stub_registration_response
     allow(Safire.logger).to receive(:warn)
 
     client.register_client(registration_metadata.merge(scope: 'system/*.rs'), client_uri:)
 
     expect(decoded_software_statement['scope']).to eq('system/*.rs')
+    expect(Safire.logger).not_to have_received(:warn)
+  end
+
+  it 'warns but still cancels when the registered wildcard is no longer advertised' do
+    stub_udap_discovery(body: udap_metadata.merge('scopes_supported' => ['system/Patient.rs']))
+    stub_registration_response(
+      status: 200,
+      body: { 'client_id' => 'udap-client-123', 'grant_types' => [] }
+    )
+    allow(Safire.logger).to receive(:warn)
+
+    result = client.cancel_registration(cancellation_metadata.merge(scope: 'system/*.rs'), client_uri:)
+
+    expect(result['grant_types']).to eq([])
     expect(Safire.logger).to have_received(:warn)
-      .with(/wildcard scope count=1.*no exact advertisement.*v0\.5\.0/i).once
-    expect(Safire.logger).not_to have_received(:warn).with(%r{system/\*\.rs})
-    expect(WebMock).to have_requested(:post, registration_endpoint)
+      .with(/wildcard scope count=1.*cancellation.*remains warning-only/i).once
+    expect(registration_requests.length).to eq(1)
   end
 
   it 'cancels registration with a signed empty grant_types claim' do

--- a/spec/safire/protocols/udap_spec.rb
+++ b/spec/safire/protocols/udap_spec.rb
@@ -534,12 +534,12 @@ RSpec.describe Safire::Protocols::Udap do
     end
     let(:software_statement) { instance_double(Safire::Protocols::UdapSoftwareStatement, to_jwt: 'header.payload.sig') }
 
-    def stub_registration_discovery_for_community(community)
+    def stub_registration_discovery_for_community(community, body: registration_discovery_body)
       stub_request(:get, well_known_url)
         .with(query: { 'community' => community })
         .to_return(
           status: 200,
-          body: registration_discovery_body.to_json,
+          body: body.to_json,
           headers: { 'Content-Type' => 'application/json' }
         )
     end
@@ -823,31 +823,35 @@ RSpec.describe Safire::Protocols::Udap do
         expect(Safire.logger).not_to have_received(:warn)
       end
 
-      it 'warns distinctly and proceeds for an unadvertised requested wildcard in v0.4.1' do
+      it 'rejects an unadvertised requested wildcard before signing or POSTing' do
         stub_udap(
           body: registration_discovery_body.merge('scopes_supported' => ['system/Patient.rs'])
         )
         client_metadata[:scope] = 'system/*.rs'
         allow(registration_metadata).to receive(:to_h).and_return('scope' => 'system/*.rs')
 
-        expect(udap.register_client(client_metadata, client_uri:)).to eq(registration_response)
-        expect(Safire.logger).to have_received(:warn)
-          .with(/wildcard scope count=1.*no exact advertisement.*v0\.5\.0/i).once
-        expect(Safire.logger).not_to have_received(:warn).with(%r{system/\*\.rs})
-        expect(WebMock).to have_requested(:post, registration_endpoint)
+        expect { udap.register_client(client_metadata, client_uri:) }
+          .to raise_error(Safire::Errors::ValidationError) { |error|
+            expect(error.message).to match(/scope.*wildcard scope count=1.*not advertised exactly/i)
+            expect(error.message).not_to include('system/*.rs')
+          }
+        expect(Safire::Protocols::UdapSoftwareStatement).not_to have_received(:new)
+        expect(WebMock).not_to have_requested(:post, registration_endpoint)
       end
 
-      it 'requires exact advertisement for a requested v1 permission wildcard' do
+      it 'rejects a requested v1 permission wildcard that coverage could otherwise normalize' do
         stub_udap(
           body: registration_discovery_body.merge('scopes_supported' => ['system/*.cruds'])
         )
         client_metadata[:scope] = 'system/Patient.*'
         allow(registration_metadata).to receive(:to_h).and_return('scope' => 'system/Patient.*')
 
-        expect(udap.register_client(client_metadata, client_uri:)).to eq(registration_response)
-        expect(Safire.logger).to have_received(:warn)
-          .with(/wildcard scope count=1.*no exact advertisement/i).once
-        expect(Safire.logger).not_to have_received(:warn).with(%r{system/Patient\.\*})
+        expect { udap.register_client(client_metadata, client_uri:) }
+          .to raise_error(Safire::Errors::ValidationError) { |error|
+            expect(error.message).to match(/wildcard scope count=1.*not advertised exactly/i)
+            expect(error.message).not_to include('system/Patient.*')
+          }
+        expect(WebMock).not_to have_requested(:post, registration_endpoint)
       end
 
       it 'does not warn when advertised FHIR scope coverage proves a non-wildcard request' do
@@ -871,7 +875,7 @@ RSpec.describe Safire::Protocols::Udap do
         expect(Safire.logger).not_to have_received(:warn).with(/mrn-123|tenant-a|study-c/)
       end
 
-      [nil, [], 'system/*.rs', ['system/*.rs', nil]].each do |advertised_scopes|
+      [nil, [], 'system/*.rs', [nil, '']].each do |advertised_scopes|
         it "warns and proceeds when scopes_supported is #{advertised_scopes.inspect}" do
           stub_udap(
             body: registration_discovery_body.merge('scopes_supported' => advertised_scopes)
@@ -879,22 +883,78 @@ RSpec.describe Safire::Protocols::Udap do
 
           expect(udap.register_client(client_metadata, client_uri:)).to eq(registration_response)
           expect(Safire.logger).to have_received(:warn)
-            .with(/non-wildcard scope count=1.*coverage cannot be confirmed.*missing, empty, or malformed/i).once
+            .with(/non-wildcard scope count=1.*coverage cannot be confirmed.*no usable scope strings/i).once
           expect(Safire.logger).not_to have_received(:warn).with(%r{system/Patient\.rs})
+        end
+
+        it "raises DiscoveryError for a requested wildcard when scopes_supported is #{advertised_scopes.inspect}" do
+          stub_udap(
+            body: registration_discovery_body.merge('scopes_supported' => advertised_scopes)
+          )
+          client_metadata[:scope] = 'system/*.rs'
+          allow(registration_metadata).to receive(:to_h).and_return('scope' => 'system/*.rs')
+
+          expect { udap.register_client(client_metadata, client_uri:) }
+            .to raise_error(
+              Safire::Errors::DiscoveryError,
+              /scopes_supported must be an array containing at least one usable scope string/
+            )
+          expect(Safire::Protocols::UdapSoftwareStatement).not_to have_received(:new)
+          expect(WebMock).not_to have_requested(:post, registration_endpoint)
         end
       end
 
-      it 'warns distinctly when a wildcard cannot be checked against malformed scope metadata' do
+      it 'preserves community context when wildcard evaluation has no usable advertised scopes' do
+        community = 'https://community.example.com/udap'
+        expected_endpoint = Addressable::URI.parse(well_known_url).tap do |uri|
+          uri.query_values = { 'community' => community }
+        end.to_s
+        stub_registration_discovery_for_community(
+          community,
+          body: registration_discovery_body.merge('scopes_supported' => [nil, ''])
+        )
+        client_metadata[:scope] = 'system/*.rs'
+        allow(registration_metadata).to receive(:to_h).and_return('scope' => 'system/*.rs')
+
+        expect { udap.register_client(client_metadata, client_uri:, community:) }
+          .to raise_error(Safire::Errors::DiscoveryError) { |error|
+            expect(error.endpoint).to eq(expected_endpoint)
+            expect(error.error_description).to match(/at least one usable scope string/)
+          }
+        expect(Safire::Protocols::UdapSoftwareStatement).not_to have_received(:new)
+        expect(WebMock).not_to have_requested(:post, registration_endpoint)
+      end
+
+      it 'proves a requested wildcard against usable entries despite a malformed sibling' do
         stub_udap(
-          body: registration_discovery_body.merge('scopes_supported' => nil)
+          body: registration_discovery_body.merge('scopes_supported' => ['system/*.rs', nil])
         )
         client_metadata[:scope] = 'system/*.rs'
         allow(registration_metadata).to receive(:to_h).and_return('scope' => 'system/*.rs')
 
         expect(udap.register_client(client_metadata, client_uri:)).to eq(registration_response)
-        expect(Safire.logger).to have_received(:warn)
-          .with(/wildcard scope count=1.*cannot be confirmed.*missing, empty, or malformed.*v0\.5\.0/i).once
-        expect(Safire.logger).not_to have_received(:warn).with(%r{system/\*\.rs})
+        expect(Safire.logger).not_to have_received(:warn)
+      end
+
+      it 'rejects an unadvertised wildcard when usable entries exist alongside a malformed sibling' do
+        stub_udap(
+          body: registration_discovery_body.merge('scopes_supported' => ['system/Patient.rs', nil])
+        )
+        client_metadata[:scope] = 'system/*.rs'
+        allow(registration_metadata).to receive(:to_h).and_return('scope' => 'system/*.rs')
+
+        expect { udap.register_client(client_metadata, client_uri:) }
+          .to raise_error(Safire::Errors::ValidationError, /wildcard scope count=1.*not advertised exactly/i)
+        expect(WebMock).not_to have_requested(:post, registration_endpoint)
+      end
+
+      it 'covers a non-wildcard request through usable entries despite a malformed sibling' do
+        stub_udap(
+          body: registration_discovery_body.merge('scopes_supported' => ['system/*.rs', nil])
+        )
+
+        expect(udap.register_client(client_metadata, client_uri:)).to eq(registration_response)
+        expect(Safire.logger).not_to have_received(:warn)
       end
 
       it 'does not treat wildcard lookalike text as a requested wildcard' do
@@ -1245,6 +1305,20 @@ RSpec.describe Safire::Protocols::Udap do
       expect(udap.cancel_registration(client_metadata, client_uri:)).to eq(cancellation_response)
       expect(Safire.logger).to have_received(:warn)
         .with(/wildcard scope count=1.*cancellation.*remains warning-only/i).once
+      expect(Safire.logger).not_to have_received(:warn).with(%r{system/\*\.rs})
+      expect(WebMock).to have_requested(:post, registration_endpoint)
+    end
+
+    it 'warns and still cancels when a cancellation wildcard cannot be checked against unusable scope metadata' do
+      stub_udap(
+        body: registration_discovery_body.merge('scopes_supported' => nil)
+      )
+      client_metadata[:scope] = 'system/*.rs'
+      allow(registration_metadata).to receive(:to_h).and_return('scope' => 'system/*.rs')
+
+      expect(udap.cancel_registration(client_metadata, client_uri:)).to eq(cancellation_response)
+      expect(Safire.logger).to have_received(:warn)
+        .with(/wildcard scope count=1.*cannot be confirmed.*no usable scope strings.*cancellation/i).once
       expect(Safire.logger).not_to have_received(:warn).with(%r{system/\*\.rs})
       expect(WebMock).to have_requested(:post, registration_endpoint)
     end


### PR DESCRIPTION
## Summary

This completes ALIGN-6 by enforcing the UDAP Security STU2 wildcard-scope rule during dynamic registration and modification. Requested scopes containing a literal `*` must appear exactly among the usable `scopes_supported` entries: Safire raises `DiscoveryError` when no usable advertisement is available and `ValidationError` when usable entries omit the wildcard, before signing or sending a registration request. Malformed sibling entries no longer discard usable advertisements, while explicit metadata validation continues to report the structural defect.

Cancellation deliberately keeps scope-advertisement drift warning-only so an existing registration can still be removed. Scope diagnostics are consolidated behind one value-free emitter, community-scoped discovery errors retain their encoded endpoint context, and the ADRs, DCR guidance, troubleshooting documentation, README, and changelog now describe the v0.5.0 behavior and its lifecycle-safety boundary.